### PR TITLE
Fix: Add null check for Select field options in fields_layout

### DIFF
--- a/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
+++ b/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
@@ -34,7 +34,7 @@ def get_fields_layout(doctype: str, type: str):
 		for field in section.get("fields") if section.get("fields") else []:
 			field = next((f for f in fields if f.fieldname == field), None)
 			if field:
-				if field.fieldtype == "Select":
+				if field.fieldtype == "Select" and field.options:
 					field.options = field.options.split("\n")
 					field.options = [{"label": _(option), "value": option} for option in field.options]
 					field.options.insert(0, {"label": "", "value": ""})


### PR DESCRIPTION
#### Changes:
- Added a null check (`and field.options`) in the condition to handle cases where options are empty or undefined for "Select" type fields.

### Why is this needed?
When I added a custom field of type Select without options, then code attempted to split `field.options` without checking if it existed, which could result in errors when `field.options` is `None` or an empty string which resulted in error and not loading all the fields after that field. By adding this check, we ensure that the code only attempts to split the options when `field.options` has a value.

### Code Changes:

```python
if field.fieldtype == "Select" and field.options:
    field.options = field.options.split("\n")

### Reproduce Issue:
Try creating a select field without options and then add it in sections field layout. then if you try to edit the layout it will cause the error and some of the fields (fields shown after the new field) will not show up