### PR TITLE
Fix: hides the section if all the fields are hidden

### DIFF
--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -113,158 +113,162 @@
         class="flex flex-1 flex-col justify-between overflow-hidden"
       >
         <div class="flex flex-col overflow-y-auto">
-          <div
-            v-for="(section, i) in fieldsLayout.data"
-            :key="section.label"
-            class="section flex flex-col p-3"
-            :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
-          >
-            <Section :is-opened="section.opened" :label="section.label">
-              <template #actions>
-                <div v-if="section.contacts" class="pr-2">
-                  <Link
-                    value=""
-                    doctype="Contact"
-                    @change="(e) => addContact(e)"
-                    :onCreate="
-                      (value, close) => {
-                        _contact = {
-                          first_name: value,
-                          company_name: deal.data.organization,
+          <div v-for="(section, i) in fieldsLayout.data" :key="section.label">
+            <div
+              v-if="
+                section.fields?.some((field) => field.hidden === 0) ||
+                section.contacts
+              "
+              class="section flex flex-col p-3"
+              :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
+            >
+              <Section :is-opened="section.opened" :label="section.label">
+                <template #actions>
+                  <div v-if="section.contacts" class="pr-2">
+                    <Link
+                      value=""
+                      doctype="Contact"
+                      @change="(e) => addContact(e)"
+                      :onCreate="
+                        (value, close) => {
+                          _contact = {
+                            first_name: value,
+                            company_name: deal.data.organization,
+                          }
+                          showContactModal = true
+                          close()
                         }
-                        showContactModal = true
-                        close()
-                      }
-                    "
-                  >
-                    <template #target="{ togglePopover }">
-                      <Button
-                        class="h-7 px-3"
-                        variant="ghost"
-                        icon="plus"
-                        @click="togglePopover()"
-                      />
-                    </template>
-                  </Link>
-                </div>
-                <Button
-                  v-else-if="
-                    ((!section.contacts && i == 1) || i == 0) && isManager()
-                  "
-                  variant="ghost"
-                  class="w-7 mr-2"
-                  @click="showSidePanelModal = true"
-                >
-                  <EditIcon class="h-4 w-4" />
-                </Button>
-              </template>
-              <SectionFields
-                v-if="section.fields"
-                :fields="section.fields"
-                :isLastSection="i == fieldsLayout.data.length - 1"
-                v-model="deal.data"
-                @update="updateField"
-              />
-              <div v-else>
-                <div
-                  v-if="
-                    dealContacts?.loading && dealContacts?.data?.length == 0
-                  "
-                  class="flex min-h-20 flex-1 items-center justify-center gap-3 text-base text-gray-500"
-                >
-                  <LoadingIndicator class="h-4 w-4" />
-                  <span>{{ __('Loading...') }}</span>
-                </div>
-                <div
-                  v-else-if="dealContacts?.data?.length"
-                  v-for="(contact, i) in dealContacts.data"
-                  :key="contact.name"
-                >
-                  <div
-                    class="px-2 pb-2.5"
-                    :class="[i == 0 ? 'pt-5' : 'pt-2.5']"
-                  >
-                    <Section :is-opened="contact.opened">
-                      <template #header="{ opened, toggle }">
-                        <div
-                          class="flex cursor-pointer items-center justify-between gap-2 pr-1 text-base leading-5 text-gray-700"
-                        >
-                          <div
-                            class="flex h-7 items-center gap-2 truncate"
-                            @click="toggle()"
-                          >
-                            <Avatar
-                              :label="contact.full_name"
-                              :image="contact.image"
-                              size="md"
-                            />
-                            <div class="truncate">
-                              {{ contact.full_name }}
-                            </div>
-                            <Badge
-                              v-if="contact.is_primary"
-                              class="ml-2"
-                              variant="outline"
-                              :label="__('Primary')"
-                              theme="green"
-                            />
-                          </div>
-                          <div class="flex items-center">
-                            <Dropdown :options="contactOptions(contact)">
-                              <Button
-                                icon="more-horizontal"
-                                class="text-gray-600"
-                                variant="ghost"
-                              />
-                            </Dropdown>
-                            <Button
-                              variant="ghost"
-                              @click="
-                                router.push({
-                                  name: 'Contact',
-                                  params: { contactId: contact.name },
-                                })
-                              "
-                            >
-                              <ArrowUpRightIcon class="h-4 w-4" />
-                            </Button>
-                            <Button variant="ghost" @click="toggle()">
-                              <FeatherIcon
-                                name="chevron-right"
-                                class="h-4 w-4 text-gray-900 transition-all duration-300 ease-in-out"
-                                :class="{ 'rotate-90': opened }"
-                              />
-                            </Button>
-                          </div>
-                        </div>
+                      "
+                    >
+                      <template #target="{ togglePopover }">
+                        <Button
+                          class="h-7 px-3"
+                          variant="ghost"
+                          icon="plus"
+                          @click="togglePopover()"
+                        />
                       </template>
-                      <div
-                        class="flex flex-col gap-1.5 text-base text-gray-800"
-                      >
-                        <div class="flex items-center gap-3 pb-1.5 pl-1 pt-4">
-                          <Email2Icon class="h-4 w-4" />
-                          {{ contact.email }}
-                        </div>
-                        <div class="flex items-center gap-3 p-1 py-1.5">
-                          <PhoneIcon class="h-4 w-4" />
-                          {{ contact.mobile_no }}
-                        </div>
-                      </div>
-                    </Section>
+                    </Link>
+                  </div>
+                  <Button
+                    v-else-if="
+                      ((!section.contacts && i == 1) || i == 0) && isManager()
+                    "
+                    variant="ghost"
+                    class="w-7 mr-2"
+                    @click="showSidePanelModal = true"
+                  >
+                    <EditIcon class="h-4 w-4" />
+                  </Button>
+                </template>
+                <SectionFields
+                  v-if="section.fields"
+                  :fields="section.fields"
+                  :isLastSection="i == fieldsLayout.data.length - 1"
+                  v-model="deal.data"
+                  @update="updateField"
+                />
+                <div v-else>
+                  <div
+                    v-if="
+                      dealContacts?.loading && dealContacts?.data?.length == 0
+                    "
+                    class="flex min-h-20 flex-1 items-center justify-center gap-3 text-base text-gray-500"
+                  >
+                    <LoadingIndicator class="h-4 w-4" />
+                    <span>{{ __('Loading...') }}</span>
                   </div>
                   <div
-                    v-if="i != dealContacts.data.length - 1"
-                    class="mx-2 h-px border-t border-gray-200"
-                  />
+                    v-else-if="dealContacts?.data?.length"
+                    v-for="(contact, i) in dealContacts.data"
+                    :key="contact.name"
+                  >
+                    <div
+                      class="px-2 pb-2.5"
+                      :class="[i == 0 ? 'pt-5' : 'pt-2.5']"
+                    >
+                      <Section :is-opened="contact.opened">
+                        <template #header="{ opened, toggle }">
+                          <div
+                            class="flex cursor-pointer items-center justify-between gap-2 pr-1 text-base leading-5 text-gray-700"
+                          >
+                            <div
+                              class="flex h-7 items-center gap-2 truncate"
+                              @click="toggle()"
+                            >
+                              <Avatar
+                                :label="contact.full_name"
+                                :image="contact.image"
+                                size="md"
+                              />
+                              <div class="truncate">
+                                {{ contact.full_name }}
+                              </div>
+                              <Badge
+                                v-if="contact.is_primary"
+                                class="ml-2"
+                                variant="outline"
+                                :label="__('Primary')"
+                                theme="green"
+                              />
+                            </div>
+                            <div class="flex items-center">
+                              <Dropdown :options="contactOptions(contact)">
+                                <Button
+                                  icon="more-horizontal"
+                                  class="text-gray-600"
+                                  variant="ghost"
+                                />
+                              </Dropdown>
+                              <Button
+                                variant="ghost"
+                                @click="
+                                  router.push({
+                                    name: 'Contact',
+                                    params: { contactId: contact.name },
+                                  })
+                                "
+                              >
+                                <ArrowUpRightIcon class="h-4 w-4" />
+                              </Button>
+                              <Button variant="ghost" @click="toggle()">
+                                <FeatherIcon
+                                  name="chevron-right"
+                                  class="h-4 w-4 text-gray-900 transition-all duration-300 ease-in-out"
+                                  :class="{ 'rotate-90': opened }"
+                                />
+                              </Button>
+                            </div>
+                          </div>
+                        </template>
+                        <div
+                          class="flex flex-col gap-1.5 text-base text-gray-800"
+                        >
+                          <div class="flex items-center gap-3 pb-1.5 pl-1 pt-4">
+                            <Email2Icon class="h-4 w-4" />
+                            {{ contact.email }}
+                          </div>
+                          <div class="flex items-center gap-3 p-1 py-1.5">
+                            <PhoneIcon class="h-4 w-4" />
+                            {{ contact.mobile_no }}
+                          </div>
+                        </div>
+                      </Section>
+                    </div>
+                    <div
+                      v-if="i != dealContacts.data.length - 1"
+                      class="mx-2 h-px border-t border-gray-200"
+                    />
+                  </div>
+                  <div
+                    v-else
+                    class="flex h-20 items-center justify-center text-base text-gray-600"
+                  >
+                    {{ __('No contacts added') }}
+                  </div>
                 </div>
-                <div
-                  v-else
-                  class="flex h-20 items-center justify-center text-base text-gray-600"
-                >
-                  {{ __('No contacts added') }}
-                </div>
-              </div>
-            </Section>
+              </Section>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -166,29 +166,30 @@
         class="flex flex-1 flex-col justify-between overflow-hidden"
       >
         <div class="flex flex-col overflow-y-auto">
-          <div
-            v-for="(section, i) in fieldsLayout.data"
-            :key="section.label"
-            class="flex flex-col p-3"
-            :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
-          >
-            <Section :is-opened="section.opened" :label="section.label">
-              <SectionFields
-                :fields="section.fields"
-                :isLastSection="i == fieldsLayout.data.length - 1"
-                v-model="lead.data"
-                @update="updateField"
-              />
-              <template v-if="i == 0 && isManager()" #actions>
-                <Button
-                  variant="ghost"
-                  class="w-7 mr-2"
-                  @click="showSidePanelModal = true"
-                >
-                  <EditIcon class="h-4 w-4" />
-                </Button>
-              </template>
-            </Section>
+          <div v-for="(section, i) in fieldsLayout.data" :key="section.label">
+            <div
+              v-if="section.fields.some((field) => field.hidden === 0)"
+              class="flex flex-col p-3"
+              :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
+            >
+              <Section :is-opened="section.opened" :label="section.label">
+                <SectionFields
+                  :fields="section.fields"
+                  :isLastSection="i == fieldsLayout.data.length - 1"
+                  v-model="lead.data"
+                  @update="updateField"
+                />
+                <template v-if="i == 0 && isManager()" #actions>
+                  <Button
+                    variant="ghost"
+                    class="w-7 mr-2"
+                    @click="showSidePanelModal = true"
+                  >
+                    <EditIcon class="h-4 w-4" />
+                  </Button>
+                </template>
+              </Section>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -63,148 +63,156 @@
           class="flex flex-1 flex-col justify-between overflow-hidden"
         >
           <div class="flex flex-col overflow-y-auto">
-            <div
-              v-for="(section, i) in fieldsLayout.data"
-              :key="section.label"
-              class="flex flex-col px-2 py-3 sm:p-3"
-              :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
-            >
-              <Section :is-opened="section.opened" :label="section.label">
-                <template #actions>
-                  <div v-if="section.contacts" class="pr-2">
-                    <Link
-                      value=""
-                      doctype="Contact"
-                      @change="(e) => addContact(e)"
-                      :onCreate="
-                        (value, close) => {
-                          _contact = {
-                            first_name: value,
-                            company_name: deal.data.organization,
+            <div v-for="(section, i) in fieldsLayout.data" :key="section.label">
+              <div
+                v-if="
+                  section.fields?.some((field) => field.hidden === 0) ||
+                  section.contacts
+                "
+                class="flex flex-col px-2 py-3 sm:p-3"
+                :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
+              >
+                <Section :is-opened="section.opened" :label="section.label">
+                  <template #actions>
+                    <div v-if="section.contacts" class="pr-2">
+                      <Link
+                        value=""
+                        doctype="Contact"
+                        @change="(e) => addContact(e)"
+                        :onCreate="
+                          (value, close) => {
+                            _contact = {
+                              first_name: value,
+                              company_name: deal.data.organization,
+                            }
+                            showContactModal = true
+                            close()
                           }
-                          showContactModal = true
-                          close()
-                        }
-                      "
-                    >
-                      <template #target="{ togglePopover }">
-                        <Button
-                          class="h-7 px-3"
-                          variant="ghost"
-                          icon="plus"
-                          @click="togglePopover()"
-                        />
-                      </template>
-                    </Link>
-                  </div>
-                </template>
-                <SectionFields
-                  v-if="section.fields"
-                  :fields="section.fields"
-                  :isLastSection="i == fieldsLayout.data.length - 1"
-                  v-model="deal.data"
-                  @update="updateField"
-                />
-                <div v-else>
-                  <div
-                    v-if="
-                      dealContacts?.loading && dealContacts?.data?.length == 0
-                    "
-                    class="flex min-h-20 flex-1 items-center justify-center gap-3 text-base text-gray-500"
-                  >
-                    <LoadingIndicator class="h-4 w-4" />
-                    <span>{{ __('Loading...') }}</span>
-                  </div>
-                  <div
-                    v-else-if="section.contacts.length"
-                    v-for="(contact, i) in section.contacts"
-                    :key="contact.name"
-                  >
-                    <div
-                      class="px-2 pb-2.5"
-                      :class="[i == 0 ? 'pt-5' : 'pt-2.5']"
-                    >
-                      <Section :is-opened="contact.opened">
-                        <template #header="{ opened, toggle }">
-                          <div
-                            class="flex cursor-pointer items-center justify-between gap-2 pr-1 text-base leading-5 text-gray-700"
-                          >
-                            <div
-                              class="flex h-7 items-center gap-2 truncate"
-                              @click="toggle()"
-                            >
-                              <Avatar
-                                :label="contact.full_name"
-                                :image="contact.image"
-                                size="md"
-                              />
-                              <div class="truncate">
-                                {{ contact.full_name }}
-                              </div>
-                              <Badge
-                                v-if="contact.is_primary"
-                                class="ml-2"
-                                variant="outline"
-                                :label="__('Primary')"
-                                theme="green"
-                              />
-                            </div>
-                            <div class="flex items-center">
-                              <Dropdown :options="contactOptions(contact.name)">
-                                <Button
-                                  icon="more-horizontal"
-                                  class="text-gray-600"
-                                  variant="ghost"
-                                />
-                              </Dropdown>
-                              <Button
-                                variant="ghost"
-                                @click="
-                                  router.push({
-                                    name: 'Contact',
-                                    params: { contactId: contact.name },
-                                  })
-                                "
-                              >
-                                <ArrowUpRightIcon class="h-4 w-4" />
-                              </Button>
-                              <Button variant="ghost" @click="toggle()">
-                                <FeatherIcon
-                                  name="chevron-right"
-                                  class="h-4 w-4 text-gray-900 transition-all duration-300 ease-in-out"
-                                  :class="{ 'rotate-90': opened }"
-                                />
-                              </Button>
-                            </div>
-                          </div>
+                        "
+                      >
+                        <template #target="{ togglePopover }">
+                          <Button
+                            class="h-7 px-3"
+                            variant="ghost"
+                            icon="plus"
+                            @click="togglePopover()"
+                          />
                         </template>
-                        <div
-                          class="flex flex-col gap-1.5 text-base text-gray-800"
-                        >
-                          <div class="flex items-center gap-3 pb-1.5 pl-1 pt-4">
-                            <Email2Icon class="h-4 w-4" />
-                            {{ contact.email }}
-                          </div>
-                          <div class="flex items-center gap-3 p-1 py-1.5">
-                            <PhoneIcon class="h-4 w-4" />
-                            {{ contact.mobile_no }}
-                          </div>
-                        </div>
-                      </Section>
+                      </Link>
+                    </div>
+                  </template>
+                  <SectionFields
+                    v-if="section.fields"
+                    :fields="section.fields"
+                    :isLastSection="i == fieldsLayout.data.length - 1"
+                    v-model="deal.data"
+                    @update="updateField"
+                  />
+                  <div v-else>
+                    <div
+                      v-if="
+                        dealContacts?.loading && dealContacts?.data?.length == 0
+                      "
+                      class="flex min-h-20 flex-1 items-center justify-center gap-3 text-base text-gray-500"
+                    >
+                      <LoadingIndicator class="h-4 w-4" />
+                      <span>{{ __('Loading...') }}</span>
                     </div>
                     <div
-                      v-if="i != section.contacts.length - 1"
-                      class="mx-2 h-px border-t border-gray-200"
-                    />
+                      v-else-if="section.contacts.length"
+                      v-for="(contact, i) in section.contacts"
+                      :key="contact.name"
+                    >
+                      <div
+                        class="px-2 pb-2.5"
+                        :class="[i == 0 ? 'pt-5' : 'pt-2.5']"
+                      >
+                        <Section :is-opened="contact.opened">
+                          <template #header="{ opened, toggle }">
+                            <div
+                              class="flex cursor-pointer items-center justify-between gap-2 pr-1 text-base leading-5 text-gray-700"
+                            >
+                              <div
+                                class="flex h-7 items-center gap-2 truncate"
+                                @click="toggle()"
+                              >
+                                <Avatar
+                                  :label="contact.full_name"
+                                  :image="contact.image"
+                                  size="md"
+                                />
+                                <div class="truncate">
+                                  {{ contact.full_name }}
+                                </div>
+                                <Badge
+                                  v-if="contact.is_primary"
+                                  class="ml-2"
+                                  variant="outline"
+                                  :label="__('Primary')"
+                                  theme="green"
+                                />
+                              </div>
+                              <div class="flex items-center">
+                                <Dropdown
+                                  :options="contactOptions(contact.name)"
+                                >
+                                  <Button
+                                    icon="more-horizontal"
+                                    class="text-gray-600"
+                                    variant="ghost"
+                                  />
+                                </Dropdown>
+                                <Button
+                                  variant="ghost"
+                                  @click="
+                                    router.push({
+                                      name: 'Contact',
+                                      params: { contactId: contact.name },
+                                    })
+                                  "
+                                >
+                                  <ArrowUpRightIcon class="h-4 w-4" />
+                                </Button>
+                                <Button variant="ghost" @click="toggle()">
+                                  <FeatherIcon
+                                    name="chevron-right"
+                                    class="h-4 w-4 text-gray-900 transition-all duration-300 ease-in-out"
+                                    :class="{ 'rotate-90': opened }"
+                                  />
+                                </Button>
+                              </div>
+                            </div>
+                          </template>
+                          <div
+                            class="flex flex-col gap-1.5 text-base text-gray-800"
+                          >
+                            <div
+                              class="flex items-center gap-3 pb-1.5 pl-1 pt-4"
+                            >
+                              <Email2Icon class="h-4 w-4" />
+                              {{ contact.email }}
+                            </div>
+                            <div class="flex items-center gap-3 p-1 py-1.5">
+                              <PhoneIcon class="h-4 w-4" />
+                              {{ contact.mobile_no }}
+                            </div>
+                          </div>
+                        </Section>
+                      </div>
+                      <div
+                        v-if="i != section.contacts.length - 1"
+                        class="mx-2 h-px border-t border-gray-200"
+                      />
+                    </div>
+                    <div
+                      v-else
+                      class="flex h-20 items-center justify-center text-base text-gray-600"
+                    >
+                      {{ __('No contacts added') }}
+                    </div>
                   </div>
-                  <div
-                    v-else
-                    class="flex h-20 items-center justify-center text-base text-gray-600"
-                  >
-                    {{ __('No contacts added') }}
-                  </div>
-                </div>
-              </Section>
+                </Section>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -68,20 +68,21 @@
           class="flex flex-1 flex-col justify-between overflow-hidden"
         >
           <div class="flex flex-col overflow-y-auto">
-            <div
-              v-for="(section, i) in fieldsLayout.data"
-              :key="section.label"
-              class="flex flex-col px-2 py-3 sm:p-3"
-              :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
-            >
-              <Section :is-opened="section.opened" :label="section.label">
-                <SectionFields
-                  :fields="section.fields"
-                  :isLastSection="i == fieldsLayout.data.length - 1"
-                  v-model="lead.data"
-                  @update="updateField"
-                />
-              </Section>
+            <div v-for="(section, i) in fieldsLayout.data" :key="section.label">
+              <div
+                v-if="section.fields.some((field) => field.hidden === 0)"
+                class="flex flex-col px-2 py-3 sm:p-3"
+                :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
+              >
+                <Section :is-opened="section.opened" :label="section.label">
+                  <SectionFields
+                    :fields="section.fields"
+                    :isLastSection="i == fieldsLayout.data.length - 1"
+                    v-model="lead.data"
+                    @update="updateField"
+                  />
+                </Section>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Description

This PR hides the section of fields if all the fields are hidden ( like when the user does not have permission to certain fields )

#### Changes:
- The looping div of Section component wrapped with another div and the loop is given to that div. And then added a v-if to the div inside.

### Why is this needed?
Previously, the section with zero fields would still show up and looks like a mess. 

### Code Changes:

In Lead.vue

```vue
          <div v-for="(section, i) in fieldsLayout.data" :key="section.label">
            <div
              v-if="section.fields.some((field) => field.hidden === 0)"
              class="flex flex-col p-3"
              :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
            >
              <Section :is-opened="section.opened" :label="section.label">
               <!-- Remaining code -->
```

In Deal.vue

```vue

        <div class="flex flex-col overflow-y-auto">
          <div v-for="(section, i) in fieldsLayout.data" :key="section.label">
            <div
              v-if="section.fields?.some((field) => field.hidden === 0) || section.contacts"
              class="section flex flex-col p-3"
              :class="{ 'border-b': i !== fieldsLayout.data.length - 1 }"
            >
              <Section :is-opened="section.opened" :label="section.label">
              <!-- Remaining code -->
```