### PR TITLE
feat: allow adding standard form script

### DIFF
--- a/crm/fcrm/doctype/crm_form_script/crm_form_script.js
+++ b/crm/fcrm/doctype/crm_form_script/crm_form_script.js
@@ -8,7 +8,29 @@ frappe.ui.form.on("CRM Form Script", {
 				istable: 0,
 			},
 		});
+
+		if (frm.doc.is_standard && !frappe.boot.developer_mode) {
+			frm.disable_form();
+			frappe.show_alert(
+				__(
+					"Standard Form Scripts can not be modified, duplicate the Form Script instead."
+				)
+			);
+		}
+
+		frm.trigger("add_enable_button");
 	},
+
+	add_enable_button(frm) {
+		frm.add_custom_button(
+			frm.doc.enabled ? __("Disable") : __("Enable"),
+			() => {
+				frm.set_value("enabled", !frm.doc.enabled);
+				frm.save();
+			}
+		);
+	},
+
 	view(frm) {
 		let has_form_boilerplate = frm.doc.script.includes(
 			"function setupForm("

--- a/crm/fcrm/doctype/crm_form_script/crm_form_script.json
+++ b/crm/fcrm/doctype/crm_form_script/crm_form_script.json
@@ -10,6 +10,7 @@
   "view",
   "column_break_gboh",
   "enabled",
+  "is_standard",
   "section_break_xeox",
   "script"
  ],
@@ -52,11 +53,18 @@
    "label": "Apply To",
    "options": "Form\nList",
    "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_standard",
+   "fieldtype": "Check",
+   "label": "Is Standard",
+   "no_copy": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-10 18:27:17.617602",
+ "modified": "2024-09-11 12:56:09.288849",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Form Script",

--- a/crm/fcrm/doctype/crm_form_script/crm_form_script.py
+++ b/crm/fcrm/doctype/crm_form_script/crm_form_script.py
@@ -2,11 +2,26 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class CRMFormScript(Document):
-	pass
+	def validate(self):
+		in_user_env = not (
+			frappe.flags.in_install
+			or frappe.flags.in_patch
+			or frappe.flags.in_test
+			or frappe.flags.in_fixtures
+		)
+		if in_user_env and self.is_standard and not frappe.conf.developer_mode:
+			# only enabled can be changed for standard form scripts
+			if self.has_value_changed("enabled"):
+				enabled_value = self.enabled
+				self.reload()
+				self.enabled = enabled_value
+			else:
+				frappe.throw(_("You need to be in developer mode to edit a Standard Form Script"))
 
 def get_form_script(dt, view="Form"):
 	"""Returns the form script for the given doctype"""


### PR DESCRIPTION
You can add standard form script which will be non editable but you can enable or disable it
<kbd>
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/420a22ab-3089-4b15-8001-72f17e04bbb2">
</kbd>

