### PR TITLE
fix: api's for live demo site

### DIFF
--- a/crm/api/demo.py
+++ b/crm/api/demo.py
@@ -1,0 +1,36 @@
+import frappe
+from frappe import _
+from frappe.auth import LoginManager
+
+
+@frappe.whitelist(allow_guest=True)
+def login():
+	if not frappe.conf.demo_username or not frappe.conf.demo_password:
+		return
+	frappe.local.response["redirect_to"] = "/crm"
+	login_manager = LoginManager()
+	login_manager.authenticate(frappe.conf.demo_username, frappe.conf.demo_password)
+	login_manager.post_login()
+	frappe.local.response["type"] = "redirect"
+	frappe.local.response["location"] = frappe.local.response["redirect_to"]
+
+
+def validate_reset_password(user):
+	if frappe.conf.demo_username and frappe.session.user == frappe.conf.demo_username:
+		frappe.throw(
+			_("Password cannot be reset by Demo User {}").format(
+				frappe.bold(frappe.conf.demo_username)
+			),
+			frappe.PermissionError,
+		)
+
+
+def validate_user(doc, event):
+	if frappe.conf.demo_username and frappe.session.user == frappe.conf.demo_username and doc.new_password:
+		frappe.throw(
+			_("Password cannot be reset by Demo User {}").format(
+				frappe.bold(frappe.conf.demo_username)
+			),
+			frappe.PermissionError,
+		)
+

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -132,6 +132,7 @@ before_uninstall = "crm.uninstall.before_uninstall"
 override_doctype_class = {
 	"Contact": "crm.overrides.contact.CustomContact",
 	"Email Template": "crm.overrides.email_template.CustomEmailTemplate",
+	"User": "crm.overrides.user.CustomUser",
 }
 
 # Document Events
@@ -156,6 +157,9 @@ doc_events = {
 	"CRM Deal": {
 		"on_update": ["crm.fcrm.doctype.erpnext_crm_settings.erpnext_crm_settings.create_customer_in_erpnext"],
 	},
+	"User": {
+		"before_validate": ["crm.api.demo.validate_user"],
+	}
 }
 
 # Scheduled Tasks

--- a/crm/overrides/user.py
+++ b/crm/overrides/user.py
@@ -1,0 +1,10 @@
+# import frappe
+from frappe import _
+from frappe.core.doctype.user.user import User
+from crm.api.demo import validate_reset_password
+
+
+class CustomUser(User):
+	def validate_reset_password(self):
+		# restrict demo user to reset password
+		validate_reset_password(self)


### PR DESCRIPTION
Api to login using demo username & password mentioned in site config
E.g
`site_config.json`
```
"demo_username": "john.doe@demo.com"
"demo_password": "password@123",
```

Open this link to login into your system with demo credentials
```
https://<sitename>/api/method/crm.api.demo.login
```

> NOTE: Demo user cannot reset password, but make sure to create a user on your site before using above link and restrict user.