### PR TITLE
feat: Preserve last visited tab

### DIFF
--- a/frontend/src/composables/useActiveTabManager.js
+++ b/frontend/src/composables/useActiveTabManager.js
@@ -1,0 +1,68 @@
+import { ref, watch } from 'vue';
+
+// Debounce function to delay updates
+function debounce(fn, delay) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}
+
+export function useActiveTabManager(tabs, storageKey) {
+    
+  const preserveLastVisitedTab = debounce((tabName) => {
+    localStorage.setItem(storageKey, tabName.toLowerCase());
+  }, 300);
+
+  function setActiveTabInUrl(tabName) {
+    window.location.hash = '#' + tabName.toLowerCase();
+  }
+
+  function getActiveTabFromUrl() {
+    return window.location.hash.replace('#', '');
+  }
+
+  function findTabIndex(tabName){
+    return tabs.value.findIndex(tabOptions => tabOptions.name.toLowerCase() === tabName);
+  }
+
+  function getTabIndex(tabName) {
+    let index = findTabIndex(tabName)
+    return index !== -1 ? index : 0; // Default to the first tab if not found
+  }
+
+  function getActiveTabFromLocalStorage() {
+    return localStorage.getItem(storageKey);
+  }
+
+  function getActiveTab() {
+    let activeTab = getActiveTabFromUrl();
+    if(activeTab){
+      let index = findTabIndex(activeTab)
+      if(index !== -1){
+        preserveLastVisitedTab(activeTab)
+        return index
+      }
+      return 0
+    }
+
+    let lastVisitedTab = getActiveTabFromLocalStorage();
+    if(lastVisitedTab){
+      setActiveTabInUrl(lastVisitedTab)
+      return getTabIndex(lastVisitedTab)
+    }
+
+    return 0 // Default to the first tab if nothing is found
+  }
+
+  const tabIndex = ref(getActiveTab());
+
+  watch(tabIndex, (tabIndexValue) => {
+    let currentTab = tabs.value[tabIndexValue].name;
+    setActiveTabInUrl(currentTab);
+    preserveLastVisitedTab(currentTab);
+  });
+
+  return { tabIndex };
+}

