### PR TITLE
fix: Link field filters

### DIFF
--- a/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
+++ b/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
@@ -45,6 +45,7 @@ def get_fields_layout(doctype: str, type: str):
 					"options": field.options,
 					"mandatory": field.reqd,
 					"placeholder": field.get("placeholder"),
+					"filters": field.get("link_filters")
 				}
 				section["fields"][section.get("fields").index(field["name"])] = field
 


### PR DESCRIPTION
Custom fields with link filters defined were not reflecting on the CRM portal

the root cause is that the get_fields_layout API is not responding with the filters.
With this small change, it is working as expected