### PR TITLE
test: fixed failing unit test

### DIFF
--- a/crm/fcrm/doctype/crm_call_log/test_crm_call_log.py
+++ b/crm/fcrm/doctype/crm_call_log/test_crm_call_log.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMCallLog(FrappeTestCase):
+class TestCRMCallLog(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_communication_status/test_crm_communication_status.py
+++ b/crm/fcrm/doctype/crm_communication_status/test_crm_communication_status.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMCommunicationStatus(FrappeTestCase):
+class TestCRMCommunicationStatus(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_deal/test_crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/test_crm_deal.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMDeal(FrappeTestCase):
+class TestCRMDeal(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_deal_status/test_crm_deal_status.py
+++ b/crm/fcrm/doctype/crm_deal_status/test_crm_deal_status.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMDealStatus(FrappeTestCase):
+class TestCRMDealStatus(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_fields_layout/test_crm_fields_layout.py
+++ b/crm/fcrm/doctype/crm_fields_layout/test_crm_fields_layout.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMFieldsLayout(FrappeTestCase):
+class TestCRMFieldsLayout(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_form_script/test_crm_form_script.py
+++ b/crm/fcrm/doctype/crm_form_script/test_crm_form_script.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMFormScript(FrappeTestCase):
+class TestCRMFormScript(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_holiday_list/test_crm_holiday_list.py
+++ b/crm/fcrm/doctype/crm_holiday_list/test_crm_holiday_list.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMHolidayList(FrappeTestCase):
+class TestCRMHolidayList(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_industry/test_crm_industry.py
+++ b/crm/fcrm/doctype/crm_industry/test_crm_industry.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMIndustry(FrappeTestCase):
+class TestCRMIndustry(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_invitation/test_crm_invitation.py
+++ b/crm/fcrm/doctype/crm_invitation/test_crm_invitation.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMInvitation(FrappeTestCase):
+class TestCRMInvitation(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMLead(FrappeTestCase):
+class TestCRMLead(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_lead_source/test_crm_lead_source.py
+++ b/crm/fcrm/doctype/crm_lead_source/test_crm_lead_source.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMLeadSource(FrappeTestCase):
+class TestCRMLeadSource(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_lead_status/test_crm_lead_status.py
+++ b/crm/fcrm/doctype/crm_lead_status/test_crm_lead_status.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMLeadStatus(FrappeTestCase):
+class TestCRMLeadStatus(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_notification/test_crm_notification.py
+++ b/crm/fcrm/doctype/crm_notification/test_crm_notification.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMNotification(FrappeTestCase):
+class TestCRMNotification(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_organization/test_crm_organization.py
+++ b/crm/fcrm/doctype/crm_organization/test_crm_organization.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMOrganization(FrappeTestCase):
+class TestCRMOrganization(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_service_level_agreement/test_crm_service_level_agreement.py
+++ b/crm/fcrm/doctype/crm_service_level_agreement/test_crm_service_level_agreement.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMServiceLevelAgreement(FrappeTestCase):
+class TestCRMServiceLevelAgreement(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_service_level_priority/test_crm_service_level_priority.py
+++ b/crm/fcrm/doctype/crm_service_level_priority/test_crm_service_level_priority.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMServiceLevelPriority(FrappeTestCase):
+class TestCRMServiceLevelPriority(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_task/test_crm_task.py
+++ b/crm/fcrm/doctype/crm_task/test_crm_task.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMTask(FrappeTestCase):
+class TestCRMTask(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_territory/test_crm_territory.py
+++ b/crm/fcrm/doctype/crm_territory/test_crm_territory.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMTerritory(FrappeTestCase):
+class TestCRMTerritory(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/crm_view_settings/test_crm_view_settings.py
+++ b/crm/fcrm/doctype/crm_view_settings/test_crm_view_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCRMViewSettings(FrappeTestCase):
+class TestCRMViewSettings(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/erpnext_crm_settings/test_erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/test_erpnext_crm_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestERPNextCRMSettings(FrappeTestCase):
+class TestERPNextCRMSettings(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/fcrm_note/test_fcrm_note.py
+++ b/crm/fcrm/doctype/fcrm_note/test_fcrm_note.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestFCRMNote(FrappeTestCase):
+class TestFCRMNote(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/twilio_agents/test_twilio_agents.py
+++ b/crm/fcrm/doctype/twilio_agents/test_twilio_agents.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestTwilioAgents(FrappeTestCase):
+class TestTwilioAgents(UnitTestCase):
 	pass

--- a/crm/fcrm/doctype/twilio_settings/test_twilio_settings.py
+++ b/crm/fcrm/doctype/twilio_settings/test_twilio_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestTwilioSettings(FrappeTestCase):
+class TestTwilioSettings(UnitTestCase):
 	pass


### PR DESCRIPTION
Fixed failing unit test with below error
```
frappe.testing.discovery.TestRunnerError: Failed to discover tests for ['crm']: function() argument 'code' must be code, not str
```
**Cause:**
PR Link: https://github.com/frappe/frappe/pull/28044