### PR TITLE
fix: show use_html & response_html in Email Template Modal

### DIFF
--- a/crm/overrides/email_template.py
+++ b/crm/overrides/email_template.py
@@ -41,9 +41,11 @@ class CustomEmailTemplate(EmailTemplate):
 		rows = [
 			"name",
 			"enabled",
+			"use_html",
 			"reference_doctype",
 			"subject",
 			"response",
+			"response_html",
 			"modified",
 		]
 		return {'columns': columns, 'rows': rows}

--- a/frontend/src/components/Modals/EmailTemplateModal.vue
+++ b/frontend/src/components/Modals/EmailTemplateModal.vue
@@ -55,18 +55,39 @@
             {{ __('Content') }}
             <span class="text-red-500">*</span>
           </div>
+          <FormControl
+            v-if="_emailTemplate.use_html"
+            type="textarea"
+            variant="outline"
+            ref="content"
+            rows="10"
+            v-model="_emailTemplate.response_html"
+            :placeholder="
+              __(
+                '<p>Dear {{ lead_name }},</p>\n\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\n\n<p>Thanks,</p>\n<p>Frappé</p>'
+              )
+            "
+          />
           <TextEditor
+            v-else
             variant="outline"
             ref="content"
             editor-class="!prose-sm overflow-auto min-h-[180px] max-h-80 py-1.5 px-2 rounded border border-gray-300 bg-white hover:border-gray-400 hover:shadow-sm focus:bg-white focus:border-gray-500 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-gray-400 text-gray-800 transition-colors"
             :bubbleMenu="true"
             :content="_emailTemplate.response"
             @change="(val) => (_emailTemplate.response = val)"
-            :placeholder="__('Dear {{ lead_name }}, \n\nThis is a reminder for the payment of {{ grand_total }}. \n\nThanks, \nFrappé')"
+            :placeholder="
+              __(
+                'Dear {{ lead_name }}, \n\nThis is a reminder for the payment of {{ grand_total }}. \n\nThanks, \nFrappé'
+              )
+            "
           />
         </div>
         <div>
           <Checkbox v-model="_emailTemplate.enabled" :label="__('Enabled')" />
+        </div>
+        <div>
+          <Checkbox v-model="_emailTemplate.use_html" :label="__('Use HTML')" />
         </div>
         <ErrorMessage :message="__(errorMessage)" />
       </div>

--- a/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
@@ -31,7 +31,14 @@
             {{ __('Subject: {0}', [template.subject]) }}
           </div>
           <TextEditor
-            v-if="template.response"
+            v-if="template.use_html && template.response_html"
+            :content="template.response_html"
+            :editable="false"
+            editor-class="!prose-sm max-w-none !text-sm text-gray-600 focus:outline-none"
+            class="flex-1 overflow-hidden"
+          />
+          <TextEditor
+            v-else-if="template.response"
             :content="template.response"
             :editable="false"
             editor-class="!prose-sm max-w-none !text-sm text-gray-600 focus:outline-none"
@@ -97,9 +104,11 @@ const templates = createListResource({
   fields: [
     'name',
     'enabled',
+    'use_html',
     'reference_doctype',
     'subject',
     'response',
+    'response_html',
     'modified',
     'owner',
   ],

--- a/frontend/src/pages/EmailTemplates.vue
+++ b/frontend/src/pages/EmailTemplates.vue
@@ -114,8 +114,10 @@ const showEmailTemplateModal = ref(false)
 const emailTemplate = ref({
   subject: '',
   response: '',
+  response_html: '',
   name: '',
   enabled: 1,
+  use_html: 0,
   owner: '',
   reference_doctype: 'CRM Deal',
 })
@@ -125,8 +127,10 @@ function showEmailTemplate(name) {
   emailTemplate.value = {
     subject: et.subject,
     response: et.response,
+    response_html: et.response_html,
     name: et.name,
     enabled: et.enabled,
+    use_html: et.use_html,
     owner: et.owner,
     reference_doctype: et.reference_doctype,
   }


### PR DESCRIPTION
fixes: https://github.com/frappe/crm/issues/198
<img width="599" alt="image" src="https://github.com/frappe/crm/assets/30859809/af3980f0-b200-41d9-a082-ae4d9cc8a9bf">