--- a/frontend/src/composables/useActiveTabManager.js
+++ b/frontend/src/composables/useActiveTabManager.js
@@ -1,54 +1,49 @@
-import { ref, watch } from 'vue';
-
-// Debounce function to delay updates
-function debounce(fn, delay) {
-  let timeout;
-  return (...args) => {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => fn(...args), delay);
-  };
-}
+import { ref, watch } from 'vue'
+import { useDebounceFn, useStorage } from '@vueuse/core'
 
 export function useActiveTabManager(tabs, storageKey) {
-    
-  const preserveLastVisitedTab = debounce((tabName) => {
-    localStorage.setItem(storageKey, tabName.toLowerCase());
-  }, 300);
+  const activieTab = useStorage(storageKey, 'activity')
+
+  const preserveLastVisitedTab = useDebounceFn((tabName) => {
+    activieTab.value = tabName.toLowerCase()
+  }, 300)
 
   function setActiveTabInUrl(tabName) {
-    window.location.hash = '#' + tabName.toLowerCase();
+    window.location.hash = '#' + tabName.toLowerCase()
   }
 
   function getActiveTabFromUrl() {
-    return window.location.hash.replace('#', '');
+    return window.location.hash.replace('#', '')
   }
 
-  function findTabIndex(tabName){
-    return tabs.value.findIndex(tabOptions => tabOptions.name.toLowerCase() === tabName);
+  function findTabIndex(tabName) {
+    return tabs.value.findIndex(
+      (tabOptions) => tabOptions.name.toLowerCase() === tabName,
+    )
   }
 
   function getTabIndex(tabName) {
     let index = findTabIndex(tabName)
-    return index !== -1 ? index : 0; // Default to the first tab if not found
+    return index !== -1 ? index : 0 // Default to the first tab if not found
   }
 
   function getActiveTabFromLocalStorage() {
-    return localStorage.getItem(storageKey);
+    return activieTab.value
   }
 
   function getActiveTab() {
-    let activeTab = getActiveTabFromUrl();
-    if(activeTab){
+    let activeTab = getActiveTabFromUrl()
+    if (activeTab) {
       let index = findTabIndex(activeTab)
-      if(index !== -1){
+      if (index !== -1) {
         preserveLastVisitedTab(activeTab)
         return index
       }
       return 0
     }
 
-    let lastVisitedTab = getActiveTabFromLocalStorage();
-    if(lastVisitedTab){
+    let lastVisitedTab = getActiveTabFromLocalStorage()
+    if (lastVisitedTab) {
       setActiveTabInUrl(lastVisitedTab)
       return getTabIndex(lastVisitedTab)
     }
@@ -56,13 +51,13 @@ export function useActiveTabManager(tabs, storageKey) {
     return 0 // Default to the first tab if nothing is found
   }
 
-  const tabIndex = ref(getActiveTab());
+  const tabIndex = ref(getActiveTab())
 
   watch(tabIndex, (tabIndexValue) => {
-    let currentTab = tabs.value[tabIndexValue].name;
-    setActiveTabInUrl(currentTab);
-    preserveLastVisitedTab(currentTab);
-  });
+    let currentTab = tabs.value[tabIndexValue].name
+    setActiveTabInUrl(currentTab)
+    preserveLastVisitedTab(currentTab)
+  })
 
-  return { tabIndex };
+  return { tabIndex }
 }

--- a/frontend/src/composables/useActiveTabManager.js
+++ b/frontend/src/composables/useActiveTabManager.js
@@ -1,8 +1,10 @@
 import { ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useDebounceFn, useStorage } from '@vueuse/core'
 
 export function useActiveTabManager(tabs, storageKey) {
   const activieTab = useStorage(storageKey, 'activity')
+  const route = useRoute()
 
   const preserveLastVisitedTab = useDebounceFn((tabName) => {
     activieTab.value = tabName.toLowerCase()
@@ -13,7 +15,7 @@ export function useActiveTabManager(tabs, storageKey) {
   }
 
   function getActiveTabFromUrl() {
-    return window.location.hash.replace('#', '')
+    return route.hash.replace('#', '')
   }
 
   function findTabIndex(tabName) {
@@ -58,6 +60,21 @@ export function useActiveTabManager(tabs, storageKey) {
     setActiveTabInUrl(currentTab)
     preserveLastVisitedTab(currentTab)
   })
+
+  watch(
+    () => route.hash,
+    (tabValue) => {
+      if (!tabValue) return
+
+      let tabName = tabValue.replace('#', '')
+      let index = findTabIndex(tabName)
+      if (index === -1) index = 0
+
+      let currentTab = tabs.value[index].name
+      preserveLastVisitedTab(currentTab)
+      tabIndex.value = index
+    },
+  )
 
   return { tabIndex }
 }

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -354,6 +354,8 @@ import {
 } from 'frappe-ui'
 import { ref, computed, h, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import {useActiveTabManager} from '@/composables/useActiveTabManager'
+
 
 const { $dialog, $socket, makeCall } = globalStore()
 const { statusOptions, getDealStatus } = statusesStore()
@@ -513,7 +515,6 @@ usePageMeta(() => {
   }
 })
 
-const tabIndex = ref(0)
 const tabs = computed(() => {
   let tabOptions = [
     {
@@ -556,6 +557,7 @@ const tabs = computed(() => {
   ]
   return tabOptions.filter((tab) => (tab.condition ? tab.condition() : true))
 })
+const { tabIndex } = useActiveTabManager(tabs, 'lastDealTab')
 
 const fieldsLayout = createResource({
   url: 'crm.api.doc.get_sidebar_fields',

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -354,7 +354,7 @@ import {
 } from 'frappe-ui'
 import { ref, computed, h, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import {useActiveTabManager} from '@/composables/useActiveTabManager'
+import { useActiveTabManager } from '@/composables/useActiveTabManager'
 
 
 const { $dialog, $socket, makeCall } = globalStore()

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -330,6 +330,7 @@ import {
 } from 'frappe-ui'
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import {useActiveTabManager} from '@/composables/useActiveTabManager'
 
 const { $dialog, $socket, makeCall } = globalStore()
 const { getContactByName, contacts } = contactsStore()
@@ -463,8 +464,6 @@ usePageMeta(() => {
   }
 })
 
-const tabIndex = ref(0)
-
 const tabs = computed(() => {
   let tabOptions = [
     {
@@ -507,6 +506,8 @@ const tabs = computed(() => {
   ]
   return tabOptions.filter((tab) => (tab.condition ? tab.condition() : true))
 })
+
+const { tabIndex } = useActiveTabManager(tabs, 'lastLeadTab')
 
 watch(tabs, (value) => {
   if (value && route.params.tabName) {

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -330,7 +330,7 @@ import {
 } from 'frappe-ui'
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import {useActiveTabManager} from '@/composables/useActiveTabManager'
+import { useActiveTabManager } from '@/composables/useActiveTabManager'
 
 const { $dialog, $socket, makeCall } = globalStore()
 const { getContactByName, contacts } = contactsStore()


### PR DESCRIPTION
- Implemented functionality to store and retrieve the last visited tab index in localStorage.
- The application now defaults to the last visited tab after a page refresh, rather than always returning to the Activity tab.
- This ensures that users remain on the same tab they were on before refreshing the page, improving user experience.

[Screencast from 09-08-24 12:45:17 PM IST.WEBM](https://github.com/user-attachments/assets/412d73fa-1660-4994-99ff-dbd8e1acf966)


Closes #192 