### PR TITLE
Fix: assigning to new owner and revoking old assignees permissions upon lead_owner change

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -18,9 +18,11 @@ class CRMDeal(Document):
 	def validate(self):
 		self.set_primary_contact()
 		self.set_primary_email_mobile_no()
-		if self.deal_owner and not self.is_new():
-			self.share_with_agent(self.deal_owner)
-			self.assign_agent(self.deal_owner)
+		if not self.is_new():
+			curr_owner = frappe.db.get_value(self.doctype,self.name,"deal_owner")
+			if self.deal_owner and self.deal_owner != curr_owner:
+				self.share_with_agent(self.deal_owner)
+				self.assign_agent(self.deal_owner)
 		if self.has_value_changed("status"):
 			add_status_change_log(self)
 

--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -18,11 +18,9 @@ class CRMDeal(Document):
 	def validate(self):
 		self.set_primary_contact()
 		self.set_primary_email_mobile_no()
-		if not self.is_new():
-			curr_owner = frappe.db.get_value(self.doctype,self.name,"deal_owner")
-			if self.deal_owner and self.deal_owner != curr_owner:
-				self.share_with_agent(self.deal_owner)
-				self.assign_agent(self.deal_owner)
+		if not self.is_new() and self.has_value_changed("deal_owner") and self.deal_owner:
+			self.share_with_agent(self.deal_owner)
+			self.assign_agent(self.deal_owner)
 		if self.has_value_changed("status"):
 			add_status_change_log(self)
 

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -21,11 +21,9 @@ class CRMLead(Document):
 		self.set_lead_name()
 		self.set_title()
 		self.validate_email()
-		if not self.is_new():
-			curr_owner = frappe.db.get_value(self.doctype,self.name,"lead_owner")
-			if self.lead_owner and self.lead_owner != curr_owner:
-				self.share_with_agent(self.lead_owner)
-				self.assign_agent(self.lead_owner)
+		if not self.is_new() and self.has_value_changed("lead_owner") and self.lead_owner:
+			self.share_with_agent(self.lead_owner)
+			self.assign_agent(self.lead_owner)
 		if self.has_value_changed("status"):
 			add_status_change_log(self)
 

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -21,9 +21,11 @@ class CRMLead(Document):
 		self.set_lead_name()
 		self.set_title()
 		self.validate_email()
-		if self.lead_owner and not self.is_new():
-			self.share_with_agent(self.lead_owner)
-			self.assign_agent(self.lead_owner)
+		if not self.is_new():
+			curr_owner = frappe.db.get_value(self.doctype,self.name,"lead_owner")
+			if self.lead_owner and self.lead_owner != curr_owner:
+				self.share_with_agent(self.lead_owner)
+				self.assign_agent(self.lead_owner)
 		if self.has_value_changed("status"):
 			add_status_change_log(self)
 


### PR DESCRIPTION
This PR is a fix to this issue #417
Previously the share permissions were revoked from the assignees each time the lead and deal get evaluated.
this PR checks if the owner of doc has changed and then revokes the perms.

 Code Changed
 ```py
 if not self.is_new():
			curr_owner = frappe.db.get_value(self.doctype,self.name,"lead_owner")
			if self.lead_owner and self.lead_owner != curr_owner:
				self.share_with_agent(self.lead_owner)
				self.assign_agent(self.lead_owner)
```