### PR TITLE
fix: quotation to option

### DIFF
--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
@@ -29,7 +29,7 @@ class ERPNextCRMSettings(Document):
 					doctype="Quotation",
 					fieldname="quotation_to",
 					property="link_filters",
-					value='[["DocType","name","in", ["Customer", "Lead", "Prospect", "Frappe CRM Deal"]]]',
+					value='[["DocType","name","in", ["Customer", "Lead", "Prospect", "CRM Deal"]]]',
 					property_type="JSON",
 					validate_fields_for_doctype=False,
 				)


### PR DESCRIPTION
There is no doctype name of Frappe CRM Deal

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/546d5574-3fc0-42ba-bd50-6da713900819">
