### PR TITLE
fix: after login header is not rendered

### DIFF
--- a/frontend/src/components/LayoutHeader.vue
+++ b/frontend/src/components/LayoutHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="#header-area">
+  <Teleport to="#header-area" v-if="showHeader">
     <header class="flex justify-between items-center px-5 py-3">
       <div class="flex items-center gap-2">
         <slot name="left-header" />
@@ -10,3 +10,12 @@
     </header>
   </Teleport>
 </template>
+<script setup>
+import { ref, nextTick } from 'vue'
+
+const showHeader = ref(false)
+
+nextTick(() => {
+  showHeader.value = true
+})
+</script>


### PR DESCRIPTION
After login header is not visible after refresh it becomes visible
Before:
<img width="1438" alt="image" src="https://github.com/frappe/crm/assets/30859809/609131eb-8acd-4f7f-8604-83665b1f61df">

After:
<img width="1438" alt="image" src="https://github.com/frappe/crm/assets/30859809/f772e392-e619-4c3f-bfec-5ff949a0ebe2">
