### PR TITLE
fix: include crm in apps page

### DIFF
--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -4,11 +4,23 @@ app_publisher = "Frappe Technologies Pvt. Ltd."
 app_description = "Kick-ass Open Source CRM"
 app_email = "shariq@frappe.io"
 app_license = "AGPLv3"
-app_icon_url = ""
+app_icon_url = "/assets/crm/manifest/apple-icon-180.png"
 app_icon_title = "CRM"
 app_icon_route = "/crm"
 
+# Apps
+# ------------------
+
 # required_apps = []
+include_as_app = [
+	{
+		"name": "crm",
+		"logo": "/assets/crm/manifest/apple-icon-180.png",
+		"title": "CRM",
+		"route": "/crm",
+		# "has_permission": "crm.api.permission.has_app_permission"
+	}
+]
 
 # Includes in <head>
 # ------------------

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -12,7 +12,7 @@ app_icon_route = "/crm"
 # ------------------
 
 # required_apps = []
-include_as_app = [
+add_to_apps_screen = [
 	{
 		"name": "crm",
 		"logo": "/assets/crm/manifest/apple-icon-180.png",


### PR DESCRIPTION
Depended on https://github.com/frappe/frappe/pull/27292/

Updated hooks.py to include crm app in apps page

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/7007ae33-a172-4328-8d8e-73f722ec9e2a">