### PR TITLE
feat[lang]: fr translations

### DIFF
--- a/crm/locale/fr.po
+++ b/crm/locale/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Frappe CRM VERSION\n"
 "Report-Msgid-Bugs-To: shariq@frappe.io\n"
 "POT-Creation-Date: 2024-10-15 20:07+0000\n"
-"PO-Revision-Date: 2024-10-16 15:46+0200\n"
+"PO-Revision-Date: 2024-10-16 23:27+0200\n"
 "Last-Translator: \n"
 "Language-Team: shariq@frappe.io\n"
 "Language: fr\n"
@@ -45,7 +45,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "1000+"
-msgstr ""
+msgstr "1000 "
 
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
@@ -154,7 +154,7 @@ msgstr "SID du Compte"
 #: frontend/src/components/CustomActions.vue:73
 #: frontend/src/components/ViewControls.vue:574
 msgid "Actions"
-msgstr "Actions"
+msgstr ""
 
 #: frontend/src/pages/Deal.vue:524 frontend/src/pages/Lead.vue:470
 #: frontend/src/pages/MobileDeal.vue:441 frontend/src/pages/MobileLead.vue:351
@@ -244,11 +244,11 @@ msgstr "Appliquer à"
 
 #: frontend/src/components/Apps.vue:14
 msgid "Apps"
-msgstr "Apps"
+msgstr ""
 
 #: frontend/src/pages/Contact.vue:346
 msgid "Are you sure you want to delete this contact?"
-msgstr "Êtes-vous sur de vouloir effacer de contact ?"
+msgstr "Êtes-vous sur de vouloir effacer ce contact ?"
 
 #: frontend/src/pages/Organization.vue:352
 msgid "Are you sure you want to delete this organization?"
@@ -289,13 +289,13 @@ msgstr "Affectation retirée avec succès"
 #. Label of the auth_token (Password) field in DocType 'Twilio Settings'
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
 msgid "Auth Token"
-msgstr ""
+msgstr "Jeton d'authentification"
 
 #: frontend/src/components/Activities/EmailArea.vue:72
 #: frontend/src/components/EmailEditor.vue:41
 #: frontend/src/components/EmailEditor.vue:63
 msgid "BCC"
-msgstr ""
+msgstr "Cci"
 
 #: frontend/src/components/Settings/ProfileSettings.vue:45
 msgid "Back"
@@ -342,68 +342,68 @@ msgstr "Statut de Communication CRM"
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_contacts/crm_contacts.json
 msgid "CRM Contacts"
-msgstr ""
+msgstr "Contacts CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: frontend/src/components/Modals/EmailTemplateModal.vue:37
 msgid "CRM Deal"
-msgstr "CRM Opportunité"
+msgstr "Opportunité CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 msgid "CRM Deal Status"
-msgstr "CRM Statut de l'Opportunité"
+msgstr "Statut de l'Opportunité CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "CRM Fields Layout"
-msgstr "CRM Disposition des Champs"
+msgstr "Disposition des Champs CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 msgid "CRM Form Script"
-msgstr "CRM Script de Formulaire"
+msgstr "Script de Formulaire CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_holiday/crm_holiday.json
 msgid "CRM Holiday"
-msgstr "CRM Jour Férié"
+msgstr "Jour Férié CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "CRM Holiday List"
-msgstr "CRM Liste des Jour Fériés"
+msgstr "Liste des Jour Fériés CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_industry/crm_industry.json
 msgid "CRM Industry"
-msgstr "CRM Industrie"
+msgstr " Industrie CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "CRM Invitation"
-msgstr "CRM Invitation"
+msgstr "Invitation CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "CRM Lead"
-msgstr "CRM Prospect"
+msgstr "Piste CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
 msgid "CRM Lead Source"
-msgstr "CRM Source du Prospect"
+msgstr "Source de la Piste CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "CRM Lead Status"
-msgstr "CRM Statut du Prospect"
+msgstr "CRM Statut du Piste"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "CRM Notification"
-msgstr "CRM Notification"
+msgstr ""
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
@@ -423,7 +423,7 @@ msgstr "CRM Jour d’Entretien"
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "CRM Service Level Agreement"
-msgstr "CRM Engagement de Niveau de Service"
+msgstr "CRM Accord de Niveau de Service"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
@@ -616,7 +616,7 @@ msgstr "Ordinateur"
 #. Label of the condition (Code) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Condition"
-msgstr "Condition"
+msgstr ""
 
 #. Label of the contact (Link) field in DocType 'CRM Contacts'
 #. Label of the contact (Link) field in DocType 'CRM Deal'
@@ -624,7 +624,7 @@ msgstr "Condition"
 #: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Lead.vue:248
 #: frontend/src/pages/MobileLead.vue:150
 msgid "Contact"
-msgstr "Contact"
+msgstr ""
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:178
 msgid "Contact Already Exists"
@@ -769,7 +769,7 @@ msgstr "Client crée avec succès"
 #. Label of the date (Date) field in DocType 'CRM Holiday'
 #: crm/fcrm/doctype/crm_holiday/crm_holiday.json
 msgid "Date"
-msgstr "Date"
+msgstr ""
 
 #: frontend/src/pages/Tasks.vue:129
 msgid "Deal"
@@ -815,7 +815,7 @@ msgstr "Cher•ère {{ lead_name }}, \\n\\nCeci est un rappel pour le paiement d
 #. Label of the default (Check) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Default"
-msgstr "Default"
+msgstr ""
 
 #. Label of the default_priority (Check) field in DocType 'CRM Service Level
 #. Priority'
@@ -825,7 +825,7 @@ msgstr "Priorité par Défaut"
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:33
 msgid "Default Service Level Agreement already exists for {0}"
-msgstr "Un Niveau d’Engagement de Service par Défaut existe déjà"
+msgstr "Un Accord de Niveau de Service par Défaut existe déjà"
 
 #: frontend/src/components/ViewControls.vue:525
 #: frontend/src/components/ViewControls.vue:883
@@ -888,7 +888,7 @@ msgstr ""
 
 #: frontend/src/components/Apps.vue:58
 msgid "Desk"
-msgstr ""
+msgstr "Bureau"
 
 #. Label of the details (Tab Break) field in DocType 'CRM Lead'
 #. Label of the details (Text Editor) field in DocType 'CRM Lead Source'
@@ -921,7 +921,7 @@ msgstr "Type de Document"
 
 #: frontend/src/components/UserDropdown.vue:88
 msgid "Docs"
-msgstr ""
+msgstr "Documents"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:32
 msgid "Doctype"
@@ -944,7 +944,7 @@ msgstr "Terminé"
 #: frontend/src/components/Activities/AudioPlayer.vue:166
 #: frontend/src/components/ViewControls.vue:175
 msgid "Download"
-msgstr "Telecharger"
+msgstr "Télecharger"
 
 #. Label of the due_date (Datetime) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -1048,7 +1048,7 @@ msgstr "Modifier profil"
 #: frontend/src/pages/Organization.vue:516
 #: frontend/src/pages/Organization.vue:544
 msgid "Email"
-msgstr ""
+msgstr "E-mail"
 
 #. Label of the email_sent_at (Datetime) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -1066,7 +1066,7 @@ msgstr "Email de la Piste"
 #: frontend/src/pages/Deal.vue:529 frontend/src/pages/Lead.vue:475
 #: frontend/src/pages/MobileDeal.vue:446 frontend/src/pages/MobileLead.vue:356
 msgid "Emails"
-msgstr ""
+msgstr "e-mails"
 
 #: frontend/src/components/ListViews/ListRows.vue:12
 msgid "Empty"
@@ -1149,8 +1149,8 @@ msgid "Error while creating customer in ERPNext, check error log for more detail
 msgstr "Erreur à la création du client dans ERPNext, vérifiez le journal des erreurs pour plus de détails"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:158
-msgid "Error while creating prospect in ERPNext, check error log for more details"
-msgstr "Erreur à la création du prospect dans ERPNext, veuillez vérifier le journal des erreur pour plus de détails"
+msgid "Error while creating Piste in ERPNext, check error log for more details"
+msgstr "Erreur à la création du Piste dans ERPNext, veuillez vérifier le journal des erreur pour plus de détails"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:112
 msgid "Error while fetching customer in ERPNext, check error log for more details"
@@ -1186,7 +1186,7 @@ msgstr "Type d’Export"
 #. Name of a DocType
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
 msgid "FCRM Note"
-msgstr ""
+msgstr "Note FCRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -1534,14 +1534,14 @@ msgstr "Est Principal"
 #. Label of the is_standard (Check) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 msgid "Is Standard"
-msgstr ""
+msgstr "est la norme"
 
 #. Label of the job_title (Data) field in DocType 'CRM Deal'
 #. Label of the job_title (Data) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Job Title"
-msgstr ""
+msgstr "Titre du poste"
 
 #: frontend/src/components/Filter.vue:73 frontend/src/components/Filter.vue:106
 #: frontend/src/components/Modals/AssignmentModal.vue:35
@@ -1559,71 +1559,71 @@ msgstr ""
 #. Label of the kanban_columns (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Kanban Columns"
-msgstr ""
+msgstr "Colonnes Kanban"
 
 #. Label of the kanban_fields (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Kanban Fields"
-msgstr ""
+msgstr "Champs Kanban"
 
 #: frontend/src/components/Kanban/KanbanSettings.vue:3
 #: frontend/src/components/Kanban/KanbanSettings.vue:11
 msgid "Kanban Settings"
-msgstr ""
+msgstr "Paramètres Kanban"
 
 #. Label of the key (Data) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Key"
-msgstr ""
+msgstr "Clé"
 
 #. Label of the label (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: frontend/src/components/ColumnSettings.vue:103
 msgid "Label"
-msgstr ""
+msgstr "Etiquette"
 
 #: frontend/src/components/Filter.vue:615
 msgid "Last 6 Months"
-msgstr ""
+msgstr "6 derniers mois"
 
 #: frontend/src/components/Filter.vue:607
 msgid "Last Month"
-msgstr ""
+msgstr "Mois dernier"
 
 #. Label of the last_name (Data) field in DocType 'CRM Deal'
 #. Label of the last_name (Data) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Last Name"
-msgstr ""
+msgstr "Nom de famille"
 
 #: frontend/src/components/Filter.vue:611
 msgid "Last Quarter"
-msgstr ""
+msgstr "Dernier trimestre"
 
 #. Label of the last_status_change_log (Link) field in DocType 'CRM Status
 #. Change Log'
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "Last Status Change Log"
-msgstr ""
+msgstr "journal du dernier changement d'état"
 
 #: frontend/src/components/Filter.vue:603
 msgid "Last Week"
-msgstr ""
+msgstr "Semaine Dernière"
 
 #: frontend/src/components/Filter.vue:619
 msgid "Last Year"
-msgstr ""
+msgstr "Année Dernière"
 
 #: frontend/src/pages/Contact.vue:451 frontend/src/pages/Organization.vue:531
 #: frontend/src/pages/Organization.vue:559
 msgid "Last modified"
-msgstr ""
+msgstr "Dernière modification"
 
 #. Label of the layout (Code) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Layout"
-msgstr ""
+msgstr "Disposition"
 
 #. Label of the lead (Link) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Tasks.vue:130
@@ -1633,39 +1633,39 @@ msgstr ""
 #. Label of the lead_details_tab (Tab Break) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Lead Details"
-msgstr ""
+msgstr "Détails de la Piste"
 
 #. Label of the lead_name (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Lead Name"
-msgstr ""
+msgstr "Nom de la Piste"
 
 #. Label of the lead_owner (Link) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Lead Owner"
-msgstr ""
+msgstr "Responsable de la Piste"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:64
 msgid "Lead Owner cannot be same as the Lead Email Address"
-msgstr ""
+msgstr "le Responsable de la Piste ne peut pas être identique à l'adresse e-mail de la Piste"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Sources"
-msgstr ""
+msgstr "Sources de la Piste"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
-msgstr ""
+msgstr "Statuts des Pistes"
 
 #: crm/fcrm/doctype/crm_lead/api.py:15
 msgid "Lead not found"
-msgstr ""
+msgstr "Piste introuvable"
 
 #: frontend/src/pages/Lead.vue:404 frontend/src/pages/MobileLead.vue:285
 msgid "Lead updated"
-msgstr ""
+msgstr "Piste mis à jour"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -1676,7 +1676,7 @@ msgstr "Pistes"
 #. Label of the lft (Int) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Left"
-msgstr ""
+msgstr "Gauche"
 
 #: frontend/src/components/Filter.vue:271
 #: frontend/src/components/Filter.vue:282
@@ -1684,7 +1684,7 @@ msgstr ""
 #: frontend/src/components/Filter.vue:320
 #: frontend/src/components/Filter.vue:334
 msgid "Like"
-msgstr ""
+msgstr "J’aime"
 
 #. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'CRM View Settings'
@@ -1693,88 +1693,88 @@ msgstr ""
 #: frontend/src/components/ViewControls.vue:285
 #: frontend/src/components/ViewControls.vue:480 frontend/src/utils/view.js:12
 msgid "List"
-msgstr ""
+msgstr "Liste"
 
 #: frontend/src/components/Activities/CallArea.vue:71
 msgid "Listen"
-msgstr ""
+msgstr "Écoutez"
 
 #. Label of the load_default_columns (Check) field in DocType 'CRM View
 #. Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Load Default Columns"
-msgstr ""
+msgstr "Charger les colonnes par défaut"
 
 #: frontend/src/components/Kanban/KanbanView.vue:138
 msgid "Load More"
-msgstr ""
+msgstr "Charger plus"
 
 #: frontend/src/components/Activities/Activities.vue:21
 #: frontend/src/pages/Deal.vue:176 frontend/src/pages/MobileDeal.vue:116
 msgid "Loading..."
-msgstr ""
+msgstr "Chargement..."
 
 #. Label of the log_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the log_tab (Tab Break) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Log"
-msgstr ""
+msgstr "Journal"
 
 #: frontend/src/components/UserDropdown.vue:104
 msgid "Log out"
-msgstr ""
+msgstr "Déconnexion"
 
 #. Option for the 'Priority' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Low"
-msgstr ""
+msgstr "Faible"
 
 #: frontend/src/pages/Contact.vue:82
 msgid "Make Call"
-msgstr ""
+msgstr "Passer un appel"
 
 #: frontend/src/components/ViewControls.vue:912
 msgid "Make Private"
-msgstr ""
+msgstr "Rendre privé"
 
 #: frontend/src/components/ViewControls.vue:912
 msgid "Make Public"
-msgstr ""
+msgstr "Rendre public"
 
 #: frontend/src/components/Activities/Activities.vue:342
 #: frontend/src/components/Activities/ActivityHeader.vue:36
 #: frontend/src/components/Activities/ActivityHeader.vue:128
 #: frontend/src/pages/Deals.vue:490 frontend/src/pages/Leads.vue:507
 msgid "Make a Call"
-msgstr ""
+msgstr "Passer un Appel"
 
 #: frontend/src/pages/Deal.vue:74 frontend/src/pages/Lead.vue:116
 msgid "Make a call"
-msgstr ""
+msgstr "Passer un appel"
 
 #: frontend/src/components/Settings/InviteMemberPage.vue:25
 #: frontend/src/components/Settings/InviteMemberPage.vue:101
 msgid "Manager Access"
-msgstr ""
+msgstr "Accès gestionnaire"
 
 #: frontend/src/components/Notifications.vue:19
 #: frontend/src/pages/MobileNotification.vue:11
 #: frontend/src/pages/MobileNotification.vue:14
 msgid "Mark all as read"
-msgstr ""
+msgstr "Marquer tout comme lu"
 
 #. Label of the medium (Data) field in DocType 'CRM Call Log'
 #. Option for the 'Priority' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Medium"
-msgstr ""
+msgstr "Moyen"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Mention"
-msgstr ""
+msgstr "Mentionner"
 
 #. Label of the message (HTML Editor) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -1784,7 +1784,7 @@ msgstr ""
 #. Label of the middle_name (Data) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Middle Name"
-msgstr ""
+msgstr "Deuxième prénom"
 
 #. Label of the mobile_no (Data) field in DocType 'CRM Contacts'
 #. Label of the mobile_no (Data) field in DocType 'CRM Deal'
@@ -1793,172 +1793,172 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Mobile No"
-msgstr ""
+msgstr "N° de portable"
 
 #: frontend/src/components/Modals/DealModal.vue:191
 #: frontend/src/components/Modals/LeadModal.vue:143
 msgid "Mobile No should be a number"
-msgstr ""
+msgstr "le Numéro de Portable doit être un numéro"
 
 #: frontend/src/pages/Contact.vue:441 frontend/src/pages/Organization.vue:521
 msgid "Mobile no"
-msgstr ""
+msgstr "N° de portable"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Monday"
-msgstr ""
+msgstr "Lundi"
 
 #: frontend/src/pages/Contact.vue:129 frontend/src/pages/Organization.vue:132
 msgid "More"
-msgstr ""
+msgstr "Plus"
 
 #: frontend/src/components/Modals/ViewModal.vue:42
 msgid "My Open Deals"
-msgstr ""
+msgstr "Mes Opportunité ouvertes"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:21
 #: frontend/src/pages/Organization.vue:539
 msgid "Name"
-msgstr ""
+msgstr "Nom"
 
 #. Label of the naming_series (Select) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Naming Series"
-msgstr ""
+msgstr "Série de noms"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:76
 msgid "New"
-msgstr ""
+msgstr "Nouveau"
 
 #: frontend/src/components/Modals/AddressModal.vue:94
 msgid "New Address"
-msgstr ""
+msgstr "Nouvelle adresse"
 
 #: frontend/src/components/Activities/Activities.vue:357
 #: frontend/src/components/Activities/ActivityHeader.vue:26
 #: frontend/src/components/Activities/ActivityHeader.vue:123
 msgid "New Comment"
-msgstr ""
+msgstr "Nouveau Commentaire"
 
 #: frontend/src/components/Activities/Activities.vue:352
 #: frontend/src/components/Activities/ActivityHeader.vue:16
 #: frontend/src/components/Activities/ActivityHeader.vue:118
 msgid "New Email"
-msgstr ""
+msgstr "Nouvel e-mail"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:67
 msgid "New Message"
-msgstr ""
+msgstr "Nouveau Message"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:46
 #: frontend/src/components/Activities/ActivityHeader.vue:134
 #: frontend/src/pages/Deals.vue:496 frontend/src/pages/Leads.vue:513
 msgid "New Note"
-msgstr ""
+msgstr "Nouvelle Note"
 
 #: frontend/src/components/Modals/OrganizationModal.vue:187
 msgid "New Organization"
-msgstr ""
+msgstr "Nouvelle Organisation"
 
 #: frontend/src/components/QuickEntryLayoutBuilder.vue:107
 #: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:127
 msgid "New Section"
-msgstr ""
+msgstr "Nouvelle Section"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:56
 #: frontend/src/components/Activities/ActivityHeader.vue:139
 #: frontend/src/pages/Deals.vue:501 frontend/src/pages/Leads.vue:518
 msgid "New Task"
-msgstr ""
+msgstr "Nouvelle Tâche"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:144
 msgid "New WhatsApp Message"
-msgstr ""
+msgstr "Nouveau Message WhatsApp"
 
 #: frontend/src/pages/Lead.vue:265 frontend/src/pages/MobileLead.vue:167
 msgid "New contact will be created based on the person's details"
-msgstr ""
+msgstr "Un nouveau contact sera créé en à partir des coordonnées de la personne"
 
 #: frontend/src/pages/Lead.vue:239 frontend/src/pages/MobileLead.vue:141
 msgid "New organization will be created based on the data in details section"
-msgstr ""
+msgstr "Une nouvelle organisation sera créée sur la base des données dans la section des coordonnées"
 
 #: frontend/src/components/Filter.vue:663
 msgid "Next 6 Months"
-msgstr ""
+msgstr "6 Mois Suivants"
 
 #: frontend/src/components/Filter.vue:655
 msgid "Next Month"
-msgstr ""
+msgstr "Mois Prochain"
 
 #: frontend/src/components/Filter.vue:659
 msgid "Next Quarter"
-msgstr ""
+msgstr "Trimestre Suivant"
 
 #. Label of the next_step (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Next Step"
-msgstr ""
+msgstr "Étape Suivante"
 
 #: frontend/src/components/Filter.vue:651
 msgid "Next Week"
-msgstr ""
+msgstr "Semaine Prochaine"
 
 #: frontend/src/components/Filter.vue:667
 msgid "Next Year"
-msgstr ""
+msgstr "Année Prochaine"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "No Answer"
-msgstr ""
+msgstr "Pas de Réponse"
 
 #: frontend/src/components/Kanban/KanbanView.vue:101
 #: frontend/src/pages/Deals.vue:106 frontend/src/pages/Leads.vue:122
 #: frontend/src/pages/Tasks.vue:68
 msgid "No Title"
-msgstr ""
+msgstr "Pas de Titre"
 
 #: frontend/src/pages/Deal.vue:264 frontend/src/pages/MobileDeal.vue:204
 msgid "No contacts added"
-msgstr ""
+msgstr "Aucun contact ajouté"
 
 #: frontend/src/pages/Deal.vue:86 frontend/src/pages/Lead.vue:136
 msgid "No email set"
-msgstr ""
+msgstr "Aucune adresse e-mail définie"
 
 #: frontend/src/pages/Deal.vue:684
 msgid "No mobile number set"
-msgstr ""
+msgstr "Aucun numéro de mobile défini"
 
 #: frontend/src/components/Notifications.vue:83
 #: frontend/src/pages/MobileNotification.vue:67
 msgid "No new notifications"
-msgstr ""
+msgstr "Aucune nouvelle notification"
 
 #: frontend/src/pages/Lead.vue:123
 msgid "No phone number set"
-msgstr ""
+msgstr "Aucun numéro de téléphone défini"
 
 #: frontend/src/pages/Deal.vue:679
 msgid "No primary contact set"
-msgstr ""
+msgstr "Aucun contact principal défini"
 
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:52
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:42
 msgid "No templates found"
-msgstr ""
+msgstr "Aucun modèle trouvé"
 
 #: frontend/src/pages/Deal.vue:98 frontend/src/pages/Lead.vue:148
 msgid "No website set"
-msgstr ""
+msgstr "Aucun site web défini"
 
 #: frontend/src/components/Fields.vue:162
 msgid "No {0} Available"
-msgstr ""
+msgstr "Pas de {0} disponible"
 
 #: frontend/src/pages/CallLogs.vue:50 frontend/src/pages/Contact.vue:203
 #: frontend/src/pages/Contacts.vue:56 frontend/src/pages/Deals.vue:232
@@ -1966,7 +1966,7 @@ msgstr ""
 #: frontend/src/pages/Notes.vue:92 frontend/src/pages/Organization.vue:213
 #: frontend/src/pages/Organizations.vue:56 frontend/src/pages/Tasks.vue:181
 msgid "No {0} Found"
-msgstr ""
+msgstr "Aucun {0} trouvé"
 
 #. Label of the no_of_employees (Select) field in DocType 'CRM Deal'
 #. Label of the no_of_employees (Select) field in DocType 'CRM Lead'
@@ -1975,7 +1975,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "No. of Employees"
-msgstr ""
+msgstr "Nombre d’Employé(e)s "
 
 #: frontend/src/components/Activities/AudioPlayer.vue:148
 msgid "Normal"
@@ -1987,7 +1987,7 @@ msgstr ""
 #: frontend/src/components/Filter.vue:319
 #: frontend/src/components/Filter.vue:346
 msgid "Not Equals"
-msgstr ""
+msgstr "Pas Égal"
 
 #: frontend/src/components/Filter.vue:274
 #: frontend/src/components/Filter.vue:295
@@ -1995,7 +1995,7 @@ msgstr ""
 #: frontend/src/components/Filter.vue:323
 #: frontend/src/components/Filter.vue:337
 msgid "Not In"
-msgstr ""
+msgstr "Pas dans"
 
 #: frontend/src/components/Filter.vue:272
 #: frontend/src/components/Filter.vue:283
@@ -2003,43 +2003,43 @@ msgstr ""
 #: frontend/src/components/Filter.vue:321
 #: frontend/src/components/Filter.vue:335
 msgid "Not Like"
-msgstr ""
+msgstr "Pas Comme"
 
 #: frontend/src/components/Modals/QuickEntryModal.vue:10
 #: frontend/src/components/Settings/SettingsPage.vue:7
 #: frontend/src/components/Settings/SidePanelModal.vue:10
 msgid "Not Saved"
-msgstr ""
+msgstr "Non Enregistré"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:204
 msgid "Not allowed to add contact to Deal"
-msgstr ""
+msgstr "Pas permis d'ajouter un contact à la Piste"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:340
 msgid "Not allowed to convert Lead to Deal"
-msgstr ""
+msgstr "Pas permis de convertir une Piste en Opportunité"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:214
 msgid "Not allowed to remove contact from Deal"
-msgstr ""
+msgstr "Interdit de supprimer un contact de Deal"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:224
 msgid "Not allowed to set primary contact for Deal"
-msgstr ""
+msgstr "Non autorisé à définir un contact principal pour Deal"
 
 #. Label of the note (Link) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Note"
-msgstr ""
+msgstr "Remarque"
 
 #: frontend/src/pages/Deal.vue:550 frontend/src/pages/Lead.vue:496
 #: frontend/src/pages/MobileDeal.vue:467 frontend/src/pages/MobileLead.vue:377
 msgid "Notes"
-msgstr ""
+msgstr "Remarques"
 
 #: frontend/src/pages/Notes.vue:20
 msgid "Notes View"
-msgstr ""
+msgstr "Vue Notes"
 
 #: frontend/src/components/Activities/EmailArea.vue:13
 msgid "Notification"
@@ -2048,19 +2048,19 @@ msgstr ""
 #. Label of the notification_text (Text) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Notification Text"
-msgstr ""
+msgstr "Texte de Notification"
 
 #. Label of the notification_type_doc (Dynamic Link) field in DocType 'CRM
 #. Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Notification Type Doc"
-msgstr ""
+msgstr "Document de type de notification"
 
 #. Label of the notification_type_doctype (Link) field in DocType 'CRM
 #. Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Notification Type Doctype"
-msgstr ""
+msgstr "Type de Document de type de notification"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:13
 #: frontend/src/components/Mobile/MobileSidebar.vue:21
@@ -2072,31 +2072,31 @@ msgstr ""
 #. Label of the old_parent (Link) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Old Parent"
-msgstr ""
+msgstr "Ancien parent"
 
 #: frontend/src/pages/Contact.vue:329 frontend/src/pages/Lead.vue:525
 #: frontend/src/pages/Organization.vue:335
 msgid "Only PNG and JPG images are allowed"
-msgstr ""
+msgstr "Seules les images PNG et JPG sont autorisées"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:55
 msgid "Only one {0} can be set as primary."
-msgstr ""
+msgstr "Un seul {0} peut être défini comme principal."
 
 #: frontend/src/components/Modals/NoteModal.vue:26
 #: frontend/src/components/Modals/TaskModal.vue:26
 msgid "Open Deal"
-msgstr ""
+msgstr "Opportunité ouvert"
 
 #: frontend/src/components/Modals/NoteModal.vue:27
 #: frontend/src/components/Modals/TaskModal.vue:27
 msgid "Open Lead"
-msgstr ""
+msgstr "Piste ouverte"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.js:6
 #: crm/fcrm/doctype/crm_lead/crm_lead.js:6
 msgid "Open in Portal"
-msgstr ""
+msgstr "Ouvrir dans le portail"
 
 #: frontend/src/components/Kanban/KanbanView.vue:220
 #: frontend/src/components/ViewControls.vue:128
@@ -2107,7 +2107,7 @@ msgstr ""
 #. Label of the order_by (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Order By"
-msgstr ""
+msgstr "Trier par"
 
 #. Label of the organization (Link) field in DocType 'CRM Deal'
 #. Label of the organization_tab (Tab Break) field in DocType 'CRM Deal'
@@ -2118,89 +2118,89 @@ msgstr ""
 #: frontend/src/pages/Organization.vue:501
 #: frontend/src/pages/Organization.vue:554
 msgid "Organization"
-msgstr ""
+msgstr "Organisation"
 
 #. Label of the organization_details_section (Section Break) field in DocType
 #. 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Organization Details"
-msgstr ""
+msgstr "Détails de l'organisation"
 
 #. Label of the organization_logo (Attach Image) field in DocType 'CRM
 #. Organization'
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Organization Logo"
-msgstr ""
+msgstr "Logo de l'organisation"
 
 #. Label of the organization_name (Data) field in DocType 'CRM Deal'
 #. Label of the organization_name (Data) field in DocType 'CRM Organization'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Organization Name"
-msgstr ""
+msgstr "Nom de l’organisation"
 
 #: frontend/src/pages/Deal.vue:57
 msgid "Organization logo"
-msgstr ""
+msgstr "Logo de l'organisation"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Organization.vue:295
 msgid "Organizations"
-msgstr ""
+msgstr "Organisations"
 
 #. Label of the organization_tab (Tab Break) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Others"
-msgstr ""
+msgstr "Autres"
 
 #: frontend/src/components/Activities/CallArea.vue:36
 msgid "Outbound Call"
-msgstr ""
+msgstr "Appel sortant"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Outgoing"
-msgstr ""
+msgstr "Sortant"
 
 #. Label of the log_owner (Link) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "Owner"
-msgstr ""
+msgstr "Responsable"
 
 #. Label of the parent_crm_territory (Link) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Parent CRM Territory"
-msgstr ""
+msgstr "Territoire CRM Parent"
 
 #: crm/api/demo.py:21 crm/api/demo.py:31
 msgid "Password cannot be reset by Demo User {}"
-msgstr ""
+msgstr "Le mot de passe ne peut pas être réinitialisé par l’Utilisateur de Démonstration {}"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:28
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:11
 msgid "Payment Reminder"
-msgstr ""
+msgstr "Rappel de Paiement"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:50
 msgid "Payment Reminder from Frappé - (#{{ name }})"
-msgstr ""
+msgstr "Rappel de Paiement de Frappé - (#{{ name }})"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Pending"
-msgstr ""
+msgstr "En attente"
 
 #: frontend/src/components/Settings/InviteMemberPage.vue:34
 msgid "Pending Invites"
-msgstr ""
+msgstr "Invitations en attente"
 
 #. Label of the person_section (Section Break) field in DocType 'CRM Deal'
 #. Label of the person_tab (Tab Break) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Person"
-msgstr ""
+msgstr "Personne"
 
 #. Label of the phone (Data) field in DocType 'CRM Contacts'
 #. Label of the phone (Data) field in DocType 'CRM Deal'
@@ -2212,36 +2212,36 @@ msgstr ""
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 #: frontend/src/pages/Organization.vue:549
 msgid "Phone"
-msgstr ""
+msgstr "Téléphone"
 
 #: frontend/src/components/ViewControls.vue:904
 msgid "Pin View"
-msgstr ""
+msgstr "Épingler la vue"
 
 #. Label of the pinned (Check) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Pinned"
-msgstr ""
+msgstr "Épinglé"
 
 #: frontend/src/components/ViewControls.vue:568
 msgid "Pinned Views"
-msgstr ""
+msgstr "Vues Épinglées"
 
 #: frontend/src/components/Activities/AudioPlayer.vue:176
 msgid "Playback speed"
-msgstr ""
+msgstr "Vitesse de lecture"
 
 #: crm/integrations/twilio/twilio_handler.py:124
 msgid "Please enable twilio settings before making a call."
-msgstr ""
+msgstr "Veuillez activer les paramètres Twilio avant de passer un appel."
 
 #: frontend/src/pages/Lead.vue:565 frontend/src/pages/MobileLead.vue:438
 msgid "Please select an existing contact"
-msgstr ""
+msgstr "Veuillez sélectionner un contact existant"
 
 #: frontend/src/pages/Lead.vue:575 frontend/src/pages/MobileLead.vue:448
 msgid "Please select an existing organization"
-msgstr ""
+msgstr "Veuillez sélectionner une organisation existante"
 
 #. Label of the position (Int) field in DocType 'CRM Deal Status'
 #. Label of the position (Int) field in DocType 'CRM Lead Status'
@@ -2252,33 +2252,33 @@ msgstr ""
 
 #: frontend/src/pages/Deal.vue:208 frontend/src/pages/MobileDeal.vue:148
 msgid "Primary"
-msgstr ""
+msgstr "Primaire"
 
 #: frontend/src/pages/Deal.vue:654 frontend/src/pages/MobileDeal.vue:571
 msgid "Primary contact set"
-msgstr ""
+msgstr "Contact primaire défini"
 
 #. Label of the priorities (Table) field in DocType 'CRM Service Level
 #. Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Priorities"
-msgstr ""
+msgstr "Priorités"
 
 #. Label of the priority (Link) field in DocType 'CRM Service Level Priority'
 #. Label of the priority (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Priority"
-msgstr ""
+msgstr "Priorité"
 
 #. Label of the probability (Percent) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Probability"
-msgstr ""
+msgstr "Probabilité"
 
 #: frontend/src/components/Settings/SettingsModal.vue:63
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 #. Label of the public (Check) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
@@ -2287,32 +2287,32 @@ msgstr ""
 
 #: frontend/src/components/ViewControls.vue:563
 msgid "Public Views"
-msgstr ""
+msgstr "Vues Publiques"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Queued"
-msgstr ""
+msgstr "En file d'attente"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Quick Entry"
-msgstr ""
+msgstr "Entrée rapide"
 
 #. Label of the read (Check) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Read"
-msgstr ""
+msgstr "Lire"
 
 #. Label of the record_calls (Check) field in DocType 'Twilio Settings'
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
 msgid "Record Calls"
-msgstr ""
+msgstr "Enregistrer Appels"
 
 #. Label of the recording_url (Data) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Recording URL"
-msgstr ""
+msgstr "URL d’Enregistrement"
 
 #. Label of the reference_name (Dynamic Link) field in DocType 'CRM
 #. Notification'
@@ -2322,12 +2322,12 @@ msgstr ""
 #: crm/fcrm/doctype/crm_task/crm_task.json
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
 msgid "Reference Doc"
-msgstr ""
+msgstr "Document de Référence"
 
 #. Label of the reference_doctype (Link) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Reference Doctype"
-msgstr ""
+msgstr "Type de Document de Référence"
 
 #. Label of the reference_doctype (Link) field in DocType 'CRM Call Log'
 #. Label of the reference_doctype (Link) field in DocType 'CRM Task'
@@ -2336,69 +2336,69 @@ msgstr ""
 #: crm/fcrm/doctype/crm_task/crm_task.json
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
 msgid "Reference Document Type"
-msgstr ""
+msgstr "Type de Document de Référence"
 
 #. Label of the reference_docname (Dynamic Link) field in DocType 'CRM Call
 #. Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Reference Name"
-msgstr ""
+msgstr "Nom de Référence"
 
 #: frontend/src/components/ViewControls.vue:25
 #: frontend/src/components/ViewControls.vue:87
 msgid "Refresh"
-msgstr ""
+msgstr "Actualiser"
 
 #: frontend/src/components/Settings/InviteMemberPage.vue:24
 #: frontend/src/components/Settings/InviteMemberPage.vue:100
 msgid "Regular Access"
-msgstr ""
+msgstr "Accès Régulier"
 
 #: frontend/src/components/CallUI.vue:103
 msgid "Reject"
-msgstr ""
+msgstr "Rejeter"
 
 #: frontend/src/pages/Deal.vue:599
 msgid "Remove"
-msgstr ""
+msgstr "Supprimer"
 
 #: frontend/src/pages/Contact.vue:37 frontend/src/pages/Lead.vue:89
 #: frontend/src/pages/Organization.vue:40
 msgid "Remove image"
-msgstr ""
+msgstr "Supprimer l'image"
 
 #: frontend/src/components/Activities/EmailArea.vue:31
 #: frontend/src/components/CommunicationArea.vue:8
 msgid "Reply"
-msgstr ""
+msgstr "Réponse"
 
 #: frontend/src/components/Activities/EmailArea.vue:44
 msgid "Reply All"
-msgstr ""
+msgstr "Répondre à tous"
 
 #: frontend/src/components/Modals/QuickEntryModal.vue:56
 #: frontend/src/components/Settings/SidePanelModal.vue:71
 msgid "Reset"
-msgstr ""
+msgstr "Réinitialiser"
 
 #: frontend/src/components/ColumnSettings.vue:76
 msgid "Reset Changes"
-msgstr ""
+msgstr "Réinitialiser les Modifications"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:7
 msgid "Reset ERPNext Form Script"
-msgstr ""
+msgstr "Réinitialiser le Script du Formulaire ERPNext"
 
 #: frontend/src/components/ColumnSettings.vue:87
 msgid "Reset to Default"
-msgstr ""
+msgstr "Réinitialiser les valeurs par défaut"
 
 #. Label of the response_by (Datetime) field in DocType 'CRM Deal'
 #. Label of the response_by (Datetime) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Response By"
-msgstr ""
+msgstr "Réponse par"
 
 #. Label of the response_details_section (Section Break) field in DocType 'CRM
 #. Deal'
@@ -2406,56 +2406,56 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Response Details"
-msgstr ""
+msgstr "Détails de la réponse"
 
 #. Label of the section_break_ufaf (Section Break) field in DocType 'CRM
 #. Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Response and Follow Up"
-msgstr ""
+msgstr "Réponse et Suivi"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:14
 msgid "Restore"
-msgstr ""
+msgstr "Restaurer"
 
 #. Label of the restore_defaults (Button) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:13
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Restore Defaults"
-msgstr ""
+msgstr "Restaurer les Paramètres par Défaut"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:62
 msgid "Rich Text"
-msgstr ""
+msgstr "Texte Riche"
 
 #. Label of the rgt (Int) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Right"
-msgstr ""
+msgstr "Droite"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Ringing"
-msgstr ""
+msgstr "Sonnerie"
 
 #: frontend/src/components/CallUI.vue:37 frontend/src/components/CallUI.vue:146
 msgid "Ringing..."
-msgstr ""
+msgstr "Sonnerie..."
 
 #. Label of the role (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Role"
-msgstr ""
+msgstr "Rôle"
 
 #. Label of the route_name (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Route Name"
-msgstr ""
+msgstr "Nom de l’URL"
 
 #. Label of the rows (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Rows"
-msgstr ""
+msgstr "Lignes"
 
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the sla (Link) field in DocType 'CRM Deal'
@@ -2473,23 +2473,23 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "SLA Creation"
-msgstr ""
+msgstr "Création de SLA"
 
 #. Label of the sla_name (Data) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "SLA Name"
-msgstr ""
+msgstr "Nom SLA"
 
 #. Label of the sla_status (Select) field in DocType 'CRM Deal'
 #. Label of the sla_status (Select) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "SLA Status"
-msgstr ""
+msgstr "Statut SLA"
 
 #: frontend/src/components/EmailEditor.vue:75
 msgid "SUBJECT"
-msgstr ""
+msgstr "SUJET"
 
 #. Name of a role
 #. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
@@ -2513,7 +2513,7 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 msgid "Sales Manager"
-msgstr ""
+msgstr "Directeur des Ventes"
 
 #. Name of a role
 #. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
@@ -2534,21 +2534,21 @@ msgstr ""
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
 msgid "Sales User"
-msgstr ""
+msgstr "Utilisateur Commercial"
 
 #. Label of the salutation (Link) field in DocType 'CRM Deal'
 #. Label of the salutation (Link) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Salutation"
-msgstr ""
+msgstr "Salut"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Saturday"
-msgstr ""
+msgstr "Samedi"
 
 #: frontend/src/components/Modals/AddressModal.vue:99
 #: frontend/src/components/Modals/OrganizationModal.vue:194
@@ -2556,17 +2556,17 @@ msgstr ""
 #: frontend/src/components/Settings/ProfileSettings.vue:52
 #: frontend/src/components/Settings/SidePanelModal.vue:67
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: frontend/src/components/Modals/ViewModal.vue:13
 #: frontend/src/components/ViewControls.vue:57
 #: frontend/src/components/ViewControls.vue:84
 msgid "Save Changes"
-msgstr ""
+msgstr "Enregistrer les modifications"
 
 #: frontend/src/components/ViewControls.vue:558
 msgid "Saved Views"
-msgstr ""
+msgstr "Vues Enregistrées"
 
 #. Label of the script (Code) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
@@ -2575,75 +2575,75 @@ msgstr ""
 
 #: frontend/src/components/Fields.vue:244
 msgid "Select {0}"
-msgstr ""
+msgstr "Sélectionnez {0}"
 
 #: frontend/src/components/EmailEditor.vue:155
 msgid "Send"
-msgstr ""
+msgstr "Envoyer"
 
 #: frontend/src/components/Settings/InviteMemberPage.vue:67
 msgid "Send Invites"
-msgstr ""
+msgstr "Envoyer Invitations"
 
 #: frontend/src/components/Settings/InviteMemberPage.vue:4
 msgid "Send Invites To"
-msgstr ""
+msgstr "Envoyer Invitations À"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:60
 msgid "Send Template"
-msgstr ""
+msgstr "Envoyer le Modèle"
 
 #: frontend/src/pages/Deal.vue:79 frontend/src/pages/Lead.vue:129
 msgid "Send an email"
-msgstr ""
+msgstr "Envoyer un e-mail"
 
 #. Label of the naming_series (Select) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Series"
-msgstr ""
+msgstr "Séries"
 
 #: frontend/src/pages/Deal.vue:68
 msgid "Set an organization"
-msgstr ""
+msgstr "Définir une organisation"
 
 #: frontend/src/pages/Deal.vue:607 frontend/src/pages/MobileDeal.vue:524
 msgid "Set as Primary Contact"
-msgstr ""
+msgstr "Définir comme Contact Principal"
 
 #: frontend/src/pages/Lead.vue:110
 msgid "Set first name"
-msgstr ""
+msgstr "Définir le prénom"
 
 #: frontend/src/components/Settings/SettingsModal.vue:7
 #: frontend/src/components/Settings/SettingsModal.vue:59
 #: frontend/src/components/UserDropdown.vue:99
 msgid "Settings"
-msgstr ""
+msgstr "Paramètres"
 
 #: frontend/src/components/Activities/Activities.vue:195
 msgid "Show"
-msgstr ""
+msgstr "Afficher"
 
 #: frontend/src/components/Modals/QuickEntryModal.vue:34
 #: frontend/src/components/Settings/SidePanelModal.vue:28
 msgid "Show preview"
-msgstr ""
+msgstr "Afficher l'aperçu"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Side Panel"
-msgstr ""
+msgstr "Panneau latéral"
 
 #. Description of the 'Condition' (Code) field in DocType 'CRM Service Level
 #. Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Simple Python Expression, Example: doc.status == 'Open' and doc.lead_source == 'Ads'"
-msgstr ""
+msgstr "Expression Python Simple, Exemple : doc.status == 'Open' et doc.lead_source == 'Ads'"
 
 #: frontend/src/components/SortBy.vue:10 frontend/src/components/SortBy.vue:22
 #: frontend/src/components/SortBy.vue:240
 msgid "Sort"
-msgstr ""
+msgstr "Trier"
 
 #. Label of the source (Link) field in DocType 'CRM Deal'
 #. Label of the source (Link) field in DocType 'CRM Lead'
@@ -2656,11 +2656,11 @@ msgstr ""
 #. Label of the source_name (Data) field in DocType 'CRM Lead Source'
 #: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
 msgid "Source Name"
-msgstr ""
+msgstr "Nom de la Source"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.js:15
 msgid "Standard Form Scripts can not be modified, duplicate the Form Script instead."
-msgstr ""
+msgstr "Les Scripts de Formulaire Standard ne peuvent pas être modifiés, dupliquez plutôt le Script de Formulaire."
 
 #. Label of the start_date (Date) field in DocType 'CRM Service Level
 #. Agreement'
@@ -2668,14 +2668,14 @@ msgstr ""
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Start Date"
-msgstr ""
+msgstr "Date de début"
 
 #. Label of the start_time (Datetime) field in DocType 'CRM Call Log'
 #. Label of the start_time (Time) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Start Time"
-msgstr ""
+msgstr "Heure de début"
 
 #. Label of the status (Select) field in DocType 'CRM Call Log'
 #. Label of the status (Data) field in DocType 'CRM Communication Status'
@@ -2695,42 +2695,42 @@ msgstr ""
 #: crm/fcrm/doctype/crm_task/crm_task.json frontend/src/pages/Contact.vue:431
 #: frontend/src/pages/Organization.vue:511
 msgid "Status"
-msgstr ""
+msgstr "Statut"
 
 #. Label of the status_change_log (Table) field in DocType 'CRM Deal'
 #. Label of the status_change_log (Table) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Status Change Log"
-msgstr ""
+msgstr "Journal des Modifications de Statut"
 
 #: frontend/src/components/Modals/DealModal.vue:199
 #: frontend/src/components/Modals/LeadModal.vue:151
 msgid "Status is required"
-msgstr ""
+msgstr "Le Statut est requis"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:43
 msgid "Subject"
-msgstr ""
+msgstr "Sujet"
 
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:31
 msgid "Subject: {0}"
-msgstr ""
+msgstr "Objet : {0}"
 
 #: frontend/src/components/Settings/SettingsPage.vue:82
 msgid "Success"
-msgstr ""
+msgstr "Succès"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Sunday"
-msgstr ""
+msgstr "Dimanche"
 
 #: frontend/src/components/UserDropdown.vue:83
 msgid "Support"
-msgstr ""
+msgstr "Prise en charge"
 
 #. Name of a role
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
@@ -2740,11 +2740,11 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
 msgid "System Manager"
-msgstr ""
+msgstr "Gestionnaire Système"
 
 #: frontend/src/components/EmailEditor.vue:22
 msgid "TO"
-msgstr ""
+msgstr "À"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -2759,7 +2759,7 @@ msgstr "Tâches"
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
-msgstr ""
+msgstr "Territoires"
 
 #. Label of the territory (Link) field in DocType 'CRM Deal'
 #. Label of the territory (Link) field in DocType 'CRM Lead'
@@ -2768,60 +2768,60 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Territory"
-msgstr ""
+msgstr "Territoire"
 
 #. Label of the territory_manager (Link) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Territory Manager"
-msgstr ""
+msgstr "Gestionnaire de Territoire"
 
 #. Label of the territory_name (Data) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Territory Name"
-msgstr ""
+msgstr "Nom du Territoire"
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:46
 msgid "The Condition '{0}' is invalid: {1}"
-msgstr ""
+msgstr "La Condition '{0}' n'est pas valide : {1}"
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.js:14
 msgid "There can only be one default priority in Priorities table"
-msgstr ""
+msgstr "Il ne peut y avoir qu'une seule priorité par défaut dans la table des Priorités"
 
 #: frontend/src/components/Filter.vue:639
 msgid "This Month"
-msgstr ""
+msgstr "Ce mois-ci"
 
 #: frontend/src/components/Filter.vue:643
 msgid "This Quarter"
-msgstr ""
+msgstr "Ce trimestre"
 
 #: frontend/src/components/Filter.vue:635
 msgid "This Week"
-msgstr ""
+msgstr "Cette semaine"
 
 #: frontend/src/components/Filter.vue:647
 msgid "This Year"
-msgstr ""
+msgstr "Cette Année"
 
 #: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:114
 msgid "This section is not editable"
-msgstr ""
+msgstr "Cette section n'est pas modifiable"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:9
 msgid "This will restore (if not exist) all the default statuses, custom fields and layouts. Delete & Restore will delete default layouts and then restore them."
-msgstr ""
+msgstr "Cela restaurera (s'ils n'existent pas) tous les statuts, champs personnalisés et mises en page par défaut. Effacer & Restaurer effacera toutes les mises en page par défaut puis les restaurera."
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Thursday"
-msgstr ""
+msgstr "Jeudi"
 
 #: frontend/src/components/Filter.vue:353
 msgid "Timespan"
-msgstr ""
+msgstr "Durée"
 
 #. Label of the title (Data) field in DocType 'CRM Task'
 #. Label of the title (Data) field in DocType 'FCRM Note'
@@ -2830,13 +2830,13 @@ msgstr ""
 #: frontend/src/components/Modals/NoteModal.vue:40
 #: frontend/src/components/Modals/TaskModal.vue:40
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #. Label of the title_field (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: frontend/src/components/Kanban/KanbanSettings.vue:31
 msgid "Title Field"
-msgstr ""
+msgstr "Champ de Titre"
 
 #. Label of the to (Data) field in DocType 'CRM Call Log'
 #. Label of the to (Data) field in DocType 'CRM Status Change Log'
@@ -2844,53 +2844,53 @@ msgstr ""
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 #: frontend/src/components/Activities/EmailArea.vue:63
 msgid "To"
-msgstr ""
+msgstr "À"
 
 #. Label of the to_date (Date) field in DocType 'CRM Holiday List'
 #. Label of the to_date (Datetime) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "To Date"
-msgstr ""
+msgstr "À ce Jour"
 
 #. Label of the to_user (Link) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "To User"
-msgstr ""
+msgstr "À l’Utilisateur"
 
 #: frontend/src/components/Filter.vue:627
 msgid "Today"
-msgstr ""
+msgstr "Aujourd’hui"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Todo"
-msgstr ""
+msgstr "À Faire"
 
 #: frontend/src/components/Settings/SidePanelModal.vue:58
 msgid "Toggle on for preview"
-msgstr ""
+msgstr "Activer l'aperçu"
 
 #: frontend/src/components/Filter.vue:631
 msgid "Tomorrow"
-msgstr ""
+msgstr "Demain"
 
 #: frontend/src/components/Modals/NoteModal.vue:58
 #: frontend/src/components/Modals/TaskModal.vue:60
 msgid "Took a call with John Doe and discussed the new project."
-msgstr ""
+msgstr "J'ai pris un appel avec M. Dupont et discuté du nouveau projet."
 
 #. Label of the total_holidays (Int) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Total Holidays"
-msgstr ""
+msgstr "Total des Jours Fériés"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Tuesday"
-msgstr ""
+msgstr "Mardi"
 
 #. Label of the twiml_sid (Data) field in DocType 'Twilio Settings'
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
@@ -2904,22 +2904,22 @@ msgstr ""
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.py:61
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.py:62
 msgid "Twilio API credential creation error."
-msgstr ""
+msgstr "Erreur de création des informations d'identification de l'API Twilio."
 
 #. Name of a DocType
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 msgid "Twilio Agents"
-msgstr ""
+msgstr "Agents Twilio"
 
 #. Label of the twilio_number (Data) field in DocType 'Twilio Agents'
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 msgid "Twilio Number"
-msgstr ""
+msgstr "Numéro Twilio"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
 msgid "Twilio Settings"
-msgstr ""
+msgstr "Paramètres Twilio"
 
 #. Label of the type (Select) field in DocType 'CRM Call Log'
 #. Label of the type (Select) field in DocType 'CRM Fields Layout'
@@ -2934,19 +2934,19 @@ msgstr ""
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:85
 msgid "Type your message here..."
-msgstr ""
+msgstr "Tapez votre message ici..."
 
 #: frontend/src/components/CallUI.vue:316
 msgid "Unknown"
-msgstr ""
+msgstr "Inconnu"
 
 #: frontend/src/components/ViewControls.vue:904
 msgid "Unpin View"
-msgstr ""
+msgstr "Désépingler la vue"
 
 #: frontend/src/components/ViewControls.vue:762
 msgid "Unsaved Changes"
-msgstr ""
+msgstr "Modifications Non Enregistrées"
 
 #: frontend/src/components/Modals/AddressModal.vue:8
 #: frontend/src/components/Modals/ContactModal.vue:8
@@ -2959,7 +2959,7 @@ msgstr ""
 #: frontend/src/pages/Lead.vue:112 frontend/src/pages/Lead.vue:454
 #: frontend/src/pages/MobileDeal.vue:425 frontend/src/pages/MobileLead.vue:335
 msgid "Untitled"
-msgstr ""
+msgstr "Sans titre"
 
 #: frontend/src/components/ColumnSettings.vue:132
 #: frontend/src/components/Modals/AssignmentModal.vue:17
@@ -2969,54 +2969,54 @@ msgstr ""
 #: frontend/src/components/Settings/SettingsPage.vue:26
 #: frontend/src/components/ViewControls.vue:767
 msgid "Update"
-msgstr ""
+msgstr "Mise à jour"
 
 #: frontend/src/components/Modals/EditValueModal.vue:30
 msgid "Update {0} Records"
-msgstr ""
+msgstr "Mettre à jour {0} Enregistrements"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:132
 msgid "Upload Document"
-msgstr ""
+msgstr "Télécharger un Document"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:140
 msgid "Upload Image"
-msgstr ""
+msgstr "Télécharger une Image"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:148
 msgid "Upload Video"
-msgstr ""
+msgstr "Télécharger la Vidéo"
 
 #: frontend/src/pages/Contact.vue:32 frontend/src/pages/Lead.vue:84
 #: frontend/src/pages/Organization.vue:35
 msgid "Upload image"
-msgstr ""
+msgstr "Téléverser une Image"
 
 #. Label of the user (Link) field in DocType 'CRM View Settings'
 #. Label of the user (Link) field in DocType 'Twilio Agents'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 msgid "User"
-msgstr ""
+msgstr "Utilisateur"
 
 #. Label of the user_name (Data) field in DocType 'Twilio Agents'
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 msgid "User Name"
-msgstr ""
+msgstr "Nom d’Utilisateur"
 
 #. Label of the section_break_nevd (Section Break) field in DocType 'CRM
 #. Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Validity"
-msgstr ""
+msgstr "Validité"
 
 #: frontend/src/components/Modals/EditValueModal.vue:14
 msgid "Value"
-msgstr ""
+msgstr "Valeur"
 
 #: frontend/src/components/Modals/ViewModal.vue:25
 msgid "View Name"
-msgstr ""
+msgstr "Afficher le Nom"
 
 #. Label of the website (Data) field in DocType 'CRM Deal'
 #. Label of the website (Data) field in DocType 'CRM Lead'
@@ -3025,25 +3025,25 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Website"
-msgstr ""
+msgstr "Site Web"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Wednesday"
-msgstr ""
+msgstr "Mercredi"
 
 #. Label of the weekly_off (Check) field in DocType 'CRM Holiday'
 #. Label of the weekly_off (Select) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday/crm_holiday.json
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Weekly Off"
-msgstr ""
+msgstr "Congé Hebdomadaire"
 
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:11
 msgid "Welcome Message"
-msgstr ""
+msgstr "Message de Bienvenue"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -3055,24 +3055,24 @@ msgstr ""
 
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:4
 msgid "WhatsApp Templates"
-msgstr ""
+msgstr "Modèles WhatsApp"
 
 #: frontend/src/components/Filter.vue:42 frontend/src/components/Filter.vue:80
 msgid "Where"
-msgstr ""
+msgstr "Où"
 
 #: frontend/src/components/ColumnSettings.vue:111
 msgid "Width"
-msgstr ""
+msgstr "Largeur"
 
 #: frontend/src/components/ColumnSettings.vue:116
 msgid "Width can be in number, pixel or rem (eg. 3, 30px, 10rem)"
-msgstr ""
+msgstr "La largeur peut être en nombre, en pixels ou en rem (par exemple 3, 30 px, 10 rem)"
 
 #. Label of the workday (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Workday"
-msgstr ""
+msgstr "Jour ouvrable"
 
 #. Label of the section_break_rmgo (Section Break) field in DocType 'CRM
 #. Service Level Agreement'
@@ -3080,62 +3080,62 @@ msgstr ""
 #. Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Working Hours"
-msgstr ""
+msgstr "Heures de Travail"
 
 #: frontend/src/components/Filter.vue:623
 msgid "Yesterday"
-msgstr ""
+msgstr "Hier"
 
 #: crm/api/whatsapp.py:221 crm/api/whatsapp.py:240
 #: frontend/src/components/Activities/WhatsAppArea.vue:34
 #: frontend/src/components/Activities/WhatsAppBox.vue:14
 msgid "You"
-msgstr ""
+msgstr "Vous"
 
 #: frontend/src/components/ViewControls.vue:763
 msgid "You have unsaved changes. Do you want to save them?"
-msgstr ""
+msgstr "Vous avez des modifications non enregistrées. Voulez-vous les sauvegarder ?"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.py:24
 msgid "You need to be in developer mode to edit a Standard Form Script"
-msgstr ""
+msgstr "Vous devez être en mode développeur pour modifier un script de formulaire standard"
 
 #: crm/api/todo.py:24
 msgid "Your assignment on {0} {1} has been removed by {2}"
-msgstr ""
+msgstr "Votre affectation sur {0} {1} a été supprimé par {2}"
 
 #: frontend/src/components/Activities/CommentArea.vue:9
 msgid "added a"
-msgstr ""
+msgstr "ajout d'un"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "amber"
-msgstr ""
+msgstr "ambre"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "black"
-msgstr ""
+msgstr "noir"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "blue"
-msgstr ""
+msgstr "bleu"
 
 #: frontend/src/components/Activities/Activities.vue:197
 msgid "changes from"
-msgstr ""
+msgstr "modifications depuis"
 
 #: frontend/src/components/Activities/CommentArea.vue:11
 msgid "comment"
-msgstr ""
+msgstr "commentaire"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -3149,14 +3149,14 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "gray"
-msgstr ""
+msgstr "gris"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "green"
-msgstr ""
+msgstr "vert"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
@@ -3165,11 +3165,11 @@ msgstr ""
 
 #: frontend/src/components/Activities/CallArea.vue:16
 msgid "has made a call"
-msgstr ""
+msgstr "a passé un appel"
 
 #: frontend/src/components/Activities/CallArea.vue:15
 msgid "has reached out"
-msgstr ""
+msgstr "a contacté"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
@@ -3178,17 +3178,17 @@ msgstr ""
 
 #: crm/api/doc.py:35 crm/api/doc.py:155 crm/api/doc.py:412
 msgid "label"
-msgstr ""
+msgstr "étiquette"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "list"
-msgstr ""
+msgstr "liste"
 
 #: frontend/src/components/Notifications.vue:65
 #: frontend/src/pages/MobileNotification.vue:52
 msgid "mentioned you in {0}"
-msgstr ""
+msgstr "vous a mentionné dans {0}"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -3202,64 +3202,64 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "pink"
-msgstr ""
+msgstr "rose"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "purple"
-msgstr ""
+msgstr "violet"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "red"
-msgstr ""
+msgstr "rouge"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "teal"
-msgstr ""
+msgstr "sarcelle"
 
 #: frontend/src/components/Activities/Activities.vue:239
 #: frontend/src/components/Activities/Activities.vue:302
 msgid "to"
-msgstr ""
+msgstr "à"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "violet"
-msgstr ""
+msgstr "violette"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "yellow"
-msgstr ""
+msgstr "jaune"
 
 #: crm/api/todo.py:28
 msgid "{0} assigned a {1} {2} to you"
-msgstr ""
+msgstr "{0} vous a attribué un {1} {2}"
 
 #: frontend/src/pages/Deal.vue:480 frontend/src/pages/Lead.vue:426
 #: frontend/src/pages/MobileDeal.vue:397 frontend/src/pages/MobileLead.vue:307
 msgid "{0} is a required field"
-msgstr ""
+msgstr "{0} est un champ obligatoire"
 
 #: frontend/src/components/EmailEditor.vue:28
 #: frontend/src/components/EmailEditor.vue:58
 #: frontend/src/components/EmailEditor.vue:70
 #: frontend/src/components/Settings/InviteMemberPage.vue:14
 msgid "{0} is an invalid email address"
-msgstr ""
+msgstr "{0} est une adresse e-mail invalide"
 
 #: frontend/src/components/Settings/SettingsPage.vue:156
 msgid "{0} is mandatory"
-msgstr ""
+msgstr "{0} est obligatoire"

--- a/crm/locale/fr.po
+++ b/crm/locale/fr.po
@@ -1,0 +1,3265 @@
+# French translations for Frappe CRM.
+# Copyright (C) 2024 Frappe Technologies Pvt. Ltd.
+# This file is distributed under the same license as the Frappe CRM project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Frappe CRM VERSION\n"
+"Report-Msgid-Bugs-To: shariq@frappe.io\n"
+"POT-Creation-Date: 2024-10-15 20:07+0000\n"
+"PO-Revision-Date: 2024-10-15 22:21+0200\n"
+"Last-Translator: \n"
+"Language: fr\n"
+"Language-Team: shariq@frappe.io\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.1\n"
+
+#: frontend/src/components/ViewControls.vue:964
+msgid " (New)"
+msgstr "(Nouveau)"
+
+#: frontend/src/components/Modals/TaskModal.vue:97
+msgid "01/04/2024 11:30 PM"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "1-10"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "1000+"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "11-50"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "201-500"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "501-1000"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "51-200"
+msgstr ""
+
+#. Paragraph text in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "<b>META</b>"
+msgstr ""
+
+#. Paragraph text in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "<b>SHORTCUTS</b>"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:78
+msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
+msgstr ""
+
+#. Header text in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "<span class=\"h5\"><b>PORTAL</b></span>"
+msgstr ""
+
+#: frontend/src/components/CommunicationArea.vue:81
+msgid "@John, can you please check this?"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:47
+msgid "A Lead requires either a person's name or an organization's name"
+msgstr ""
+
+#. Label of the api_key (Data) field in DocType 'ERPNext CRM Settings'
+#. Label of the api_key (Data) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "API Key"
+msgstr "Clé API"
+
+#. Label of the api_secret (Password) field in DocType 'ERPNext CRM Settings'
+#. Label of the api_secret (Password) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "API Secret"
+msgstr "Secret API"
+
+#: frontend/src/components/CallUI.vue:91
+msgid "Accept"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.js:7
+msgid "Accept Invitation"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Accepted"
+msgstr "Accepté"
+
+#. Label of the accepted_at (Datetime) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Accepted At"
+msgstr "Accepté à"
+
+#. Label of the account_sid (Data) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Account SID"
+msgstr ""
+
+#: frontend/src/components/CustomActions.vue:73
+#: frontend/src/components/ViewControls.vue:574
+msgid "Actions"
+msgstr "Actions"
+
+#: frontend/src/pages/Deal.vue:524 frontend/src/pages/Lead.vue:470
+#: frontend/src/pages/MobileDeal.vue:441 frontend/src/pages/MobileLead.vue:351
+msgid "Activity"
+msgstr "Activité"
+
+#: frontend/src/components/ColumnSettings.vue:63
+#: frontend/src/components/Kanban/KanbanView.vue:156
+msgid "Add Column"
+msgstr "Ajouter une Colonne"
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:83
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:80
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:93
+msgid "Add Field"
+msgstr "Ajouter un Champ"
+
+#: frontend/src/components/Filter.vue:136
+msgid "Add Filter"
+msgstr "Ajouter un Filtre"
+
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:104
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:125
+msgid "Add Section"
+msgstr "Ajouter une Section"
+
+#: frontend/src/components/SortBy.vue:146
+msgid "Add Sort"
+msgstr "Ajouter un Tri"
+
+#. Label of the add_weekly_holidays_section (Section Break) field in DocType
+#. 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Add Weekly Holidays"
+msgstr "Ajouter Jour Férié Hebdomadaire"
+
+#. Label of the add_to_holidays (Button) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Add to Holidays"
+msgstr "Ajouter aux Jours Fériés"
+
+#. Label of the address (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Address"
+msgstr "Adresse"
+
+#: crm/integrations/twilio/twilio_handler.py:148
+msgid "Agent is unavailable to take the call, please call after some time."
+msgstr "L’agent n’est pas disponible pour prendre cet appel, veuillez rappeler plus tard."
+
+#. Label of the annual_revenue (Currency) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Contact.vue:426
+#: frontend/src/pages/Organization.vue:506
+msgid "Amount"
+msgstr "Montant"
+
+#: frontend/src/components/Filter.vue:42 frontend/src/components/Filter.vue:80
+msgid "And"
+msgstr "Et"
+
+#. Label of the annual_revenue (Currency) field in DocType 'CRM Lead'
+#. Label of the annual_revenue (Currency) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Annual Revenue"
+msgstr "Revenue Annuel"
+
+#: frontend/src/components/Modals/DealModal.vue:186
+#: frontend/src/components/Modals/LeadModal.vue:138
+msgid "Annual Revenue should be a number"
+msgstr "Revenu Annuel devrait être un nombre"
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:106
+#: frontend/src/components/Kanban/KanbanView.vue:44
+msgid "Apply"
+msgstr "Appliquer"
+
+#. Label of the apply_on (Link) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Apply On"
+msgstr "Appliquer le"
+
+#. Label of the view (Select) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Apply To"
+msgstr "Appliquer à"
+
+#: frontend/src/components/Apps.vue:14
+msgid "Apps"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:346
+msgid "Are you sure you want to delete this contact?"
+msgstr "Êtes-vous sur de vouloir effacer de contact ?"
+
+#: frontend/src/pages/Organization.vue:352
+msgid "Are you sure you want to delete this organization?"
+msgstr "Êtes-vous sure de vouloir effacer cette organisation ?"
+
+#: frontend/src/components/Activities/TaskArea.vue:58
+msgid "Are you sure you want to delete this task?"
+msgstr "Êtes-vous sur de vouloir effacer cette tâche ?"
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:9
+msgid "Are you sure you want to reset 'Create Quotation from CRM Deal' Form Script?"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:193
+#: frontend/src/components/Modals/AssignmentModal.vue:5
+msgid "Assign To"
+msgstr ""
+
+#. Label of the assigned_to (Link) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Assigned To"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Assignment"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Assignment Rule"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:158
+msgid "Assignment cleared successfully"
+msgstr ""
+
+#. Label of the auth_token (Password) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Auth Token"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:72
+#: frontend/src/components/EmailEditor.vue:41
+#: frontend/src/components/EmailEditor.vue:63
+msgid "BCC"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:45
+msgid "Back"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Backlog"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:352
+msgid "Between"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:2
+msgid "Bulk Edit"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Busy"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:67
+#: frontend/src/components/EmailEditor.vue:33
+#: frontend/src/components/EmailEditor.vue:51
+msgid "CC"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:24
+msgid "CRM"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "CRM Call Log"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+msgid "CRM Communication Status"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+msgid "CRM Contacts"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: frontend/src/components/Modals/EmailTemplateModal.vue:37
+msgid "CRM Deal"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+msgid "CRM Deal Status"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "CRM Fields Layout"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "CRM Form Script"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+msgid "CRM Holiday"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "CRM Holiday List"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+msgid "CRM Industry"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "CRM Invitation"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "CRM Lead"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+msgid "CRM Lead Source"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "CRM Lead Status"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "CRM Notification"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "CRM Organization"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "CRM Portal Page"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "CRM Service Day"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "CRM Service Level Agreement"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+msgid "CRM Service Level Priority"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "CRM Status Change Log"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "CRM Task"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "CRM Territory"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "CRM View Settings"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:193
+msgid "CSV"
+msgstr ""
+
+#: frontend/src/components/Modals/CallLogModal.vue:6
+msgid "Call Details"
+msgstr ""
+
+#. Label of the receiver (Link) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Call Received By"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:45
+#: frontend/src/components/Modals/TaskModal.vue:45
+msgid "Call with John Doe"
+msgstr ""
+
+#. Label of the caller (Link) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Caller"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:39 frontend/src/components/CallUI.vue:146
+msgid "Calling..."
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:539 frontend/src/pages/Lead.vue:485
+#: frontend/src/pages/MobileDeal.vue:456 frontend/src/pages/MobileLead.vue:366
+msgid "Calls"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:76
+#: frontend/src/components/ColumnSettings.vue:126
+#: frontend/src/components/Modals/AssignmentModal.vue:9
+#: frontend/src/components/ViewControls.vue:56
+#: frontend/src/components/ViewControls.vue:83
+msgid "Cancel"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Canceled"
+msgstr ""
+
+#: frontend/src/components/Activities/TaskArea.vue:44
+msgid "Change Status"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:31 frontend/src/pages/Lead.vue:83
+#: frontend/src/pages/Organization.vue:34
+msgid "Change image"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:225 frontend/src/pages/Lead.vue:252
+#: frontend/src/pages/MobileLead.vue:127 frontend/src/pages/MobileLead.vue:154
+msgid "Choose Existing"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:32
+msgid "Choose Existing Contact"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:28
+msgid "Choose Existing Organization"
+msgstr ""
+
+#: frontend/src/components/Controls/Link.vue:48
+msgid "Clear"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:139
+#: frontend/src/components/ListBulkActions.vue:147
+#: frontend/src/components/ListBulkActions.vue:197
+msgid "Clear Assignment"
+msgstr ""
+
+#: frontend/src/components/SortBy.vue:158
+msgid "Clear Sort"
+msgstr ""
+
+#. Label of the clear_table (Button) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Clear Table"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:18 frontend/src/components/Filter.vue:148
+msgid "Clear all Filter"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:28
+msgid "Close"
+msgstr ""
+
+#. Label of the close_date (Date) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Close Date"
+msgstr ""
+
+#: frontend/src/components/Layouts/AppSidebar.vue:79
+msgid "Collapse"
+msgstr ""
+
+#. Label of the color (Select) field in DocType 'CRM Deal Status'
+#. Label of the color (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "Color"
+msgstr ""
+
+#. Label of the column_field (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/Kanban/KanbanSettings.vue:14
+msgid "Column Field"
+msgstr ""
+
+#. Label of the columns (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ColumnSettings.vue:4
+msgid "Columns"
+msgstr ""
+
+#. Label of the comment (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: frontend/src/components/CommentBox.vue:80
+#: frontend/src/components/CommunicationArea.vue:17
+msgid "Comment"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:534 frontend/src/pages/Lead.vue:480
+#: frontend/src/pages/MobileDeal.vue:451 frontend/src/pages/MobileLead.vue:361
+msgid "Comments"
+msgstr ""
+
+#. Label of the communication_status (Link) field in DocType 'CRM Deal'
+#. Label of the communication_status (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Communication Status"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Communication Statuses"
+msgstr ""
+
+#. Label of the erpnext_company (Data) field in DocType 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Company in ERPNext Site"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Completed"
+msgstr ""
+
+#. Option for the 'Device' (Select) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Computer"
+msgstr ""
+
+#. Label of the condition (Code) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Condition"
+msgstr ""
+
+#. Label of the contact (Link) field in DocType 'CRM Contacts'
+#. Label of the contact (Link) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Lead.vue:248
+#: frontend/src/pages/MobileLead.vue:150
+msgid "Contact"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:178
+msgid "Contact Already Exists"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:20
+msgid "Contact Us"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:624 frontend/src/pages/MobileDeal.vue:541
+msgid "Contact added"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:177
+msgid "Contact already exists with {0}"
+msgstr ""
+
+#: crm/api/contact.py:57
+msgid "Contact not found"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:639 frontend/src/pages/MobileDeal.vue:556
+msgid "Contact removed"
+msgstr ""
+
+#. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the contacts (Table) field in DocType 'CRM Deal'
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Contact.vue:296
+msgid "Contacts"
+msgstr ""
+
+#. Label of the content (Text Editor) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+#: frontend/src/components/Modals/EmailTemplateModal.vue:67
+#: frontend/src/components/Modals/NoteModal.vue:49
+msgid "Content"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:55
+msgid "Content Type"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:70
+#: frontend/src/pages/Lead.vue:211 frontend/src/pages/MobileLead.vue:46
+#: frontend/src/pages/MobileLead.vue:113
+msgid "Convert"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:62
+#: frontend/src/components/ListBulkActions.vue:204
+#: frontend/src/pages/Lead.vue:37 frontend/src/pages/Lead.vue:207
+#: frontend/src/pages/MobileLead.vue:109
+msgid "Convert to Deal"
+msgstr ""
+
+#. Label of the converted (Check) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Converted"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:79
+msgid "Converted successfully"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:99
+#: frontend/src/components/Modals/DealModal.vue:49
+#: frontend/src/components/Modals/EmailTemplateModal.vue:9
+#: frontend/src/components/Modals/LeadModal.vue:34
+#: frontend/src/components/Modals/NoteModal.vue:8
+#: frontend/src/components/Modals/OrganizationModal.vue:194
+#: frontend/src/components/Modals/TaskModal.vue:8
+#: frontend/src/components/Modals/ViewModal.vue:16
+#: frontend/src/pages/Contacts.vue:13 frontend/src/pages/Contacts.vue:57
+#: frontend/src/pages/Deals.vue:13 frontend/src/pages/Deals.vue:233
+#: frontend/src/pages/EmailTemplates.vue:13
+#: frontend/src/pages/EmailTemplates.vue:58 frontend/src/pages/Leads.vue:13
+#: frontend/src/pages/Leads.vue:259 frontend/src/pages/Notes.vue:7
+#: frontend/src/pages/Notes.vue:93 frontend/src/pages/Organizations.vue:13
+#: frontend/src/pages/Organizations.vue:57 frontend/src/pages/Tasks.vue:11
+#: frontend/src/pages/Tasks.vue:182
+msgid "Create"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:8
+msgid "Create Deal"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:5
+msgid "Create Email Template"
+msgstr ""
+
+#: frontend/src/components/Modals/LeadModal.vue:8
+msgid "Create Lead"
+msgstr ""
+
+#: frontend/src/components/Controls/Link.vue:36
+#: frontend/src/components/Fields.vue:170
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:55
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:45
+msgid "Create New"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:347
+#: frontend/src/components/Modals/NoteModal.vue:18
+msgid "Create Note"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:362
+#: frontend/src/components/Modals/TaskModal.vue:18
+msgid "Create Task"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:9
+#: frontend/src/components/ViewControls.vue:578
+msgid "Create View"
+msgstr ""
+
+#. Label of the create_customer_on_status_change (Check) field in DocType
+#. 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Create customer on status change"
+msgstr ""
+
+#: frontend/src/components/Modals/CallLogModal.vue:95
+msgid "Create lead"
+msgstr ""
+
+#. Label of the currency (Link) field in DocType 'CRM Deal'
+#. Label of the currency (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Currency"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:417
+msgid "Customer created successfully"
+msgstr ""
+
+#. Label of the date (Date) field in DocType 'CRM Holiday'
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+msgid "Date"
+msgstr ""
+
+#: frontend/src/pages/Tasks.vue:129
+msgid "Deal"
+msgstr ""
+
+#. Label of the deal_owner (Link) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Deal Owner"
+msgstr ""
+
+#. Label of the deal_status (Link) field in DocType 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Deal Status"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Deal Statuses"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/api.py:20
+msgid "Deal not found"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:446 frontend/src/pages/Organization.vue:526
+msgid "Deal owner"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:458 frontend/src/pages/MobileDeal.vue:375
+msgid "Deal updated"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Deal.vue:490 frontend/src/pages/MobileDeal.vue:407
+msgid "Deals"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:92
+msgid "Dear {{ lead_name }}, \\n\\nThis is a reminder for the payment of {{ grand_total }}. \\n\\nThanks, \\nFrappé"
+msgstr ""
+
+#. Label of the default (Check) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Default"
+msgstr ""
+
+#. Label of the default_priority (Check) field in DocType 'CRM Service Level
+#. Priority'
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+msgid "Default Priority"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:33
+msgid "Default Service Level Agreement already exists for {0}"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:525
+#: frontend/src/components/ViewControls.vue:883
+msgid "Default Views"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:18
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:30
+msgid "Default statuses, custom fields and layouts restored successfully."
+msgstr ""
+
+#: frontend/src/components/Activities/NoteArea.vue:12
+#: frontend/src/components/Activities/TaskArea.vue:53
+#: frontend/src/components/Activities/TaskArea.vue:61
+#: frontend/src/components/Kanban/KanbanView.vue:224
+#: frontend/src/components/ListBulkActions.vue:96
+#: frontend/src/components/ListBulkActions.vue:104
+#: frontend/src/components/ListBulkActions.vue:186
+#: frontend/src/components/ViewControls.vue:927
+#: frontend/src/components/ViewControls.vue:938
+#: frontend/src/pages/Contact.vue:155 frontend/src/pages/Contact.vue:349
+#: frontend/src/pages/MobileDeal.vue:516 frontend/src/pages/Notes.vue:40
+#: frontend/src/pages/Organization.vue:158
+#: frontend/src/pages/Organization.vue:355 frontend/src/pages/Tasks.vue:334
+msgid "Delete"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:26
+msgid "Delete & Restore"
+msgstr ""
+
+#: frontend/src/components/Activities/TaskArea.vue:57
+msgid "Delete Task"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:923
+#: frontend/src/components/ViewControls.vue:931
+msgid "Delete View"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:345
+msgid "Delete contact"
+msgstr ""
+
+#: frontend/src/pages/Organization.vue:351
+msgid "Delete organization"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:114
+msgid "Deleted successfully"
+msgstr ""
+
+#. Label of the description (Text Editor) field in DocType 'CRM Holiday'
+#. Label of the description (Text Editor) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: frontend/src/components/Modals/TaskModal.vue:50
+msgid "Description"
+msgstr ""
+
+#: frontend/src/components/Apps.vue:58
+msgid "Desk"
+msgstr ""
+
+#. Label of the details (Tab Break) field in DocType 'CRM Lead'
+#. Label of the details (Text Editor) field in DocType 'CRM Lead Source'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+#: frontend/src/pages/MobileDeal.vue:435 frontend/src/pages/MobileLead.vue:345
+msgid "Details"
+msgstr ""
+
+#. Label of the call_receiving_device (Select) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Device"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
+msgid "Disable"
+msgstr ""
+
+#: frontend/src/components/CommentBox.vue:76
+#: frontend/src/components/EmailEditor.vue:151
+msgid "Discard"
+msgstr ""
+
+#. Label of the dt (Link) field in DocType 'CRM Form Script'
+#. Label of the dt (Link) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "DocType"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:88
+msgid "Docs"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:32
+msgid "Doctype"
+msgstr ""
+
+#. Label of the dt (Link) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Document Type"
+msgstr ""
+
+#: crm/api/activities.py:15
+msgid "Document not found"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Done"
+msgstr ""
+
+#: frontend/src/components/Activities/AudioPlayer.vue:166
+#: frontend/src/components/ViewControls.vue:175
+msgid "Download"
+msgstr ""
+
+#. Label of the due_date (Datetime) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Due Date"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:15
+#: frontend/src/components/ViewControls.vue:887
+msgid "Duplicate"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:8
+msgid "Duplicate View"
+msgstr ""
+
+#. Label of the duration (Duration) field in DocType 'CRM Call Log'
+#. Label of the duration (Duration) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "Duration"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:89
+msgid "ERPNext"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "ERPNext CRM Settings"
+msgstr ""
+
+#: frontend/src/components/Settings/ERPNextSettings.vue:4
+msgid "ERPNext Settings"
+msgstr ""
+
+#: frontend/src/components/Settings/ERPNextSettings.vue:5
+msgid "ERPNext Settings updated"
+msgstr ""
+
+#. Label of the erpnext_site_url (Data) field in DocType 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "ERPNext Site URL"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:23
+msgid "ERPNext is not installed in the current site"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:93
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:119
+msgid "ERPNext is not integrated with the CRM"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:100
+#: frontend/src/components/ListBulkActions.vue:179
+#: frontend/src/components/ViewControls.vue:897
+#: frontend/src/pages/Contact.vue:141 frontend/src/pages/Organization.vue:144
+msgid "Edit"
+msgstr ""
+
+#: frontend/src/components/Settings/SidePanelModal.vue:7
+msgid "Edit Field Layout"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:18
+msgid "Edit Note"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:16
+msgid "Edit Profile"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:31
+msgid "Edit Profile Photo"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:7
+msgid "Edit Quick Entry Layout"
+msgstr ""
+
+#: frontend/src/components/Modals/TaskModal.vue:18
+msgid "Edit Task"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:6
+msgid "Edit View"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:14
+msgid "Edit profile"
+msgstr ""
+
+#. Label of the email (Data) field in DocType 'CRM Contacts'
+#. Label of the email (Data) field in DocType 'CRM Deal'
+#. Label of the email (Data) field in DocType 'CRM Invitation'
+#. Label of the email (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json frontend/src/pages/Contact.vue:436
+#: frontend/src/pages/Organization.vue:516
+#: frontend/src/pages/Organization.vue:544
+msgid "Email"
+msgstr ""
+
+#. Label of the email_sent_at (Datetime) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Email Sent At"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:4
+msgid "Email Templates"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:199
+msgid "Email from Lead"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:529 frontend/src/pages/Lead.vue:475
+#: frontend/src/pages/MobileDeal.vue:446 frontend/src/pages/MobileLead.vue:356
+msgid "Emails"
+msgstr ""
+
+#: frontend/src/components/ListViews/ListRows.vue:12
+msgid "Empty"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:122
+msgid "Empty - Choose a field to filter by"
+msgstr ""
+
+#: frontend/src/components/SortBy.vue:132
+msgid "Empty - Choose a field to sort by"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
+msgid "Enable"
+msgstr ""
+
+#. Label of the enabled (Check) field in DocType 'CRM Form Script'
+#. Label of the enabled (Check) field in DocType 'CRM Service Level Agreement'
+#. Label of the enabled (Check) field in DocType 'ERPNext CRM Settings'
+#. Label of the enabled (Check) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+#: frontend/src/components/Modals/EmailTemplateModal.vue:99
+msgid "Enabled"
+msgstr ""
+
+#. Label of the end_date (Date) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "End Date"
+msgstr ""
+
+#. Label of the end_time (Datetime) field in DocType 'CRM Call Log'
+#. Label of the end_time (Time) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "End Time"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:246
+msgid "Enter {0}"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:65 frontend/src/components/Filter.vue:98
+#: frontend/src/components/Filter.vue:269
+#: frontend/src/components/Filter.vue:290
+#: frontend/src/components/Filter.vue:307
+#: frontend/src/components/Filter.vue:318
+#: frontend/src/components/Filter.vue:329
+#: frontend/src/components/Filter.vue:345
+msgid "Equals"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsPage.vue:90
+#: frontend/src/pages/Lead.vue:564 frontend/src/pages/Lead.vue:574
+#: frontend/src/pages/MobileLead.vue:437 frontend/src/pages/MobileLead.vue:447
+msgid "Error"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:479 frontend/src/pages/MobileDeal.vue:396
+msgid "Error Updating Deal"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:425 frontend/src/pages/MobileLead.vue:306
+msgid "Error Updating Lead"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:466 frontend/src/pages/MobileDeal.vue:383
+msgid "Error updating deal"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:412 frontend/src/pages/MobileLead.vue:293
+msgid "Error updating lead"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:231
+msgid "Error while creating customer in ERPNext, check error log for more details"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:158
+msgid "Error while creating prospect in ERPNext, check error log for more details"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:112
+msgid "Error while fetching customer in ERPNext, check error log for more details"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:189
+#: frontend/src/components/ViewControls.vue:198
+msgid "Excel"
+msgstr ""
+
+#: frontend/src/components/Layouts/AppSidebar.vue:79
+msgid "Expand"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Expired"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:132
+#: frontend/src/components/ViewControls.vue:172
+msgid "Export"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:203
+msgid "Export All {0} Record(s)"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:185
+msgid "Export Type"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "FCRM Note"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+msgid "FCRM Settings"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Failed"
+msgstr ""
+
+#: crm/integrations/twilio/api.py:106
+msgid "Failed to capture Twilio recording"
+msgstr ""
+
+#: crm/integrations/twilio/api.py:129
+msgid "Failed to update Twilio call status"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:5
+msgid "Field"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:50
+msgid "Fields Order"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:6
+msgid "Filter"
+msgstr ""
+
+#. Label of the filters (Code) field in DocType 'CRM View Settings'
+#. Label of the filters_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Filters"
+msgstr ""
+
+#. Label of the first_name (Data) field in DocType 'CRM Deal'
+#. Label of the first_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: frontend/src/components/ColumnSettings.vue:106
+#: frontend/src/components/Filter.vue:56 frontend/src/components/Filter.vue:87
+#: frontend/src/components/SortBy.vue:6 frontend/src/components/SortBy.vue:104
+#: frontend/src/components/SortBy.vue:138
+msgid "First Name"
+msgstr ""
+
+#: frontend/src/components/Modals/LeadModal.vue:132
+msgid "First Name is mandatory"
+msgstr ""
+
+#. Label of the first_responded_on (Datetime) field in DocType 'CRM Deal'
+#. Label of the first_responded_on (Datetime) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "First Responded On"
+msgstr ""
+
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "First Response Due"
+msgstr ""
+
+#. Label of the first_response_time (Duration) field in DocType 'CRM Service
+#. Level Priority'
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+msgid "First Response TIme"
+msgstr ""
+
+#. Label of the first_response_time (Duration) field in DocType 'CRM Deal'
+#. Label of the first_response_time (Duration) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "First Response Time"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:129
+msgid "First name"
+msgstr ""
+
+#. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Form"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:19
+msgid "Form Script updated successfully"
+msgstr ""
+
+#. Name of a Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Frappe CRM"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Friday"
+msgstr ""
+
+#. Label of the from (Data) field in DocType 'CRM Call Log'
+#. Label of the from (Data) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "From"
+msgstr ""
+
+#. Label of the from_date (Date) field in DocType 'CRM Holiday List'
+#. Label of the from_date (Datetime) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "From Date"
+msgstr ""
+
+#. Label of the from_user (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "From User"
+msgstr ""
+
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Fulfilled"
+msgstr ""
+
+#. Label of the full_name (Data) field in DocType 'CRM Contacts'
+#. Label of the lead_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Full Name"
+msgstr ""
+
+#. Label of the gender (Link) field in DocType 'CRM Contacts'
+#. Label of the gender (Link) field in DocType 'CRM Deal'
+#. Label of the gender (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Gender"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:91 frontend/src/pages/Lead.vue:141
+msgid "Go to website"
+msgstr ""
+
+#. Label of the group_by_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ViewControls.vue:290
+#: frontend/src/components/ViewControls.vue:502 frontend/src/utils/view.js:16
+msgid "Group By"
+msgstr ""
+
+#. Label of the group_by_field (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Group By Field"
+msgstr ""
+
+#: frontend/src/components/GroupBy.vue:8
+msgid "Group By: "
+msgstr ""
+
+#: frontend/src/components/CommunicationArea.vue:58
+msgid "Hi John, \\n\\nCan you please provide more details on this..."
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:195
+msgid "Hide"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:71
+msgid "Hide Recording"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:34
+#: frontend/src/components/Settings/SidePanelModal.vue:28
+msgid "Hide preview"
+msgstr ""
+
+#. Option for the 'Priority' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "High"
+msgstr ""
+
+#. Label of the holiday_list (Link) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Holiday List"
+msgstr ""
+
+#. Label of the holiday_list_name (Data) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Holiday List Name"
+msgstr ""
+
+#. Label of the holidays_section (Section Break) field in DocType 'CRM Holiday
+#. List'
+#. Label of the holidays (Table) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Holidays"
+msgstr ""
+
+#. Label of the id (Data) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: frontend/src/components/ViewControls.vue:589
+msgid "ID"
+msgstr ""
+
+#. Label of the icon (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Icon"
+msgstr ""
+
+#. Label of the image (Attach Image) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Image"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:273
+#: frontend/src/components/Filter.vue:294
+#: frontend/src/components/Filter.vue:309
+#: frontend/src/components/Filter.vue:322
+#: frontend/src/components/Filter.vue:336
+msgid "In"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "In Progress"
+msgstr ""
+
+#: frontend/src/components/SLASection.vue:75
+msgid "In less than a minute"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:35
+msgid "Inbound Call"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Incoming"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:40
+msgid "Incoming call..."
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Industries"
+msgstr ""
+
+#. Label of the industry (Link) field in DocType 'CRM Deal'
+#. Label of the industry (Data) field in DocType 'CRM Industry'
+#. Label of the industry (Link) field in DocType 'CRM Lead'
+#. Label of the industry (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Industry"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Initiated"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:35
+msgid "Initiating call..."
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:75
+msgid "Integrations"
+msgstr ""
+
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.py:33
+msgid "Invalid Account SID or Auth Token."
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:195
+#: frontend/src/components/Modals/LeadModal.vue:147
+msgid "Invalid Email"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:68
+msgid "Invite Members"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:22
+msgid "Invite as"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:8
+msgid "Invite by email"
+msgstr ""
+
+#. Label of the invited_by (Link) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Invited By"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:275
+#: frontend/src/components/Filter.vue:284
+#: frontend/src/components/Filter.vue:296
+#: frontend/src/components/Filter.vue:311
+#: frontend/src/components/Filter.vue:324
+#: frontend/src/components/Filter.vue:338
+#: frontend/src/components/Filter.vue:347
+msgid "Is"
+msgstr ""
+
+#. Label of the is_default (Check) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Is Default"
+msgstr ""
+
+#. Label of the is_erpnext_in_different_site (Check) field in DocType 'ERPNext
+#. CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Is ERPNext installed on a different site?"
+msgstr ""
+
+#. Label of the is_group (Check) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Is Group"
+msgstr ""
+
+#. Label of the is_primary (Check) field in DocType 'CRM Contacts'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+msgid "Is Primary"
+msgstr ""
+
+#. Label of the is_standard (Check) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Is Standard"
+msgstr ""
+
+#. Label of the job_title (Data) field in DocType 'CRM Deal'
+#. Label of the job_title (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Job Title"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:73 frontend/src/components/Filter.vue:106
+#: frontend/src/components/Modals/AssignmentModal.vue:35
+#: frontend/src/components/Modals/TaskModal.vue:77
+msgid "John Doe"
+msgstr ""
+
+#. Label of the kanban_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ViewControls.vue:295
+#: frontend/src/components/ViewControls.vue:491 frontend/src/utils/view.js:20
+msgid "Kanban"
+msgstr ""
+
+#. Label of the kanban_columns (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Kanban Columns"
+msgstr ""
+
+#. Label of the kanban_fields (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Kanban Fields"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:3
+#: frontend/src/components/Kanban/KanbanSettings.vue:11
+msgid "Kanban Settings"
+msgstr ""
+
+#. Label of the key (Data) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Key"
+msgstr ""
+
+#. Label of the label (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ColumnSettings.vue:103
+msgid "Label"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:615
+msgid "Last 6 Months"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:607
+msgid "Last Month"
+msgstr ""
+
+#. Label of the last_name (Data) field in DocType 'CRM Deal'
+#. Label of the last_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Last Name"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:611
+msgid "Last Quarter"
+msgstr ""
+
+#. Label of the last_status_change_log (Link) field in DocType 'CRM Status
+#. Change Log'
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "Last Status Change Log"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:603
+msgid "Last Week"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:619
+msgid "Last Year"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:451 frontend/src/pages/Organization.vue:531
+#: frontend/src/pages/Organization.vue:559
+msgid "Last modified"
+msgstr ""
+
+#. Label of the layout (Code) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Layout"
+msgstr ""
+
+#. Label of the lead (Link) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Tasks.vue:130
+msgid "Lead"
+msgstr ""
+
+#. Label of the lead_details_tab (Tab Break) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Lead Details"
+msgstr ""
+
+#. Label of the lead_name (Data) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Lead Name"
+msgstr ""
+
+#. Label of the lead_owner (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Lead Owner"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:64
+msgid "Lead Owner cannot be same as the Lead Email Address"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Lead Sources"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Lead Statuses"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/api.py:15
+msgid "Lead not found"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:404 frontend/src/pages/MobileLead.vue:285
+msgid "Lead updated"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Lead.vue:436 frontend/src/pages/MobileLead.vue:317
+msgid "Leads"
+msgstr "Pistes"
+
+#. Label of the lft (Int) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Left"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:271
+#: frontend/src/components/Filter.vue:282
+#: frontend/src/components/Filter.vue:292
+#: frontend/src/components/Filter.vue:320
+#: frontend/src/components/Filter.vue:334
+msgid "Like"
+msgstr ""
+
+#. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
+#. Label of the list_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ViewControls.vue:285
+#: frontend/src/components/ViewControls.vue:480 frontend/src/utils/view.js:12
+msgid "List"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:71
+msgid "Listen"
+msgstr ""
+
+#. Label of the load_default_columns (Check) field in DocType 'CRM View
+#. Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Load Default Columns"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanView.vue:138
+msgid "Load More"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:21
+#: frontend/src/pages/Deal.vue:176 frontend/src/pages/MobileDeal.vue:116
+msgid "Loading..."
+msgstr ""
+
+#. Label of the log_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the log_tab (Tab Break) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Log"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:104
+msgid "Log out"
+msgstr ""
+
+#. Option for the 'Priority' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Low"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:82
+msgid "Make Call"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:912
+msgid "Make Private"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:912
+msgid "Make Public"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:342
+#: frontend/src/components/Activities/ActivityHeader.vue:36
+#: frontend/src/components/Activities/ActivityHeader.vue:128
+#: frontend/src/pages/Deals.vue:490 frontend/src/pages/Leads.vue:507
+msgid "Make a Call"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:74 frontend/src/pages/Lead.vue:116
+msgid "Make a call"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:25
+#: frontend/src/components/Settings/InviteMemberPage.vue:101
+msgid "Manager Access"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:19
+#: frontend/src/pages/MobileNotification.vue:11
+#: frontend/src/pages/MobileNotification.vue:14
+msgid "Mark all as read"
+msgstr ""
+
+#. Label of the medium (Data) field in DocType 'CRM Call Log'
+#. Option for the 'Priority' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Medium"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Mention"
+msgstr ""
+
+#. Label of the message (HTML Editor) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Message"
+msgstr ""
+
+#. Label of the middle_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Middle Name"
+msgstr ""
+
+#. Label of the mobile_no (Data) field in DocType 'CRM Contacts'
+#. Label of the mobile_no (Data) field in DocType 'CRM Deal'
+#. Label of the mobile_no (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Mobile No"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:191
+#: frontend/src/components/Modals/LeadModal.vue:143
+msgid "Mobile No should be a number"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:441 frontend/src/pages/Organization.vue:521
+msgid "Mobile no"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Monday"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:129 frontend/src/pages/Organization.vue:132
+msgid "More"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:42
+msgid "My Open Deals"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:21
+#: frontend/src/pages/Organization.vue:539
+msgid "Name"
+msgstr ""
+
+#. Label of the naming_series (Select) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Naming Series"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:76
+msgid "New"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:94
+msgid "New Address"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:357
+#: frontend/src/components/Activities/ActivityHeader.vue:26
+#: frontend/src/components/Activities/ActivityHeader.vue:123
+msgid "New Comment"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:352
+#: frontend/src/components/Activities/ActivityHeader.vue:16
+#: frontend/src/components/Activities/ActivityHeader.vue:118
+msgid "New Email"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:67
+msgid "New Message"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:46
+#: frontend/src/components/Activities/ActivityHeader.vue:134
+#: frontend/src/pages/Deals.vue:496 frontend/src/pages/Leads.vue:513
+msgid "New Note"
+msgstr ""
+
+#: frontend/src/components/Modals/OrganizationModal.vue:187
+msgid "New Organization"
+msgstr ""
+
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:107
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:127
+msgid "New Section"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:56
+#: frontend/src/components/Activities/ActivityHeader.vue:139
+#: frontend/src/pages/Deals.vue:501 frontend/src/pages/Leads.vue:518
+msgid "New Task"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:144
+msgid "New WhatsApp Message"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:265 frontend/src/pages/MobileLead.vue:167
+msgid "New contact will be created based on the person's details"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:239 frontend/src/pages/MobileLead.vue:141
+msgid "New organization will be created based on the data in details section"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:663
+msgid "Next 6 Months"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:655
+msgid "Next Month"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:659
+msgid "Next Quarter"
+msgstr ""
+
+#. Label of the next_step (Data) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Next Step"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:651
+msgid "Next Week"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:667
+msgid "Next Year"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "No Answer"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanView.vue:101
+#: frontend/src/pages/Deals.vue:106 frontend/src/pages/Leads.vue:122
+#: frontend/src/pages/Tasks.vue:68
+msgid "No Title"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:264 frontend/src/pages/MobileDeal.vue:204
+msgid "No contacts added"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:86 frontend/src/pages/Lead.vue:136
+msgid "No email set"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:684
+msgid "No mobile number set"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:83
+#: frontend/src/pages/MobileNotification.vue:67
+msgid "No new notifications"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:123
+msgid "No phone number set"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:679
+msgid "No primary contact set"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:52
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:42
+msgid "No templates found"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:98 frontend/src/pages/Lead.vue:148
+msgid "No website set"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:162
+msgid "No {0} Available"
+msgstr ""
+
+#: frontend/src/pages/CallLogs.vue:50 frontend/src/pages/Contact.vue:203
+#: frontend/src/pages/Contacts.vue:56 frontend/src/pages/Deals.vue:232
+#: frontend/src/pages/EmailTemplates.vue:57 frontend/src/pages/Leads.vue:258
+#: frontend/src/pages/Notes.vue:92 frontend/src/pages/Organization.vue:213
+#: frontend/src/pages/Organizations.vue:56 frontend/src/pages/Tasks.vue:181
+msgid "No {0} Found"
+msgstr ""
+
+#. Label of the no_of_employees (Select) field in DocType 'CRM Deal'
+#. Label of the no_of_employees (Select) field in DocType 'CRM Lead'
+#. Label of the no_of_employees (Select) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "No. of Employees"
+msgstr ""
+
+#: frontend/src/components/Activities/AudioPlayer.vue:148
+msgid "Normal"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:270
+#: frontend/src/components/Filter.vue:291
+#: frontend/src/components/Filter.vue:308
+#: frontend/src/components/Filter.vue:319
+#: frontend/src/components/Filter.vue:346
+msgid "Not Equals"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:274
+#: frontend/src/components/Filter.vue:295
+#: frontend/src/components/Filter.vue:310
+#: frontend/src/components/Filter.vue:323
+#: frontend/src/components/Filter.vue:337
+msgid "Not In"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:272
+#: frontend/src/components/Filter.vue:283
+#: frontend/src/components/Filter.vue:293
+#: frontend/src/components/Filter.vue:321
+#: frontend/src/components/Filter.vue:335
+msgid "Not Like"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:10
+#: frontend/src/components/Settings/SettingsPage.vue:7
+#: frontend/src/components/Settings/SidePanelModal.vue:10
+msgid "Not Saved"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:204
+msgid "Not allowed to add contact to Deal"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:340
+msgid "Not allowed to convert Lead to Deal"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:214
+msgid "Not allowed to remove contact from Deal"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:224
+msgid "Not allowed to set primary contact for Deal"
+msgstr ""
+
+#. Label of the note (Link) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Note"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:550 frontend/src/pages/Lead.vue:496
+#: frontend/src/pages/MobileDeal.vue:467 frontend/src/pages/MobileLead.vue:377
+msgid "Notes"
+msgstr ""
+
+#: frontend/src/pages/Notes.vue:20
+msgid "Notes View"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:13
+msgid "Notification"
+msgstr ""
+
+#. Label of the notification_text (Text) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Notification Text"
+msgstr ""
+
+#. Label of the notification_type_doc (Dynamic Link) field in DocType 'CRM
+#. Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Notification Type Doc"
+msgstr ""
+
+#. Label of the notification_type_doctype (Link) field in DocType 'CRM
+#. Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Notification Type Doctype"
+msgstr ""
+
+#: frontend/src/components/Layouts/AppSidebar.vue:13
+#: frontend/src/components/Mobile/MobileSidebar.vue:21
+#: frontend/src/components/Notifications.vue:17
+#: frontend/src/pages/MobileNotification.vue:6
+msgid "Notifications"
+msgstr ""
+
+#. Label of the old_parent (Link) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Old Parent"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:329 frontend/src/pages/Lead.vue:525
+#: frontend/src/pages/Organization.vue:335
+msgid "Only PNG and JPG images are allowed"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:55
+msgid "Only one {0} can be set as primary."
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:26
+#: frontend/src/components/Modals/TaskModal.vue:26
+msgid "Open Deal"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:27
+#: frontend/src/components/Modals/TaskModal.vue:27
+msgid "Open Lead"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.js:6
+#: crm/fcrm/doctype/crm_lead/crm_lead.js:6
+msgid "Open in Portal"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanView.vue:220
+#: frontend/src/components/ViewControls.vue:128
+msgid "Options"
+msgstr ""
+
+#. Label of the order_by_tab (Tab Break) field in DocType 'CRM View Settings'
+#. Label of the order_by (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Order By"
+msgstr ""
+
+#. Label of the organization (Link) field in DocType 'CRM Deal'
+#. Label of the organization_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the organization (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json frontend/src/pages/Contact.vue:421
+#: frontend/src/pages/Lead.vue:221 frontend/src/pages/MobileLead.vue:123
+#: frontend/src/pages/Organization.vue:501
+#: frontend/src/pages/Organization.vue:554
+msgid "Organization"
+msgstr ""
+
+#. Label of the organization_details_section (Section Break) field in DocType
+#. 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Organization Details"
+msgstr ""
+
+#. Label of the organization_logo (Attach Image) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Organization Logo"
+msgstr ""
+
+#. Label of the organization_name (Data) field in DocType 'CRM Deal'
+#. Label of the organization_name (Data) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Organization Name"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:57
+msgid "Organization logo"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Organization.vue:295
+msgid "Organizations"
+msgstr ""
+
+#. Label of the organization_tab (Tab Break) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Others"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:36
+msgid "Outbound Call"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Outgoing"
+msgstr ""
+
+#. Label of the log_owner (Link) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "Owner"
+msgstr ""
+
+#. Label of the parent_crm_territory (Link) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Parent CRM Territory"
+msgstr ""
+
+#: crm/api/demo.py:21 crm/api/demo.py:31
+msgid "Password cannot be reset by Demo User {}"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:28
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:11
+msgid "Payment Reminder"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:50
+msgid "Payment Reminder from Frappé - (#{{ name }})"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Pending"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:34
+msgid "Pending Invites"
+msgstr ""
+
+#. Label of the person_section (Section Break) field in DocType 'CRM Deal'
+#. Label of the person_tab (Tab Break) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Person"
+msgstr ""
+
+#. Label of the phone (Data) field in DocType 'CRM Contacts'
+#. Label of the phone (Data) field in DocType 'CRM Deal'
+#. Label of the phone (Data) field in DocType 'CRM Lead'
+#. Option for the 'Device' (Select) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+#: frontend/src/pages/Organization.vue:549
+msgid "Phone"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:904
+msgid "Pin View"
+msgstr ""
+
+#. Label of the pinned (Check) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Pinned"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:568
+msgid "Pinned Views"
+msgstr ""
+
+#: frontend/src/components/Activities/AudioPlayer.vue:176
+msgid "Playback speed"
+msgstr ""
+
+#: crm/integrations/twilio/twilio_handler.py:124
+msgid "Please enable twilio settings before making a call."
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:565 frontend/src/pages/MobileLead.vue:438
+msgid "Please select an existing contact"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:575 frontend/src/pages/MobileLead.vue:448
+msgid "Please select an existing organization"
+msgstr ""
+
+#. Label of the position (Int) field in DocType 'CRM Deal Status'
+#. Label of the position (Int) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "Position"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:208 frontend/src/pages/MobileDeal.vue:148
+msgid "Primary"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:654 frontend/src/pages/MobileDeal.vue:571
+msgid "Primary contact set"
+msgstr ""
+
+#. Label of the priorities (Table) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Priorities"
+msgstr ""
+
+#. Label of the priority (Link) field in DocType 'CRM Service Level Priority'
+#. Label of the priority (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Priority"
+msgstr ""
+
+#. Label of the probability (Percent) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Probability"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:63
+msgid "Profile"
+msgstr ""
+
+#. Label of the public (Check) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Public"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:563
+msgid "Public Views"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Queued"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Quick Entry"
+msgstr ""
+
+#. Label of the read (Check) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Read"
+msgstr ""
+
+#. Label of the record_calls (Check) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Record Calls"
+msgstr ""
+
+#. Label of the recording_url (Data) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Recording URL"
+msgstr ""
+
+#. Label of the reference_name (Dynamic Link) field in DocType 'CRM
+#. Notification'
+#. Label of the reference_docname (Dynamic Link) field in DocType 'CRM Task'
+#. Label of the reference_docname (Dynamic Link) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "Reference Doc"
+msgstr ""
+
+#. Label of the reference_doctype (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Reference Doctype"
+msgstr ""
+
+#. Label of the reference_doctype (Link) field in DocType 'CRM Call Log'
+#. Label of the reference_doctype (Link) field in DocType 'CRM Task'
+#. Label of the reference_doctype (Link) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "Reference Document Type"
+msgstr ""
+
+#. Label of the reference_docname (Dynamic Link) field in DocType 'CRM Call
+#. Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Reference Name"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:25
+#: frontend/src/components/ViewControls.vue:87
+msgid "Refresh"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:24
+#: frontend/src/components/Settings/InviteMemberPage.vue:100
+msgid "Regular Access"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:103
+msgid "Reject"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:599
+msgid "Remove"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:37 frontend/src/pages/Lead.vue:89
+#: frontend/src/pages/Organization.vue:40
+msgid "Remove image"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:31
+#: frontend/src/components/CommunicationArea.vue:8
+msgid "Reply"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:44
+msgid "Reply All"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:56
+#: frontend/src/components/Settings/SidePanelModal.vue:71
+msgid "Reset"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:76
+msgid "Reset Changes"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:7
+msgid "Reset ERPNext Form Script"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:87
+msgid "Reset to Default"
+msgstr ""
+
+#. Label of the response_by (Datetime) field in DocType 'CRM Deal'
+#. Label of the response_by (Datetime) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Response By"
+msgstr ""
+
+#. Label of the response_details_section (Section Break) field in DocType 'CRM
+#. Deal'
+#. Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Response Details"
+msgstr ""
+
+#. Label of the section_break_ufaf (Section Break) field in DocType 'CRM
+#. Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Response and Follow Up"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:14
+msgid "Restore"
+msgstr ""
+
+#. Label of the restore_defaults (Button) field in DocType 'FCRM Settings'
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:13
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+msgid "Restore Defaults"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:62
+msgid "Rich Text"
+msgstr ""
+
+#. Label of the rgt (Int) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Right"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Ringing"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:37 frontend/src/components/CallUI.vue:146
+msgid "Ringing..."
+msgstr ""
+
+#. Label of the role (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Role"
+msgstr ""
+
+#. Label of the route_name (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Route Name"
+msgstr ""
+
+#. Label of the rows (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Rows"
+msgstr ""
+
+#. Label of the sla_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the sla (Link) field in DocType 'CRM Deal'
+#. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
+#. Label of the sla (Link) field in DocType 'CRM Lead'
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "SLA"
+msgstr ""
+
+#. Label of the sla_creation (Datetime) field in DocType 'CRM Deal'
+#. Label of the sla_creation (Datetime) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "SLA Creation"
+msgstr ""
+
+#. Label of the sla_name (Data) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "SLA Name"
+msgstr ""
+
+#. Label of the sla_status (Select) field in DocType 'CRM Deal'
+#. Label of the sla_status (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "SLA Status"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:75
+msgid "SUBJECT"
+msgstr ""
+
+#. Name of a role
+#. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Sales Manager"
+msgstr ""
+
+#. Name of a role
+#. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "Sales User"
+msgstr ""
+
+#. Label of the salutation (Link) field in DocType 'CRM Deal'
+#. Label of the salutation (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Salutation"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Saturday"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:99
+#: frontend/src/components/Modals/OrganizationModal.vue:194
+#: frontend/src/components/Modals/QuickEntryModal.vue:52
+#: frontend/src/components/Settings/ProfileSettings.vue:52
+#: frontend/src/components/Settings/SidePanelModal.vue:67
+msgid "Save"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:13
+#: frontend/src/components/ViewControls.vue:57
+#: frontend/src/components/ViewControls.vue:84
+msgid "Save Changes"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:558
+msgid "Saved Views"
+msgstr ""
+
+#. Label of the script (Code) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Script"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:244
+msgid "Select {0}"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:155
+msgid "Send"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:67
+msgid "Send Invites"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:4
+msgid "Send Invites To"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:60
+msgid "Send Template"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:79 frontend/src/pages/Lead.vue:129
+msgid "Send an email"
+msgstr ""
+
+#. Label of the naming_series (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Series"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:68
+msgid "Set an organization"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:607 frontend/src/pages/MobileDeal.vue:524
+msgid "Set as Primary Contact"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:110
+msgid "Set first name"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:7
+#: frontend/src/components/Settings/SettingsModal.vue:59
+#: frontend/src/components/UserDropdown.vue:99
+msgid "Settings"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:195
+msgid "Show"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:34
+#: frontend/src/components/Settings/SidePanelModal.vue:28
+msgid "Show preview"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Side Panel"
+msgstr ""
+
+#. Description of the 'Condition' (Code) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Simple Python Expression, Example: doc.status == 'Open' and doc.lead_source == 'Ads'"
+msgstr ""
+
+#: frontend/src/components/SortBy.vue:10 frontend/src/components/SortBy.vue:22
+#: frontend/src/components/SortBy.vue:240
+msgid "Sort"
+msgstr ""
+
+#. Label of the source (Link) field in DocType 'CRM Deal'
+#. Label of the source (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: frontend/src/components/Modals/EditValueModal.vue:10
+msgid "Source"
+msgstr ""
+
+#. Label of the source_name (Data) field in DocType 'CRM Lead Source'
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+msgid "Source Name"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.js:15
+msgid "Standard Form Scripts can not be modified, duplicate the Form Script instead."
+msgstr ""
+
+#. Label of the start_date (Date) field in DocType 'CRM Service Level
+#. Agreement'
+#. Label of the start_date (Date) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Start Date"
+msgstr ""
+
+#. Label of the start_time (Datetime) field in DocType 'CRM Call Log'
+#. Label of the start_time (Time) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Start Time"
+msgstr ""
+
+#. Label of the status (Select) field in DocType 'CRM Call Log'
+#. Label of the status (Data) field in DocType 'CRM Communication Status'
+#. Label of the status (Link) field in DocType 'CRM Deal'
+#. Label of the deal_status (Data) field in DocType 'CRM Deal Status'
+#. Label of the status (Select) field in DocType 'CRM Invitation'
+#. Label of the status (Link) field in DocType 'CRM Lead'
+#. Label of the lead_status (Data) field in DocType 'CRM Lead Status'
+#. Label of the status (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+#: crm/fcrm/doctype/crm_task/crm_task.json frontend/src/pages/Contact.vue:431
+#: frontend/src/pages/Organization.vue:511
+msgid "Status"
+msgstr ""
+
+#. Label of the status_change_log (Table) field in DocType 'CRM Deal'
+#. Label of the status_change_log (Table) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Status Change Log"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:199
+#: frontend/src/components/Modals/LeadModal.vue:151
+msgid "Status is required"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:43
+msgid "Subject"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:31
+msgid "Subject: {0}"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsPage.vue:82
+msgid "Success"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Sunday"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:83
+msgid "Support"
+msgstr ""
+
+#. Name of a role
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "System Manager"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:22
+msgid "TO"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Task"
+msgstr "Tâche"
+
+#: frontend/src/pages/Deal.vue:545 frontend/src/pages/Lead.vue:491
+#: frontend/src/pages/MobileDeal.vue:462 frontend/src/pages/MobileLead.vue:372
+msgid "Tasks"
+msgstr "Tâches"
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Territories"
+msgstr ""
+
+#. Label of the territory (Link) field in DocType 'CRM Deal'
+#. Label of the territory (Link) field in DocType 'CRM Lead'
+#. Label of the territory (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Territory"
+msgstr ""
+
+#. Label of the territory_manager (Link) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Territory Manager"
+msgstr ""
+
+#. Label of the territory_name (Data) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Territory Name"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:46
+msgid "The Condition '{0}' is invalid: {1}"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.js:14
+msgid "There can only be one default priority in Priorities table"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:639
+msgid "This Month"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:643
+msgid "This Quarter"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:635
+msgid "This Week"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:647
+msgid "This Year"
+msgstr ""
+
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:114
+msgid "This section is not editable"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:9
+msgid "This will restore (if not exist) all the default statuses, custom fields and layouts. Delete & Restore will delete default layouts and then restore them."
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Thursday"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:353
+msgid "Timespan"
+msgstr ""
+
+#. Label of the title (Data) field in DocType 'CRM Task'
+#. Label of the title (Data) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+#: frontend/src/components/Modals/NoteModal.vue:40
+#: frontend/src/components/Modals/TaskModal.vue:40
+msgid "Title"
+msgstr ""
+
+#. Label of the title_field (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/Kanban/KanbanSettings.vue:31
+msgid "Title Field"
+msgstr ""
+
+#. Label of the to (Data) field in DocType 'CRM Call Log'
+#. Label of the to (Data) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+#: frontend/src/components/Activities/EmailArea.vue:63
+msgid "To"
+msgstr ""
+
+#. Label of the to_date (Date) field in DocType 'CRM Holiday List'
+#. Label of the to_date (Datetime) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "To Date"
+msgstr ""
+
+#. Label of the to_user (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "To User"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:627
+msgid "Today"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Todo"
+msgstr ""
+
+#: frontend/src/components/Settings/SidePanelModal.vue:58
+msgid "Toggle on for preview"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:631
+msgid "Tomorrow"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:58
+#: frontend/src/components/Modals/TaskModal.vue:60
+msgid "Took a call with John Doe and discussed the new project."
+msgstr ""
+
+#. Label of the total_holidays (Int) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Total Holidays"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Tuesday"
+msgstr ""
+
+#. Label of the twiml_sid (Data) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "TwiML SID"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:78
+msgid "Twilio"
+msgstr ""
+
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.py:61
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.py:62
+msgid "Twilio API credential creation error."
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Twilio Agents"
+msgstr ""
+
+#. Label of the twilio_number (Data) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Twilio Number"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Twilio Settings"
+msgstr ""
+
+#. Label of the type (Select) field in DocType 'CRM Call Log'
+#. Label of the type (Select) field in DocType 'CRM Fields Layout'
+#. Label of the type (Select) field in DocType 'CRM Notification'
+#. Label of the type (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Type"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:85
+msgid "Type your message here..."
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:316
+msgid "Unknown"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:904
+msgid "Unpin View"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:762
+msgid "Unsaved Changes"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:8
+#: frontend/src/components/Modals/ContactModal.vue:8
+#: frontend/src/components/Modals/OrganizationModal.vue:8
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:14
+#: frontend/src/components/Section.vue:13
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:19
+#: frontend/src/pages/Deal.vue:62 frontend/src/pages/Deal.vue:70
+#: frontend/src/pages/Deal.vue:508 frontend/src/pages/Lead.vue:71
+#: frontend/src/pages/Lead.vue:112 frontend/src/pages/Lead.vue:454
+#: frontend/src/pages/MobileDeal.vue:425 frontend/src/pages/MobileLead.vue:335
+msgid "Untitled"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:132
+#: frontend/src/components/Modals/AssignmentModal.vue:17
+#: frontend/src/components/Modals/EmailTemplateModal.vue:9
+#: frontend/src/components/Modals/NoteModal.vue:8
+#: frontend/src/components/Modals/TaskModal.vue:8
+#: frontend/src/components/Settings/SettingsPage.vue:26
+#: frontend/src/components/ViewControls.vue:767
+msgid "Update"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:30
+msgid "Update {0} Records"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:132
+msgid "Upload Document"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:140
+msgid "Upload Image"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:148
+msgid "Upload Video"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:32 frontend/src/pages/Lead.vue:84
+#: frontend/src/pages/Organization.vue:35
+msgid "Upload image"
+msgstr ""
+
+#. Label of the user (Link) field in DocType 'CRM View Settings'
+#. Label of the user (Link) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "User"
+msgstr ""
+
+#. Label of the user_name (Data) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "User Name"
+msgstr ""
+
+#. Label of the section_break_nevd (Section Break) field in DocType 'CRM
+#. Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Validity"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:14
+msgid "Value"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:25
+msgid "View Name"
+msgstr ""
+
+#. Label of the website (Data) field in DocType 'CRM Deal'
+#. Label of the website (Data) field in DocType 'CRM Lead'
+#. Label of the website (Data) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Website"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Wednesday"
+msgstr ""
+
+#. Label of the weekly_off (Check) field in DocType 'CRM Holiday'
+#. Label of the weekly_off (Select) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Weekly Off"
+msgstr ""
+
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:11
+msgid "Welcome Message"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: frontend/src/components/Settings/SettingsModal.vue:83
+#: frontend/src/pages/Deal.vue:555 frontend/src/pages/Lead.vue:501
+#: frontend/src/pages/MobileDeal.vue:472 frontend/src/pages/MobileLead.vue:382
+msgid "WhatsApp"
+msgstr ""
+
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:4
+msgid "WhatsApp Templates"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:42 frontend/src/components/Filter.vue:80
+msgid "Where"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:111
+msgid "Width"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:116
+msgid "Width can be in number, pixel or rem (eg. 3, 30px, 10rem)"
+msgstr ""
+
+#. Label of the workday (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Workday"
+msgstr ""
+
+#. Label of the section_break_rmgo (Section Break) field in DocType 'CRM
+#. Service Level Agreement'
+#. Label of the working_hours (Table) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Working Hours"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:623
+msgid "Yesterday"
+msgstr ""
+
+#: crm/api/whatsapp.py:221 crm/api/whatsapp.py:240
+#: frontend/src/components/Activities/WhatsAppArea.vue:34
+#: frontend/src/components/Activities/WhatsAppBox.vue:14
+msgid "You"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:763
+msgid "You have unsaved changes. Do you want to save them?"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.py:24
+msgid "You need to be in developer mode to edit a Standard Form Script"
+msgstr ""
+
+#: crm/api/todo.py:24
+msgid "Your assignment on {0} {1} has been removed by {2}"
+msgstr ""
+
+#: frontend/src/components/Activities/CommentArea.vue:9
+msgid "added a"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "amber"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "black"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "blue"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:197
+msgid "changes from"
+msgstr ""
+
+#: frontend/src/components/Activities/CommentArea.vue:11
+msgid "comment"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "cyan"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "gray"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "green"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "group_by"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:16
+msgid "has made a call"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:15
+msgid "has reached out"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "kanban"
+msgstr ""
+
+#: crm/api/doc.py:35 crm/api/doc.py:155 crm/api/doc.py:412
+msgid "label"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "list"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:65
+#: frontend/src/pages/MobileNotification.vue:52
+msgid "mentioned you in {0}"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "orange"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "pink"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "purple"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "red"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "teal"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:239
+#: frontend/src/components/Activities/Activities.vue:302
+msgid "to"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "violet"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "yellow"
+msgstr ""
+
+#: crm/api/todo.py:28
+msgid "{0} assigned a {1} {2} to you"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:480 frontend/src/pages/Lead.vue:426
+#: frontend/src/pages/MobileDeal.vue:397 frontend/src/pages/MobileLead.vue:307
+msgid "{0} is a required field"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:28
+#: frontend/src/components/EmailEditor.vue:58
+#: frontend/src/components/EmailEditor.vue:70
+#: frontend/src/components/Settings/InviteMemberPage.vue:14
+msgid "{0} is an invalid email address"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsPage.vue:156
+msgid "{0} is mandatory"
+msgstr ""
+

--- a/crm/locale/fr.po
+++ b/crm/locale/fr.po
@@ -8,15 +8,16 @@ msgstr ""
 "Project-Id-Version: Frappe CRM VERSION\n"
 "Report-Msgid-Bugs-To: shariq@frappe.io\n"
 "POT-Creation-Date: 2024-10-15 20:07+0000\n"
-"PO-Revision-Date: 2024-10-15 22:21+0200\n"
+"PO-Revision-Date: 2024-10-15 22:57+0200\n"
 "Last-Translator: \n"
-"Language: fr\n"
 "Language-Team: shariq@frappe.io\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.13.1\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #: frontend/src/components/ViewControls.vue:964
 msgid " (New)"
@@ -94,24 +95,24 @@ msgstr ""
 #. Paragraph text in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
-msgstr ""
+msgstr "<b>RACCOURCIS</b>"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:78
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
-msgstr ""
+msgstr "<p>Cher·ère {{ lead_name }},</p>\\n\\n<p>Ceci est un rappel pour le paiement de {{ grand_total }}.</p>\\n\\n<p>Merci,</p>\\n<p>Frappé</p>"
 
 #. Header text in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
-msgstr ""
+msgstr "<span class=“h5”><b>PORTAIL</b></span>"
 
 #: frontend/src/components/CommunicationArea.vue:81
 msgid "@John, can you please check this?"
-msgstr ""
+msgstr "@John, pouvez-vous vérifier cela?"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:47
 msgid "A Lead requires either a person's name or an organization's name"
-msgstr ""
+msgstr "Une Piste nécessite soit un nom de personne ou d’organisation"
 
 #. Label of the api_key (Data) field in DocType 'ERPNext CRM Settings'
 #. Label of the api_key (Data) field in DocType 'Twilio Settings'
@@ -129,11 +130,11 @@ msgstr "Secret API"
 
 #: frontend/src/components/CallUI.vue:91
 msgid "Accept"
-msgstr ""
+msgstr "Accepter"
 
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.js:7
 msgid "Accept Invitation"
-msgstr ""
+msgstr "Accepter l’Invitation"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -148,7 +149,7 @@ msgstr "Accepté à"
 #. Label of the account_sid (Data) field in DocType 'Twilio Settings'
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
 msgid "Account SID"
-msgstr ""
+msgstr "SID du Compte"
 
 #: frontend/src/components/CustomActions.vue:73
 #: frontend/src/components/ViewControls.vue:574
@@ -243,7 +244,7 @@ msgstr "Appliquer à"
 
 #: frontend/src/components/Apps.vue:14
 msgid "Apps"
-msgstr ""
+msgstr "Apps"
 
 #: frontend/src/pages/Contact.vue:346
 msgid "Are you sure you want to delete this contact?"
@@ -259,31 +260,31 @@ msgstr "Êtes-vous sur de vouloir effacer cette tâche ?"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:9
 msgid "Are you sure you want to reset 'Create Quotation from CRM Deal' Form Script?"
-msgstr ""
+msgstr "Êtes-vous sur de vouloir réinitialiser le Script Formulaire ‘Créer Devis depuis Opportunité CRM’"
 
 #: frontend/src/components/ListBulkActions.vue:193
 #: frontend/src/components/Modals/AssignmentModal.vue:5
 msgid "Assign To"
-msgstr ""
+msgstr "Assigner à"
 
 #. Label of the assigned_to (Link) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Assigned To"
-msgstr ""
+msgstr "Assigné•e À"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Assignment"
-msgstr ""
+msgstr "Affectation"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Assignment Rule"
-msgstr ""
+msgstr "Règle d’Affectation"
 
 #: frontend/src/components/ListBulkActions.vue:158
 msgid "Assignment cleared successfully"
-msgstr ""
+msgstr "Affectation retirée avec succès"
 
 #. Label of the auth_token (Password) field in DocType 'Twilio Settings'
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
@@ -298,7 +299,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/ProfileSettings.vue:45
 msgid "Back"
-msgstr ""
+msgstr "Retour"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -307,16 +308,16 @@ msgstr ""
 
 #: frontend/src/components/Filter.vue:352
 msgid "Between"
-msgstr ""
+msgstr "Entre"
 
 #: frontend/src/components/Modals/EditValueModal.vue:2
 msgid "Bulk Edit"
-msgstr ""
+msgstr "Edition en Masse"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Busy"
-msgstr ""
+msgstr "Occupé"
 
 #: frontend/src/components/Activities/EmailArea.vue:67
 #: frontend/src/components/EmailEditor.vue:33
@@ -331,12 +332,12 @@ msgstr ""
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "CRM Call Log"
-msgstr ""
+msgstr "Journal des Appels CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
 msgid "CRM Communication Status"
-msgstr ""
+msgstr "Statut de Communication CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_contacts/crm_contacts.json
@@ -347,107 +348,107 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: frontend/src/components/Modals/EmailTemplateModal.vue:37
 msgid "CRM Deal"
-msgstr ""
+msgstr "CRM Opportunité"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 msgid "CRM Deal Status"
-msgstr ""
+msgstr "CRM Statut de l'Opportunité"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "CRM Fields Layout"
-msgstr ""
+msgstr "CRM Disposition des Champs"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 msgid "CRM Form Script"
-msgstr ""
+msgstr "CRM Script de Formulaire"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_holiday/crm_holiday.json
 msgid "CRM Holiday"
-msgstr ""
+msgstr "CRM Jour Férié"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "CRM Holiday List"
-msgstr ""
+msgstr "CRM Liste des Jour Fériés"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_industry/crm_industry.json
 msgid "CRM Industry"
-msgstr ""
+msgstr "CRM Industrie"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "CRM Invitation"
-msgstr ""
+msgstr "CRM Invitation"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "CRM Lead"
-msgstr ""
+msgstr "CRM Prospect"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
 msgid "CRM Lead Source"
-msgstr ""
+msgstr "CRM Source du Prospect"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "CRM Lead Status"
-msgstr ""
+msgstr "CRM Statut du Prospect"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "CRM Notification"
-msgstr ""
+msgstr "CRM Notification"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "CRM Organization"
-msgstr ""
+msgstr "CRM Organisation"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
-msgstr ""
+msgstr "CRM Page du Portail"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "CRM Service Day"
-msgstr ""
+msgstr "CRM Jour d’Entretien"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "CRM Service Level Agreement"
-msgstr ""
+msgstr "CRM Engagement de Niveau de Service"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
 msgid "CRM Service Level Priority"
-msgstr ""
+msgstr "CRM Priorité de Niveau de Service"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "CRM Status Change Log"
-msgstr ""
+msgstr "CRM Journal des Changements de Statut"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "CRM Task"
-msgstr ""
+msgstr "CRM Tâche"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "CRM Territory"
-msgstr ""
+msgstr "CRM Territoire"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "CRM View Settings"
-msgstr ""
+msgstr "CRM Paramètres de Vue"
 
 #: frontend/src/components/ViewControls.vue:193
 msgid "CSV"
@@ -455,31 +456,31 @@ msgstr ""
 
 #: frontend/src/components/Modals/CallLogModal.vue:6
 msgid "Call Details"
-msgstr ""
+msgstr "Détails de l'Appel"
 
 #. Label of the receiver (Link) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Call Received By"
-msgstr ""
+msgstr "Appel Reçu Par"
 
 #: frontend/src/components/Modals/NoteModal.vue:45
 #: frontend/src/components/Modals/TaskModal.vue:45
 msgid "Call with John Doe"
-msgstr ""
+msgstr "Appel avec M.Dupont"
 
 #. Label of the caller (Link) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Caller"
-msgstr ""
+msgstr "Appelant"
 
 #: frontend/src/components/CallUI.vue:39 frontend/src/components/CallUI.vue:146
 msgid "Calling..."
-msgstr ""
+msgstr "Appel…"
 
 #: frontend/src/pages/Deal.vue:539 frontend/src/pages/Lead.vue:485
 #: frontend/src/pages/MobileDeal.vue:456 frontend/src/pages/MobileLead.vue:366
 msgid "Calls"
-msgstr ""
+msgstr "Appels"
 
 #: frontend/src/components/CallUI.vue:76
 #: frontend/src/components/ColumnSettings.vue:126
@@ -487,135 +488,135 @@ msgstr ""
 #: frontend/src/components/ViewControls.vue:56
 #: frontend/src/components/ViewControls.vue:83
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Canceled"
-msgstr ""
+msgstr "Annulé•e"
 
 #: frontend/src/components/Activities/TaskArea.vue:44
 msgid "Change Status"
-msgstr ""
+msgstr "Changement de Statut"
 
 #: frontend/src/pages/Contact.vue:31 frontend/src/pages/Lead.vue:83
 #: frontend/src/pages/Organization.vue:34
 msgid "Change image"
-msgstr ""
+msgstr "Changement d’image"
 
 #: frontend/src/pages/Lead.vue:225 frontend/src/pages/Lead.vue:252
 #: frontend/src/pages/MobileLead.vue:127 frontend/src/pages/MobileLead.vue:154
 msgid "Choose Existing"
-msgstr ""
+msgstr "Choisir Existant"
 
 #: frontend/src/components/Modals/DealModal.vue:32
 msgid "Choose Existing Contact"
-msgstr ""
+msgstr "Choisir le Contact Existant"
 
 #: frontend/src/components/Modals/DealModal.vue:28
 msgid "Choose Existing Organization"
-msgstr ""
+msgstr "Choisir l’Organisation Existante"
 
 #: frontend/src/components/Controls/Link.vue:48
 msgid "Clear"
-msgstr ""
+msgstr "Effacer"
 
 #: frontend/src/components/ListBulkActions.vue:139
 #: frontend/src/components/ListBulkActions.vue:147
 #: frontend/src/components/ListBulkActions.vue:197
 msgid "Clear Assignment"
-msgstr ""
+msgstr "Effacer l’Affectation"
 
 #: frontend/src/components/SortBy.vue:158
 msgid "Clear Sort"
-msgstr ""
+msgstr "Effacer le Tri"
 
 #. Label of the clear_table (Button) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Clear Table"
-msgstr ""
+msgstr "Effacer le Tableau"
 
 #: frontend/src/components/Filter.vue:18 frontend/src/components/Filter.vue:148
 msgid "Clear all Filter"
-msgstr ""
+msgstr "Effacer tout les Filtres"
 
 #: frontend/src/components/Notifications.vue:28
 msgid "Close"
-msgstr ""
+msgstr "Fermer"
 
 #. Label of the close_date (Date) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Close Date"
-msgstr ""
+msgstr "Fermer la Date"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:79
 msgid "Collapse"
-msgstr ""
+msgstr "Réduire"
 
 #. Label of the color (Select) field in DocType 'CRM Deal Status'
 #. Label of the color (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "Color"
-msgstr ""
+msgstr "Couleur"
 
 #. Label of the column_field (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: frontend/src/components/Kanban/KanbanSettings.vue:14
 msgid "Column Field"
-msgstr ""
+msgstr "Champ de Colonne"
 
 #. Label of the columns (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: frontend/src/components/ColumnSettings.vue:4
 msgid "Columns"
-msgstr ""
+msgstr "Colonnes"
 
 #. Label of the comment (Link) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 #: frontend/src/components/CommentBox.vue:80
 #: frontend/src/components/CommunicationArea.vue:17
 msgid "Comment"
-msgstr ""
+msgstr "Commentaire"
 
 #: frontend/src/pages/Deal.vue:534 frontend/src/pages/Lead.vue:480
 #: frontend/src/pages/MobileDeal.vue:451 frontend/src/pages/MobileLead.vue:361
 msgid "Comments"
-msgstr ""
+msgstr "Commentaires"
 
 #. Label of the communication_status (Link) field in DocType 'CRM Deal'
 #. Label of the communication_status (Link) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Communication Status"
-msgstr ""
+msgstr "Statut de la Communication"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
-msgstr ""
+msgstr "Statuts des Communications"
 
 #. Label of the erpnext_company (Data) field in DocType 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "Company in ERPNext Site"
-msgstr ""
+msgstr "Société sur le site ERPNext"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Completed"
-msgstr ""
+msgstr "Terminé"
 
 #. Option for the 'Device' (Select) field in DocType 'Twilio Agents'
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 msgid "Computer"
-msgstr ""
+msgstr "Ordinateur"
 
 #. Label of the condition (Code) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Condition"
-msgstr ""
+msgstr "Condition"
 
 #. Label of the contact (Link) field in DocType 'CRM Contacts'
 #. Label of the contact (Link) field in DocType 'CRM Deal'
@@ -623,31 +624,31 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Lead.vue:248
 #: frontend/src/pages/MobileLead.vue:150
 msgid "Contact"
-msgstr ""
+msgstr "Contact"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:178
 msgid "Contact Already Exists"
-msgstr ""
+msgstr "Le Contact Existe Déjà"
 
 #: frontend/src/components/Modals/EditValueModal.vue:20
 msgid "Contact Us"
-msgstr ""
+msgstr "Contactez-nous"
 
 #: frontend/src/pages/Deal.vue:624 frontend/src/pages/MobileDeal.vue:541
 msgid "Contact added"
-msgstr ""
+msgstr "Contact Ajouté"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:177
 msgid "Contact already exists with {0}"
-msgstr ""
+msgstr "Le Contact existe déjà avec {0}"
 
 #: crm/api/contact.py:57
 msgid "Contact not found"
-msgstr ""
+msgstr "Pas de Contact trouvé"
 
 #: frontend/src/pages/Deal.vue:639 frontend/src/pages/MobileDeal.vue:556
 msgid "Contact removed"
-msgstr ""
+msgstr "Contact enlevé"
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
@@ -663,33 +664,33 @@ msgstr ""
 #: frontend/src/components/Modals/EmailTemplateModal.vue:67
 #: frontend/src/components/Modals/NoteModal.vue:49
 msgid "Content"
-msgstr ""
+msgstr "Contenu"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:55
 msgid "Content Type"
-msgstr ""
+msgstr "Type de Contenu"
 
 #: frontend/src/components/ListBulkActions.vue:70
 #: frontend/src/pages/Lead.vue:211 frontend/src/pages/MobileLead.vue:46
 #: frontend/src/pages/MobileLead.vue:113
 msgid "Convert"
-msgstr ""
+msgstr "Convertir"
 
 #: frontend/src/components/ListBulkActions.vue:62
 #: frontend/src/components/ListBulkActions.vue:204
 #: frontend/src/pages/Lead.vue:37 frontend/src/pages/Lead.vue:207
 #: frontend/src/pages/MobileLead.vue:109
 msgid "Convert to Deal"
-msgstr ""
+msgstr "Convertir en Opportunité"
 
 #. Label of the converted (Check) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Converted"
-msgstr ""
+msgstr "Conterti"
 
 #: frontend/src/components/ListBulkActions.vue:79
 msgid "Converted successfully"
-msgstr ""
+msgstr "Converti avec succès"
 
 #: frontend/src/components/Modals/AddressModal.vue:99
 #: frontend/src/components/Modals/DealModal.vue:49
@@ -708,133 +709,133 @@ msgstr ""
 #: frontend/src/pages/Organizations.vue:57 frontend/src/pages/Tasks.vue:11
 #: frontend/src/pages/Tasks.vue:182
 msgid "Create"
-msgstr ""
+msgstr "Créer"
 
 #: frontend/src/components/Modals/DealModal.vue:8
 msgid "Create Deal"
-msgstr ""
+msgstr "Créer Opportunité"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:5
 msgid "Create Email Template"
-msgstr ""
+msgstr "Créer un Modèle d’Email"
 
 #: frontend/src/components/Modals/LeadModal.vue:8
 msgid "Create Lead"
-msgstr ""
+msgstr "Créer une Piste"
 
 #: frontend/src/components/Controls/Link.vue:36
 #: frontend/src/components/Fields.vue:170
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:55
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:45
 msgid "Create New"
-msgstr ""
+msgstr "Créer Nouveau"
 
 #: frontend/src/components/Activities/Activities.vue:347
 #: frontend/src/components/Modals/NoteModal.vue:18
 msgid "Create Note"
-msgstr ""
+msgstr "Créer Note"
 
 #: frontend/src/components/Activities/Activities.vue:362
 #: frontend/src/components/Modals/TaskModal.vue:18
 msgid "Create Task"
-msgstr ""
+msgstr "Créer Tâche"
 
 #: frontend/src/components/Modals/ViewModal.vue:9
 #: frontend/src/components/ViewControls.vue:578
 msgid "Create View"
-msgstr ""
+msgstr "Créer Vue"
 
 #. Label of the create_customer_on_status_change (Check) field in DocType
 #. 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "Create customer on status change"
-msgstr ""
+msgstr "Créer client quand le statut change"
 
 #: frontend/src/components/Modals/CallLogModal.vue:95
 msgid "Create lead"
-msgstr ""
+msgstr "Créer piste"
 
 #. Label of the currency (Link) field in DocType 'CRM Deal'
 #. Label of the currency (Link) field in DocType 'CRM Organization'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Currency"
-msgstr ""
+msgstr "Device"
 
 #: frontend/src/pages/Deal.vue:417
 msgid "Customer created successfully"
-msgstr ""
+msgstr "Client crée avec succès"
 
 #. Label of the date (Date) field in DocType 'CRM Holiday'
 #: crm/fcrm/doctype/crm_holiday/crm_holiday.json
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #: frontend/src/pages/Tasks.vue:129
 msgid "Deal"
-msgstr ""
+msgstr "Opportunité"
 
 #. Label of the deal_owner (Link) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Deal Owner"
-msgstr ""
+msgstr "En Charge de l’Opportunité"
 
 #. Label of the deal_status (Link) field in DocType 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "Deal Status"
-msgstr ""
+msgstr "Statut de l’Opportunité"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
-msgstr ""
+msgstr "Statuts de l’Opportunité"
 
 #: crm/fcrm/doctype/crm_deal/api.py:20
 msgid "Deal not found"
-msgstr ""
+msgstr "Aucune Opportunité trouvée"
 
 #: frontend/src/pages/Contact.vue:446 frontend/src/pages/Organization.vue:526
 msgid "Deal owner"
-msgstr ""
+msgstr "En charge de l’Opportunité"
 
 #: frontend/src/pages/Deal.vue:458 frontend/src/pages/MobileDeal.vue:375
 msgid "Deal updated"
-msgstr ""
+msgstr "Opportunité mise à jour"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/pages/Deal.vue:490 frontend/src/pages/MobileDeal.vue:407
 msgid "Deals"
-msgstr ""
+msgstr "Opportunités"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:92
 msgid "Dear {{ lead_name }}, \\n\\nThis is a reminder for the payment of {{ grand_total }}. \\n\\nThanks, \\nFrappé"
-msgstr ""
+msgstr "Cher•ère {{ lead_name }}, \\n\\nCeci est un rappel pour le paiement de {{ grand_total }}. \\n\\Merci, \\nFrappé"
 
 #. Label of the default (Check) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 #. Label of the default_priority (Check) field in DocType 'CRM Service Level
 #. Priority'
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
 msgid "Default Priority"
-msgstr ""
+msgstr "Priorité par Défaut"
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:33
 msgid "Default Service Level Agreement already exists for {0}"
-msgstr ""
+msgstr "Un Niveau d’Engagement de Service par Défaut existe déjà"
 
 #: frontend/src/components/ViewControls.vue:525
 #: frontend/src/components/ViewControls.vue:883
 msgid "Default Views"
-msgstr ""
+msgstr "Vues par Défaut"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:18
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:30
 msgid "Default statuses, custom fields and layouts restored successfully."
-msgstr ""
+msgstr "Statuts par Défaut, Champs personnalisé et disposition restaurés avec succès."
 
 #: frontend/src/components/Activities/NoteArea.vue:12
 #: frontend/src/components/Activities/TaskArea.vue:53
@@ -850,32 +851,32 @@ msgstr ""
 #: frontend/src/pages/Organization.vue:158
 #: frontend/src/pages/Organization.vue:355 frontend/src/pages/Tasks.vue:334
 msgid "Delete"
-msgstr ""
+msgstr "Effacer"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:26
 msgid "Delete & Restore"
-msgstr ""
+msgstr "Effacer & Restaurer"
 
 #: frontend/src/components/Activities/TaskArea.vue:57
 msgid "Delete Task"
-msgstr ""
+msgstr "Effacer Tâche"
 
 #: frontend/src/components/ViewControls.vue:923
 #: frontend/src/components/ViewControls.vue:931
 msgid "Delete View"
-msgstr ""
+msgstr "Effacer Vue"
 
 #: frontend/src/pages/Contact.vue:345
 msgid "Delete contact"
-msgstr ""
+msgstr "Effacer contact"
 
 #: frontend/src/pages/Organization.vue:351
 msgid "Delete organization"
-msgstr ""
+msgstr "Effacer organisation"
 
 #: frontend/src/components/ListBulkActions.vue:114
 msgid "Deleted successfully"
-msgstr ""
+msgstr "Effacé avec succès"
 
 #. Label of the description (Text Editor) field in DocType 'CRM Holiday'
 #. Label of the description (Text Editor) field in DocType 'CRM Task'
@@ -895,16 +896,16 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
 #: frontend/src/pages/MobileDeal.vue:435 frontend/src/pages/MobileLead.vue:345
 msgid "Details"
-msgstr ""
+msgstr "Détails"
 
 #. Label of the call_receiving_device (Select) field in DocType 'Twilio Agents'
 #: crm/fcrm/doctype/twilio_agents/twilio_agents.json
 msgid "Device"
-msgstr ""
+msgstr "Appareil"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
 msgid "Disable"
-msgstr ""
+msgstr "Désactiver"
 
 #: frontend/src/components/CommentBox.vue:76
 #: frontend/src/components/EmailEditor.vue:151
@@ -3262,4 +3263,3 @@ msgstr ""
 #: frontend/src/components/Settings/SettingsPage.vue:156
 msgid "{0} is mandatory"
 msgstr ""
-

--- a/crm/locale/fr.po
+++ b/crm/locale/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Frappe CRM VERSION\n"
 "Report-Msgid-Bugs-To: shariq@frappe.io\n"
 "POT-Creation-Date: 2024-10-15 20:07+0000\n"
-"PO-Revision-Date: 2024-10-16 23:27+0200\n"
+"PO-Revision-Date: 2024-10-21 20:51+0200\n"
 "Last-Translator: \n"
 "Language-Team: shariq@frappe.io\n"
 "Language: fr\n"
@@ -686,7 +686,7 @@ msgstr "Convertir en Opportunité"
 #. Label of the converted (Check) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Converted"
-msgstr "Conterti"
+msgstr "Converti"
 
 #: frontend/src/components/ListBulkActions.vue:79
 msgid "Converted successfully"
@@ -760,7 +760,7 @@ msgstr "Créer piste"
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Currency"
-msgstr "Device"
+msgstr "Devise"
 
 #: frontend/src/pages/Deal.vue:417
 msgid "Customer created successfully"
@@ -1066,7 +1066,7 @@ msgstr "Email de la Piste"
 #: frontend/src/pages/Deal.vue:529 frontend/src/pages/Lead.vue:475
 #: frontend/src/pages/MobileDeal.vue:446 frontend/src/pages/MobileLead.vue:356
 msgid "Emails"
-msgstr "e-mails"
+msgstr "E-mails"
 
 #: frontend/src/components/ListViews/ListRows.vue:12
 msgid "Empty"
@@ -1355,7 +1355,7 @@ msgstr "Grouper Par Champ"
 
 #: frontend/src/components/GroupBy.vue:8
 msgid "Group By: "
-msgstr "Grouper Par:"
+msgstr "Grouper Par :"
 
 #: frontend/src/components/CommunicationArea.vue:58
 msgid "Hi John, \\n\\nCan you please provide more details on this..."
@@ -1534,7 +1534,7 @@ msgstr "Est Principal"
 #. Label of the is_standard (Check) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 msgid "Is Standard"
-msgstr "est la norme"
+msgstr "Est Standard"
 
 #. Label of the job_title (Data) field in DocType 'CRM Deal'
 #. Label of the job_title (Data) field in DocType 'CRM Lead'
@@ -1605,7 +1605,7 @@ msgstr "Dernier trimestre"
 #. Change Log'
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "Last Status Change Log"
-msgstr "journal du dernier changement d'état"
+msgstr "Journal du dernier changement de Statut"
 
 #: frontend/src/components/Filter.vue:603
 msgid "Last Week"
@@ -1697,7 +1697,7 @@ msgstr "Liste"
 
 #: frontend/src/components/Activities/CallArea.vue:71
 msgid "Listen"
-msgstr "Écoutez"
+msgstr "Écouter"
 
 #. Label of the load_default_columns (Check) field in DocType 'CRM View
 #. Settings'
@@ -1774,7 +1774,7 @@ msgstr "Moyen"
 #. Option for the 'Type' (Select) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Mention"
-msgstr "Mentionner"
+msgstr ""
 
 #. Label of the message (HTML Editor) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -2141,7 +2141,7 @@ msgstr "Nom de l’organisation"
 
 #: frontend/src/pages/Deal.vue:57
 msgid "Organization logo"
-msgstr "Logo de l'organisation"
+msgstr "Logo de l’organisation"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json

--- a/crm/locale/fr.po
+++ b/crm/locale/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Frappe CRM VERSION\n"
 "Report-Msgid-Bugs-To: shariq@frappe.io\n"
 "POT-Creation-Date: 2024-10-15 20:07+0000\n"
-"PO-Revision-Date: 2024-10-15 22:57+0200\n"
+"PO-Revision-Date: 2024-10-16 15:46+0200\n"
 "Last-Translator: \n"
 "Language-Team: shariq@frappe.io\n"
 "Language: fr\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.13.1\n"
-"X-Generator: Poedit 3.4.4\n"
+"X-Generator: Poedit 3.5\n"
 
 #: frontend/src/components/ViewControls.vue:964
 msgid " (New)"
@@ -910,14 +910,14 @@ msgstr "Désactiver"
 #: frontend/src/components/CommentBox.vue:76
 #: frontend/src/components/EmailEditor.vue:151
 msgid "Discard"
-msgstr ""
+msgstr "Abandonner"
 
 #. Label of the dt (Link) field in DocType 'CRM Form Script'
 #. Label of the dt (Link) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "DocType"
-msgstr ""
+msgstr "Type de Document"
 
 #: frontend/src/components/UserDropdown.vue:88
 msgid "Docs"
@@ -925,47 +925,47 @@ msgstr ""
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:32
 msgid "Doctype"
-msgstr ""
+msgstr "Type de document"
 
 #. Label of the dt (Link) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Document Type"
-msgstr ""
+msgstr "Type de Document"
 
 #: crm/api/activities.py:15
 msgid "Document not found"
-msgstr ""
+msgstr "Document non trouvé"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Done"
-msgstr ""
+msgstr "Terminé"
 
 #: frontend/src/components/Activities/AudioPlayer.vue:166
 #: frontend/src/components/ViewControls.vue:175
 msgid "Download"
-msgstr ""
+msgstr "Telecharger"
 
 #. Label of the due_date (Datetime) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Due Date"
-msgstr ""
+msgstr "Date limite"
 
 #: frontend/src/components/Modals/ViewModal.vue:15
 #: frontend/src/components/ViewControls.vue:887
 msgid "Duplicate"
-msgstr ""
+msgstr "Dupliquer"
 
 #: frontend/src/components/Modals/ViewModal.vue:8
 msgid "Duplicate View"
-msgstr ""
+msgstr "Dupliquer Vue"
 
 #. Label of the duration (Duration) field in DocType 'CRM Call Log'
 #. Label of the duration (Duration) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "Duration"
-msgstr ""
+msgstr "Durée"
 
 #: frontend/src/components/Settings/SettingsModal.vue:89
 msgid "ERPNext"
@@ -974,68 +974,68 @@ msgstr ""
 #. Name of a DocType
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "ERPNext CRM Settings"
-msgstr ""
+msgstr "Paramètres CRM ERPNext"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:4
 msgid "ERPNext Settings"
-msgstr ""
+msgstr "Paramètres ERPNext"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:5
 msgid "ERPNext Settings updated"
-msgstr ""
+msgstr "Paramètres ERPNext mis à jour"
 
 #. Label of the erpnext_site_url (Data) field in DocType 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "ERPNext Site URL"
-msgstr ""
+msgstr "URL du Site ERPNext"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:23
 msgid "ERPNext is not installed in the current site"
-msgstr ""
+msgstr "ERPNext n’est pas installé sur ce site"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:93
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:119
 msgid "ERPNext is not integrated with the CRM"
-msgstr ""
+msgstr "ERPNext n’est pas intégré avec le CRM"
 
 #: frontend/src/components/Fields.vue:100
 #: frontend/src/components/ListBulkActions.vue:179
 #: frontend/src/components/ViewControls.vue:897
 #: frontend/src/pages/Contact.vue:141 frontend/src/pages/Organization.vue:144
 msgid "Edit"
-msgstr ""
+msgstr "Modifier"
 
 #: frontend/src/components/Settings/SidePanelModal.vue:7
 msgid "Edit Field Layout"
-msgstr ""
+msgstr "Modifier la Disposition des Champs"
 
 #: frontend/src/components/Modals/NoteModal.vue:18
 msgid "Edit Note"
-msgstr ""
+msgstr "Note de Modification"
 
 #: frontend/src/components/Settings/ProfileSettings.vue:16
 msgid "Edit Profile"
-msgstr ""
+msgstr "Modifier Profil"
 
 #: frontend/src/components/Settings/ProfileSettings.vue:31
 msgid "Edit Profile Photo"
-msgstr ""
+msgstr "Modifier Photo de Profil"
 
 #: frontend/src/components/Modals/QuickEntryModal.vue:7
 msgid "Edit Quick Entry Layout"
-msgstr ""
+msgstr "Modifier la Disposition de la Saisie Rapide"
 
 #: frontend/src/components/Modals/TaskModal.vue:18
 msgid "Edit Task"
-msgstr ""
+msgstr "Modifier la Tâche"
 
 #: frontend/src/components/Modals/ViewModal.vue:6
 msgid "Edit View"
-msgstr ""
+msgstr "Modifier la Vue"
 
 #: frontend/src/components/Settings/ProfileSettings.vue:14
 msgid "Edit profile"
-msgstr ""
+msgstr "Modifier profil"
 
 #. Label of the email (Data) field in DocType 'CRM Contacts'
 #. Label of the email (Data) field in DocType 'CRM Deal'
@@ -1053,15 +1053,15 @@ msgstr ""
 #. Label of the email_sent_at (Datetime) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Email Sent At"
-msgstr ""
+msgstr "Email Envoyé à"
 
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:4
 msgid "Email Templates"
-msgstr ""
+msgstr "Modèles d’Email"
 
 #: frontend/src/components/EmailEditor.vue:199
 msgid "Email from Lead"
-msgstr ""
+msgstr "Email de la Piste"
 
 #: frontend/src/pages/Deal.vue:529 frontend/src/pages/Lead.vue:475
 #: frontend/src/pages/MobileDeal.vue:446 frontend/src/pages/MobileLead.vue:356
@@ -1070,19 +1070,19 @@ msgstr ""
 
 #: frontend/src/components/ListViews/ListRows.vue:12
 msgid "Empty"
-msgstr ""
+msgstr "Vide"
 
 #: frontend/src/components/Filter.vue:122
 msgid "Empty - Choose a field to filter by"
-msgstr ""
+msgstr "Vide - Choisissez un champ de filtre"
 
 #: frontend/src/components/SortBy.vue:132
 msgid "Empty - Choose a field to sort by"
-msgstr ""
+msgstr "Vide - Choisissez un champ de tri"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
 msgid "Enable"
-msgstr ""
+msgstr "Activer"
 
 #. Label of the enabled (Check) field in DocType 'CRM Form Script'
 #. Label of the enabled (Check) field in DocType 'CRM Service Level Agreement'
@@ -1094,23 +1094,23 @@ msgstr ""
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.json
 #: frontend/src/components/Modals/EmailTemplateModal.vue:99
 msgid "Enabled"
-msgstr ""
+msgstr "Activé"
 
 #. Label of the end_date (Date) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "End Date"
-msgstr ""
+msgstr "Date de Fin"
 
 #. Label of the end_time (Datetime) field in DocType 'CRM Call Log'
 #. Label of the end_time (Time) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "End Time"
-msgstr ""
+msgstr "Heure de Fin"
 
 #: frontend/src/components/Fields.vue:246
 msgid "Enter {0}"
-msgstr ""
+msgstr "Entrez {0}"
 
 #: frontend/src/components/Filter.vue:65 frontend/src/components/Filter.vue:98
 #: frontend/src/components/Filter.vue:269
@@ -1120,41 +1120,41 @@ msgstr ""
 #: frontend/src/components/Filter.vue:329
 #: frontend/src/components/Filter.vue:345
 msgid "Equals"
-msgstr ""
+msgstr "Égal"
 
 #: frontend/src/components/Settings/SettingsPage.vue:90
 #: frontend/src/pages/Lead.vue:564 frontend/src/pages/Lead.vue:574
 #: frontend/src/pages/MobileLead.vue:437 frontend/src/pages/MobileLead.vue:447
 msgid "Error"
-msgstr ""
+msgstr "Erreur"
 
 #: frontend/src/pages/Deal.vue:479 frontend/src/pages/MobileDeal.vue:396
 msgid "Error Updating Deal"
-msgstr ""
+msgstr "Erreur à la Mise à Jour de l’Opportunité"
 
 #: frontend/src/pages/Lead.vue:425 frontend/src/pages/MobileLead.vue:306
 msgid "Error Updating Lead"
-msgstr ""
+msgstr "Erreur à la Mise à Jour de la Piste"
 
 #: frontend/src/pages/Deal.vue:466 frontend/src/pages/MobileDeal.vue:383
 msgid "Error updating deal"
-msgstr ""
+msgstr "Erreur à la mise à jour de l’opportunité"
 
 #: frontend/src/pages/Lead.vue:412 frontend/src/pages/MobileLead.vue:293
 msgid "Error updating lead"
-msgstr ""
+msgstr "Erreur à la mise à jour de la piste"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:231
 msgid "Error while creating customer in ERPNext, check error log for more details"
-msgstr ""
+msgstr "Erreur à la création du client dans ERPNext, vérifiez le journal des erreurs pour plus de détails"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:158
 msgid "Error while creating prospect in ERPNext, check error log for more details"
-msgstr ""
+msgstr "Erreur à la création du prospect dans ERPNext, veuillez vérifier le journal des erreur pour plus de détails"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:112
 msgid "Error while fetching customer in ERPNext, check error log for more details"
-msgstr ""
+msgstr "Erreur à la récupération du client dans ERPNext, veuillez vérifier le journal des erreur pour plus de détails"
 
 #: frontend/src/components/ViewControls.vue:189
 #: frontend/src/components/ViewControls.vue:198
@@ -1163,25 +1163,25 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:79
 msgid "Expand"
-msgstr ""
+msgstr "Agrandir"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Expired"
-msgstr ""
+msgstr "Expiré(e)"
 
 #: frontend/src/components/ViewControls.vue:132
 #: frontend/src/components/ViewControls.vue:172
 msgid "Export"
-msgstr ""
+msgstr "Exporter"
 
 #: frontend/src/components/ViewControls.vue:203
 msgid "Export All {0} Record(s)"
-msgstr ""
+msgstr "Exporter Toutes les {0} Transaction(s)"
 
 #: frontend/src/components/ViewControls.vue:185
 msgid "Export Type"
-msgstr ""
+msgstr "Type d’Export"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
@@ -1191,7 +1191,7 @@ msgstr ""
 #. Name of a DocType
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "FCRM Settings"
-msgstr ""
+msgstr "FCRM Paramètres"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
@@ -1200,33 +1200,33 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Failed"
-msgstr ""
+msgstr "Échec"
 
 #: crm/integrations/twilio/api.py:106
 msgid "Failed to capture Twilio recording"
-msgstr ""
+msgstr "Échec de l’enregistrement Twilio"
 
 #: crm/integrations/twilio/api.py:129
 msgid "Failed to update Twilio call status"
-msgstr ""
+msgstr "Échec de la mise jour du statut de l’appel Twilio"
 
 #: frontend/src/components/Modals/EditValueModal.vue:5
 msgid "Field"
-msgstr ""
+msgstr "Champ"
 
 #: frontend/src/components/Kanban/KanbanSettings.vue:50
 msgid "Fields Order"
-msgstr ""
+msgstr "Ordre des Champs"
 
 #: frontend/src/components/Filter.vue:6
 msgid "Filter"
-msgstr ""
+msgstr "Filtre"
 
 #. Label of the filters (Code) field in DocType 'CRM View Settings'
 #. Label of the filters_tab (Tab Break) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Filters"
-msgstr ""
+msgstr "Filtres"
 
 #. Label of the first_name (Data) field in DocType 'CRM Deal'
 #. Label of the first_name (Data) field in DocType 'CRM Lead'
@@ -1237,51 +1237,51 @@ msgstr ""
 #: frontend/src/components/SortBy.vue:6 frontend/src/components/SortBy.vue:104
 #: frontend/src/components/SortBy.vue:138
 msgid "First Name"
-msgstr ""
+msgstr "Prénom"
 
 #: frontend/src/components/Modals/LeadModal.vue:132
 msgid "First Name is mandatory"
-msgstr ""
+msgstr "Le Prénom est obligatoire"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'CRM Deal'
 #. Label of the first_responded_on (Datetime) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "First Responded On"
-msgstr ""
+msgstr "Première Réponse le"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "First Response Due"
-msgstr ""
+msgstr "Première Réponse due"
 
 #. Label of the first_response_time (Duration) field in DocType 'CRM Service
 #. Level Priority'
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
 msgid "First Response TIme"
-msgstr ""
+msgstr "Heure de Première Réponse"
 
 #. Label of the first_response_time (Duration) field in DocType 'CRM Deal'
 #. Label of the first_response_time (Duration) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "First Response Time"
-msgstr ""
+msgstr "Heure de Première Réponse"
 
 #: frontend/src/components/Filter.vue:129
 msgid "First name"
-msgstr ""
+msgstr "Prénom"
 
 #. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 msgid "Form"
-msgstr ""
+msgstr "Formulaire"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:19
 msgid "Form Script updated successfully"
-msgstr ""
+msgstr "Script de Formulaire mis à jour avec succès"
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -1293,40 +1293,40 @@ msgstr ""
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "Friday"
-msgstr ""
+msgstr "Vendredi"
 
 #. Label of the from (Data) field in DocType 'CRM Call Log'
 #. Label of the from (Data) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "From"
-msgstr ""
+msgstr "De"
 
 #. Label of the from_date (Date) field in DocType 'CRM Holiday List'
 #. Label of the from_date (Datetime) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "From Date"
-msgstr ""
+msgstr "Depuis la date du"
 
 #. Label of the from_user (Link) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "From User"
-msgstr ""
+msgstr "De l’Utilisateur"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Fulfilled"
-msgstr ""
+msgstr "Rempli"
 
 #. Label of the full_name (Data) field in DocType 'CRM Contacts'
 #. Label of the lead_name (Data) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_contacts/crm_contacts.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Full Name"
-msgstr ""
+msgstr "Nom Complet"
 
 #. Label of the gender (Link) field in DocType 'CRM Contacts'
 #. Label of the gender (Link) field in DocType 'CRM Deal'
@@ -1335,67 +1335,67 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Gender"
-msgstr ""
+msgstr "Genre"
 
 #: frontend/src/pages/Deal.vue:91 frontend/src/pages/Lead.vue:141
 msgid "Go to website"
-msgstr ""
+msgstr "Aller au site web"
 
 #. Label of the group_by_tab (Tab Break) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: frontend/src/components/ViewControls.vue:290
 #: frontend/src/components/ViewControls.vue:502 frontend/src/utils/view.js:16
 msgid "Group By"
-msgstr ""
+msgstr "Grouper Par"
 
 #. Label of the group_by_field (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Group By Field"
-msgstr ""
+msgstr "Grouper Par Champ"
 
 #: frontend/src/components/GroupBy.vue:8
 msgid "Group By: "
-msgstr ""
+msgstr "Grouper Par:"
 
 #: frontend/src/components/CommunicationArea.vue:58
 msgid "Hi John, \\n\\nCan you please provide more details on this..."
-msgstr ""
+msgstr "Bonjour John, \\n\\nPouvez me donner plus de détails à ce sujet…"
 
 #: frontend/src/components/Activities/Activities.vue:195
 msgid "Hide"
-msgstr ""
+msgstr "Cacher"
 
 #: frontend/src/components/Activities/CallArea.vue:71
 msgid "Hide Recording"
-msgstr ""
+msgstr "Cacher Enregistrement"
 
 #: frontend/src/components/Modals/QuickEntryModal.vue:34
 #: frontend/src/components/Settings/SidePanelModal.vue:28
 msgid "Hide preview"
-msgstr ""
+msgstr "Cacher aperçu"
 
 #. Option for the 'Priority' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "High"
-msgstr ""
+msgstr "Haute"
 
 #. Label of the holiday_list (Link) field in DocType 'CRM Service Level
 #. Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Holiday List"
-msgstr ""
+msgstr "Liste des Jours Fériés"
 
 #. Label of the holiday_list_name (Data) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Holiday List Name"
-msgstr ""
+msgstr "Nom de la Liste des Jours Fériés"
 
 #. Label of the holidays_section (Section Break) field in DocType 'CRM Holiday
 #. List'
 #. Label of the holidays (Table) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Holidays"
-msgstr ""
+msgstr "Jours Fériés"
 
 #. Label of the id (Data) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
@@ -1406,7 +1406,7 @@ msgstr ""
 #. Label of the icon (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Icon"
-msgstr ""
+msgstr "Icône"
 
 #. Label of the image (Attach Image) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -1419,31 +1419,31 @@ msgstr ""
 #: frontend/src/components/Filter.vue:322
 #: frontend/src/components/Filter.vue:336
 msgid "In"
-msgstr ""
+msgstr "Dans"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "In Progress"
-msgstr ""
+msgstr "En Cours"
 
 #: frontend/src/components/SLASection.vue:75
 msgid "In less than a minute"
-msgstr ""
+msgstr "Dans moins d’une minute"
 
 #: frontend/src/components/Activities/CallArea.vue:35
 msgid "Inbound Call"
-msgstr ""
+msgstr "Appel Entrant"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Incoming"
-msgstr ""
+msgstr "Entrant"
 
 #: frontend/src/components/CallUI.vue:40
 msgid "Incoming call..."
-msgstr ""
+msgstr "Appel entrant…"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -1459,46 +1459,46 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Industry"
-msgstr ""
+msgstr "Industrie"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Initiated"
-msgstr ""
+msgstr "Initié"
 
 #: frontend/src/components/CallUI.vue:35
 msgid "Initiating call..."
-msgstr ""
+msgstr "Démarrage de l’appel..."
 
 #: frontend/src/components/Settings/SettingsModal.vue:75
 msgid "Integrations"
-msgstr ""
+msgstr "Intégrations"
 
 #: crm/fcrm/doctype/twilio_settings/twilio_settings.py:33
 msgid "Invalid Account SID or Auth Token."
-msgstr ""
+msgstr "SID de Compte ou Token d’Autorisation Invalide"
 
 #: frontend/src/components/Modals/DealModal.vue:195
 #: frontend/src/components/Modals/LeadModal.vue:147
 msgid "Invalid Email"
-msgstr ""
+msgstr "Email Invalide"
 
 #: frontend/src/components/Settings/SettingsModal.vue:68
 msgid "Invite Members"
-msgstr ""
+msgstr "Inviter des Membres"
 
 #: frontend/src/components/Settings/InviteMemberPage.vue:22
 msgid "Invite as"
-msgstr ""
+msgstr "Invite en tant que"
 
 #: frontend/src/components/Settings/InviteMemberPage.vue:8
 msgid "Invite by email"
-msgstr ""
+msgstr "Inviter par email"
 
 #. Label of the invited_by (Link) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Invited By"
-msgstr ""
+msgstr "Invité Par"
 
 #: frontend/src/components/Filter.vue:275
 #: frontend/src/components/Filter.vue:284
@@ -1508,28 +1508,28 @@ msgstr ""
 #: frontend/src/components/Filter.vue:338
 #: frontend/src/components/Filter.vue:347
 msgid "Is"
-msgstr ""
+msgstr "Est"
 
 #. Label of the is_default (Check) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Is Default"
-msgstr ""
+msgstr "Est pas Défault"
 
 #. Label of the is_erpnext_in_different_site (Check) field in DocType 'ERPNext
 #. CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "Is ERPNext installed on a different site?"
-msgstr ""
+msgstr "ERPNext est il installé sur un autre site ?"
 
 #. Label of the is_group (Check) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Is Group"
-msgstr ""
+msgstr "Est un Group"
 
 #. Label of the is_primary (Check) field in DocType 'CRM Contacts'
 #: crm/fcrm/doctype/crm_contacts/crm_contacts.json
 msgid "Is Primary"
-msgstr ""
+msgstr "Est Principal"
 
 #. Label of the is_standard (Check) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json

--- a/crm/locale/main.pot
+++ b/crm/locale/main.pot
@@ -1,0 +1,3264 @@
+# Translations template for Frappe CRM.
+# Copyright (C) 2024 Frappe Technologies Pvt. Ltd.
+# This file is distributed under the same license as the Frappe CRM project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Frappe CRM VERSION\n"
+"Report-Msgid-Bugs-To: shariq@frappe.io\n"
+"POT-Creation-Date: 2024-10-15 20:07+0000\n"
+"PO-Revision-Date: 2024-10-15 20:07+0000\n"
+"Last-Translator: shariq@frappe.io\n"
+"Language-Team: shariq@frappe.io\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.1\n"
+
+#: frontend/src/components/ViewControls.vue:964
+msgid " (New)"
+msgstr ""
+
+#: frontend/src/components/Modals/TaskModal.vue:97
+msgid "01/04/2024 11:30 PM"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "1-10"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "1000+"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "11-50"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "201-500"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "501-1000"
+msgstr ""
+
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
+#. Option for the 'No. of Employees' (Select) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "51-200"
+msgstr ""
+
+#. Paragraph text in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "<b>META</b>"
+msgstr ""
+
+#. Paragraph text in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "<b>SHORTCUTS</b>"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:78
+msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
+msgstr ""
+
+#. Header text in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "<span class=\"h5\"><b>PORTAL</b></span>"
+msgstr ""
+
+#: frontend/src/components/CommunicationArea.vue:81
+msgid "@John, can you please check this?"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:47
+msgid "A Lead requires either a person's name or an organization's name"
+msgstr ""
+
+#. Label of the api_key (Data) field in DocType 'ERPNext CRM Settings'
+#. Label of the api_key (Data) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "API Key"
+msgstr ""
+
+#. Label of the api_secret (Password) field in DocType 'ERPNext CRM Settings'
+#. Label of the api_secret (Password) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "API Secret"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:91
+msgid "Accept"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.js:7
+msgid "Accept Invitation"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Accepted"
+msgstr ""
+
+#. Label of the accepted_at (Datetime) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Accepted At"
+msgstr ""
+
+#. Label of the account_sid (Data) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Account SID"
+msgstr ""
+
+#: frontend/src/components/CustomActions.vue:73
+#: frontend/src/components/ViewControls.vue:574
+msgid "Actions"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:524 frontend/src/pages/Lead.vue:470
+#: frontend/src/pages/MobileDeal.vue:441 frontend/src/pages/MobileLead.vue:351
+msgid "Activity"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:63
+#: frontend/src/components/Kanban/KanbanView.vue:156
+msgid "Add Column"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:83
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:80
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:93
+msgid "Add Field"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:136
+msgid "Add Filter"
+msgstr ""
+
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:104
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:125
+msgid "Add Section"
+msgstr ""
+
+#: frontend/src/components/SortBy.vue:146
+msgid "Add Sort"
+msgstr ""
+
+#. Label of the add_weekly_holidays_section (Section Break) field in DocType
+#. 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Add Weekly Holidays"
+msgstr ""
+
+#. Label of the add_to_holidays (Button) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Add to Holidays"
+msgstr ""
+
+#. Label of the address (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Address"
+msgstr ""
+
+#: crm/integrations/twilio/twilio_handler.py:148
+msgid "Agent is unavailable to take the call, please call after some time."
+msgstr ""
+
+#. Label of the annual_revenue (Currency) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Contact.vue:426
+#: frontend/src/pages/Organization.vue:506
+msgid "Amount"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:42 frontend/src/components/Filter.vue:80
+msgid "And"
+msgstr ""
+
+#. Label of the annual_revenue (Currency) field in DocType 'CRM Lead'
+#. Label of the annual_revenue (Currency) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Annual Revenue"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:186
+#: frontend/src/components/Modals/LeadModal.vue:138
+msgid "Annual Revenue should be a number"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:106
+#: frontend/src/components/Kanban/KanbanView.vue:44
+msgid "Apply"
+msgstr ""
+
+#. Label of the apply_on (Link) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Apply On"
+msgstr ""
+
+#. Label of the view (Select) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Apply To"
+msgstr ""
+
+#: frontend/src/components/Apps.vue:14
+msgid "Apps"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:346
+msgid "Are you sure you want to delete this contact?"
+msgstr ""
+
+#: frontend/src/pages/Organization.vue:352
+msgid "Are you sure you want to delete this organization?"
+msgstr ""
+
+#: frontend/src/components/Activities/TaskArea.vue:58
+msgid "Are you sure you want to delete this task?"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:9
+msgid "Are you sure you want to reset 'Create Quotation from CRM Deal' Form Script?"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:193
+#: frontend/src/components/Modals/AssignmentModal.vue:5
+msgid "Assign To"
+msgstr ""
+
+#. Label of the assigned_to (Link) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Assigned To"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Assignment"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Assignment Rule"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:158
+msgid "Assignment cleared successfully"
+msgstr ""
+
+#. Label of the auth_token (Password) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Auth Token"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:72
+#: frontend/src/components/EmailEditor.vue:41
+#: frontend/src/components/EmailEditor.vue:63
+msgid "BCC"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:45
+msgid "Back"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Backlog"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:352
+msgid "Between"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:2
+msgid "Bulk Edit"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Busy"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:67
+#: frontend/src/components/EmailEditor.vue:33
+#: frontend/src/components/EmailEditor.vue:51
+msgid "CC"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:24
+msgid "CRM"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "CRM Call Log"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+msgid "CRM Communication Status"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+msgid "CRM Contacts"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: frontend/src/components/Modals/EmailTemplateModal.vue:37
+msgid "CRM Deal"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+msgid "CRM Deal Status"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "CRM Fields Layout"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "CRM Form Script"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+msgid "CRM Holiday"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "CRM Holiday List"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+msgid "CRM Industry"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "CRM Invitation"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "CRM Lead"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+msgid "CRM Lead Source"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "CRM Lead Status"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "CRM Notification"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "CRM Organization"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "CRM Portal Page"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "CRM Service Day"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "CRM Service Level Agreement"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+msgid "CRM Service Level Priority"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "CRM Status Change Log"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "CRM Task"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "CRM Territory"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "CRM View Settings"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:193
+msgid "CSV"
+msgstr ""
+
+#: frontend/src/components/Modals/CallLogModal.vue:6
+msgid "Call Details"
+msgstr ""
+
+#. Label of the receiver (Link) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Call Received By"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:45
+#: frontend/src/components/Modals/TaskModal.vue:45
+msgid "Call with John Doe"
+msgstr ""
+
+#. Label of the caller (Link) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Caller"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:39 frontend/src/components/CallUI.vue:146
+msgid "Calling..."
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:539 frontend/src/pages/Lead.vue:485
+#: frontend/src/pages/MobileDeal.vue:456 frontend/src/pages/MobileLead.vue:366
+msgid "Calls"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:76
+#: frontend/src/components/ColumnSettings.vue:126
+#: frontend/src/components/Modals/AssignmentModal.vue:9
+#: frontend/src/components/ViewControls.vue:56
+#: frontend/src/components/ViewControls.vue:83
+msgid "Cancel"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Canceled"
+msgstr ""
+
+#: frontend/src/components/Activities/TaskArea.vue:44
+msgid "Change Status"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:31 frontend/src/pages/Lead.vue:83
+#: frontend/src/pages/Organization.vue:34
+msgid "Change image"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:225 frontend/src/pages/Lead.vue:252
+#: frontend/src/pages/MobileLead.vue:127 frontend/src/pages/MobileLead.vue:154
+msgid "Choose Existing"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:32
+msgid "Choose Existing Contact"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:28
+msgid "Choose Existing Organization"
+msgstr ""
+
+#: frontend/src/components/Controls/Link.vue:48
+msgid "Clear"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:139
+#: frontend/src/components/ListBulkActions.vue:147
+#: frontend/src/components/ListBulkActions.vue:197
+msgid "Clear Assignment"
+msgstr ""
+
+#: frontend/src/components/SortBy.vue:158
+msgid "Clear Sort"
+msgstr ""
+
+#. Label of the clear_table (Button) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Clear Table"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:18 frontend/src/components/Filter.vue:148
+msgid "Clear all Filter"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:28
+msgid "Close"
+msgstr ""
+
+#. Label of the close_date (Date) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Close Date"
+msgstr ""
+
+#: frontend/src/components/Layouts/AppSidebar.vue:79
+msgid "Collapse"
+msgstr ""
+
+#. Label of the color (Select) field in DocType 'CRM Deal Status'
+#. Label of the color (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "Color"
+msgstr ""
+
+#. Label of the column_field (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/Kanban/KanbanSettings.vue:14
+msgid "Column Field"
+msgstr ""
+
+#. Label of the columns (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ColumnSettings.vue:4
+msgid "Columns"
+msgstr ""
+
+#. Label of the comment (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: frontend/src/components/CommentBox.vue:80
+#: frontend/src/components/CommunicationArea.vue:17
+msgid "Comment"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:534 frontend/src/pages/Lead.vue:480
+#: frontend/src/pages/MobileDeal.vue:451 frontend/src/pages/MobileLead.vue:361
+msgid "Comments"
+msgstr ""
+
+#. Label of the communication_status (Link) field in DocType 'CRM Deal'
+#. Label of the communication_status (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Communication Status"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Communication Statuses"
+msgstr ""
+
+#. Label of the erpnext_company (Data) field in DocType 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Company in ERPNext Site"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Completed"
+msgstr ""
+
+#. Option for the 'Device' (Select) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Computer"
+msgstr ""
+
+#. Label of the condition (Code) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Condition"
+msgstr ""
+
+#. Label of the contact (Link) field in DocType 'CRM Contacts'
+#. Label of the contact (Link) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Lead.vue:248
+#: frontend/src/pages/MobileLead.vue:150
+msgid "Contact"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:178
+msgid "Contact Already Exists"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:20
+msgid "Contact Us"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:624 frontend/src/pages/MobileDeal.vue:541
+msgid "Contact added"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:177
+msgid "Contact already exists with {0}"
+msgstr ""
+
+#: crm/api/contact.py:57
+msgid "Contact not found"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:639 frontend/src/pages/MobileDeal.vue:556
+msgid "Contact removed"
+msgstr ""
+
+#. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the contacts (Table) field in DocType 'CRM Deal'
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Contact.vue:296
+msgid "Contacts"
+msgstr ""
+
+#. Label of the content (Text Editor) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+#: frontend/src/components/Modals/EmailTemplateModal.vue:67
+#: frontend/src/components/Modals/NoteModal.vue:49
+msgid "Content"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:55
+msgid "Content Type"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:70
+#: frontend/src/pages/Lead.vue:211 frontend/src/pages/MobileLead.vue:46
+#: frontend/src/pages/MobileLead.vue:113
+msgid "Convert"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:62
+#: frontend/src/components/ListBulkActions.vue:204
+#: frontend/src/pages/Lead.vue:37 frontend/src/pages/Lead.vue:207
+#: frontend/src/pages/MobileLead.vue:109
+msgid "Convert to Deal"
+msgstr ""
+
+#. Label of the converted (Check) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Converted"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:79
+msgid "Converted successfully"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:99
+#: frontend/src/components/Modals/DealModal.vue:49
+#: frontend/src/components/Modals/EmailTemplateModal.vue:9
+#: frontend/src/components/Modals/LeadModal.vue:34
+#: frontend/src/components/Modals/NoteModal.vue:8
+#: frontend/src/components/Modals/OrganizationModal.vue:194
+#: frontend/src/components/Modals/TaskModal.vue:8
+#: frontend/src/components/Modals/ViewModal.vue:16
+#: frontend/src/pages/Contacts.vue:13 frontend/src/pages/Contacts.vue:57
+#: frontend/src/pages/Deals.vue:13 frontend/src/pages/Deals.vue:233
+#: frontend/src/pages/EmailTemplates.vue:13
+#: frontend/src/pages/EmailTemplates.vue:58 frontend/src/pages/Leads.vue:13
+#: frontend/src/pages/Leads.vue:259 frontend/src/pages/Notes.vue:7
+#: frontend/src/pages/Notes.vue:93 frontend/src/pages/Organizations.vue:13
+#: frontend/src/pages/Organizations.vue:57 frontend/src/pages/Tasks.vue:11
+#: frontend/src/pages/Tasks.vue:182
+msgid "Create"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:8
+msgid "Create Deal"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:5
+msgid "Create Email Template"
+msgstr ""
+
+#: frontend/src/components/Modals/LeadModal.vue:8
+msgid "Create Lead"
+msgstr ""
+
+#: frontend/src/components/Controls/Link.vue:36
+#: frontend/src/components/Fields.vue:170
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:55
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:45
+msgid "Create New"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:347
+#: frontend/src/components/Modals/NoteModal.vue:18
+msgid "Create Note"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:362
+#: frontend/src/components/Modals/TaskModal.vue:18
+msgid "Create Task"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:9
+#: frontend/src/components/ViewControls.vue:578
+msgid "Create View"
+msgstr ""
+
+#. Label of the create_customer_on_status_change (Check) field in DocType
+#. 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Create customer on status change"
+msgstr ""
+
+#: frontend/src/components/Modals/CallLogModal.vue:95
+msgid "Create lead"
+msgstr ""
+
+#. Label of the currency (Link) field in DocType 'CRM Deal'
+#. Label of the currency (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Currency"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:417
+msgid "Customer created successfully"
+msgstr ""
+
+#. Label of the date (Date) field in DocType 'CRM Holiday'
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+msgid "Date"
+msgstr ""
+
+#: frontend/src/pages/Tasks.vue:129
+msgid "Deal"
+msgstr ""
+
+#. Label of the deal_owner (Link) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Deal Owner"
+msgstr ""
+
+#. Label of the deal_status (Link) field in DocType 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Deal Status"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Deal Statuses"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/api.py:20
+msgid "Deal not found"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:446 frontend/src/pages/Organization.vue:526
+msgid "Deal owner"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:458 frontend/src/pages/MobileDeal.vue:375
+msgid "Deal updated"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Deal.vue:490 frontend/src/pages/MobileDeal.vue:407
+msgid "Deals"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:92
+msgid "Dear {{ lead_name }}, \\n\\nThis is a reminder for the payment of {{ grand_total }}. \\n\\nThanks, \\nFrappé"
+msgstr ""
+
+#. Label of the default (Check) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Default"
+msgstr ""
+
+#. Label of the default_priority (Check) field in DocType 'CRM Service Level
+#. Priority'
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+msgid "Default Priority"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:33
+msgid "Default Service Level Agreement already exists for {0}"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:525
+#: frontend/src/components/ViewControls.vue:883
+msgid "Default Views"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:18
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:30
+msgid "Default statuses, custom fields and layouts restored successfully."
+msgstr ""
+
+#: frontend/src/components/Activities/NoteArea.vue:12
+#: frontend/src/components/Activities/TaskArea.vue:53
+#: frontend/src/components/Activities/TaskArea.vue:61
+#: frontend/src/components/Kanban/KanbanView.vue:224
+#: frontend/src/components/ListBulkActions.vue:96
+#: frontend/src/components/ListBulkActions.vue:104
+#: frontend/src/components/ListBulkActions.vue:186
+#: frontend/src/components/ViewControls.vue:927
+#: frontend/src/components/ViewControls.vue:938
+#: frontend/src/pages/Contact.vue:155 frontend/src/pages/Contact.vue:349
+#: frontend/src/pages/MobileDeal.vue:516 frontend/src/pages/Notes.vue:40
+#: frontend/src/pages/Organization.vue:158
+#: frontend/src/pages/Organization.vue:355 frontend/src/pages/Tasks.vue:334
+msgid "Delete"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:26
+msgid "Delete & Restore"
+msgstr ""
+
+#: frontend/src/components/Activities/TaskArea.vue:57
+msgid "Delete Task"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:923
+#: frontend/src/components/ViewControls.vue:931
+msgid "Delete View"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:345
+msgid "Delete contact"
+msgstr ""
+
+#: frontend/src/pages/Organization.vue:351
+msgid "Delete organization"
+msgstr ""
+
+#: frontend/src/components/ListBulkActions.vue:114
+msgid "Deleted successfully"
+msgstr ""
+
+#. Label of the description (Text Editor) field in DocType 'CRM Holiday'
+#. Label of the description (Text Editor) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: frontend/src/components/Modals/TaskModal.vue:50
+msgid "Description"
+msgstr ""
+
+#: frontend/src/components/Apps.vue:58
+msgid "Desk"
+msgstr ""
+
+#. Label of the details (Tab Break) field in DocType 'CRM Lead'
+#. Label of the details (Text Editor) field in DocType 'CRM Lead Source'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+#: frontend/src/pages/MobileDeal.vue:435 frontend/src/pages/MobileLead.vue:345
+msgid "Details"
+msgstr ""
+
+#. Label of the call_receiving_device (Select) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Device"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
+msgid "Disable"
+msgstr ""
+
+#: frontend/src/components/CommentBox.vue:76
+#: frontend/src/components/EmailEditor.vue:151
+msgid "Discard"
+msgstr ""
+
+#. Label of the dt (Link) field in DocType 'CRM Form Script'
+#. Label of the dt (Link) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "DocType"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:88
+msgid "Docs"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:32
+msgid "Doctype"
+msgstr ""
+
+#. Label of the dt (Link) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Document Type"
+msgstr ""
+
+#: crm/api/activities.py:15
+msgid "Document not found"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Done"
+msgstr ""
+
+#: frontend/src/components/Activities/AudioPlayer.vue:166
+#: frontend/src/components/ViewControls.vue:175
+msgid "Download"
+msgstr ""
+
+#. Label of the due_date (Datetime) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Due Date"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:15
+#: frontend/src/components/ViewControls.vue:887
+msgid "Duplicate"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:8
+msgid "Duplicate View"
+msgstr ""
+
+#. Label of the duration (Duration) field in DocType 'CRM Call Log'
+#. Label of the duration (Duration) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "Duration"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:89
+msgid "ERPNext"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "ERPNext CRM Settings"
+msgstr ""
+
+#: frontend/src/components/Settings/ERPNextSettings.vue:4
+msgid "ERPNext Settings"
+msgstr ""
+
+#: frontend/src/components/Settings/ERPNextSettings.vue:5
+msgid "ERPNext Settings updated"
+msgstr ""
+
+#. Label of the erpnext_site_url (Data) field in DocType 'ERPNext CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "ERPNext Site URL"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:23
+msgid "ERPNext is not installed in the current site"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:93
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:119
+msgid "ERPNext is not integrated with the CRM"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:100
+#: frontend/src/components/ListBulkActions.vue:179
+#: frontend/src/components/ViewControls.vue:897
+#: frontend/src/pages/Contact.vue:141 frontend/src/pages/Organization.vue:144
+msgid "Edit"
+msgstr ""
+
+#: frontend/src/components/Settings/SidePanelModal.vue:7
+msgid "Edit Field Layout"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:18
+msgid "Edit Note"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:16
+msgid "Edit Profile"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:31
+msgid "Edit Profile Photo"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:7
+msgid "Edit Quick Entry Layout"
+msgstr ""
+
+#: frontend/src/components/Modals/TaskModal.vue:18
+msgid "Edit Task"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:6
+msgid "Edit View"
+msgstr ""
+
+#: frontend/src/components/Settings/ProfileSettings.vue:14
+msgid "Edit profile"
+msgstr ""
+
+#. Label of the email (Data) field in DocType 'CRM Contacts'
+#. Label of the email (Data) field in DocType 'CRM Deal'
+#. Label of the email (Data) field in DocType 'CRM Invitation'
+#. Label of the email (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json frontend/src/pages/Contact.vue:436
+#: frontend/src/pages/Organization.vue:516
+#: frontend/src/pages/Organization.vue:544
+msgid "Email"
+msgstr ""
+
+#. Label of the email_sent_at (Datetime) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Email Sent At"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:4
+msgid "Email Templates"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:199
+msgid "Email from Lead"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:529 frontend/src/pages/Lead.vue:475
+#: frontend/src/pages/MobileDeal.vue:446 frontend/src/pages/MobileLead.vue:356
+msgid "Emails"
+msgstr ""
+
+#: frontend/src/components/ListViews/ListRows.vue:12
+msgid "Empty"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:122
+msgid "Empty - Choose a field to filter by"
+msgstr ""
+
+#: frontend/src/components/SortBy.vue:132
+msgid "Empty - Choose a field to sort by"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
+msgid "Enable"
+msgstr ""
+
+#. Label of the enabled (Check) field in DocType 'CRM Form Script'
+#. Label of the enabled (Check) field in DocType 'CRM Service Level Agreement'
+#. Label of the enabled (Check) field in DocType 'ERPNext CRM Settings'
+#. Label of the enabled (Check) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+#: frontend/src/components/Modals/EmailTemplateModal.vue:99
+msgid "Enabled"
+msgstr ""
+
+#. Label of the end_date (Date) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "End Date"
+msgstr ""
+
+#. Label of the end_time (Datetime) field in DocType 'CRM Call Log'
+#. Label of the end_time (Time) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "End Time"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:246
+msgid "Enter {0}"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:65 frontend/src/components/Filter.vue:98
+#: frontend/src/components/Filter.vue:269
+#: frontend/src/components/Filter.vue:290
+#: frontend/src/components/Filter.vue:307
+#: frontend/src/components/Filter.vue:318
+#: frontend/src/components/Filter.vue:329
+#: frontend/src/components/Filter.vue:345
+msgid "Equals"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsPage.vue:90
+#: frontend/src/pages/Lead.vue:564 frontend/src/pages/Lead.vue:574
+#: frontend/src/pages/MobileLead.vue:437 frontend/src/pages/MobileLead.vue:447
+msgid "Error"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:479 frontend/src/pages/MobileDeal.vue:396
+msgid "Error Updating Deal"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:425 frontend/src/pages/MobileLead.vue:306
+msgid "Error Updating Lead"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:466 frontend/src/pages/MobileDeal.vue:383
+msgid "Error updating deal"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:412 frontend/src/pages/MobileLead.vue:293
+msgid "Error updating lead"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:231
+msgid "Error while creating customer in ERPNext, check error log for more details"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:158
+msgid "Error while creating prospect in ERPNext, check error log for more details"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:112
+msgid "Error while fetching customer in ERPNext, check error log for more details"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:189
+#: frontend/src/components/ViewControls.vue:198
+msgid "Excel"
+msgstr ""
+
+#: frontend/src/components/Layouts/AppSidebar.vue:79
+msgid "Expand"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Expired"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:132
+#: frontend/src/components/ViewControls.vue:172
+msgid "Export"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:203
+msgid "Export All {0} Record(s)"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:185
+msgid "Export Type"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "FCRM Note"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+msgid "FCRM Settings"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Failed"
+msgstr ""
+
+#: crm/integrations/twilio/api.py:106
+msgid "Failed to capture Twilio recording"
+msgstr ""
+
+#: crm/integrations/twilio/api.py:129
+msgid "Failed to update Twilio call status"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:5
+msgid "Field"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:50
+msgid "Fields Order"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:6
+msgid "Filter"
+msgstr ""
+
+#. Label of the filters (Code) field in DocType 'CRM View Settings'
+#. Label of the filters_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Filters"
+msgstr ""
+
+#. Label of the first_name (Data) field in DocType 'CRM Deal'
+#. Label of the first_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: frontend/src/components/ColumnSettings.vue:106
+#: frontend/src/components/Filter.vue:56 frontend/src/components/Filter.vue:87
+#: frontend/src/components/SortBy.vue:6 frontend/src/components/SortBy.vue:104
+#: frontend/src/components/SortBy.vue:138
+msgid "First Name"
+msgstr ""
+
+#: frontend/src/components/Modals/LeadModal.vue:132
+msgid "First Name is mandatory"
+msgstr ""
+
+#. Label of the first_responded_on (Datetime) field in DocType 'CRM Deal'
+#. Label of the first_responded_on (Datetime) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "First Responded On"
+msgstr ""
+
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "First Response Due"
+msgstr ""
+
+#. Label of the first_response_time (Duration) field in DocType 'CRM Service
+#. Level Priority'
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+msgid "First Response TIme"
+msgstr ""
+
+#. Label of the first_response_time (Duration) field in DocType 'CRM Deal'
+#. Label of the first_response_time (Duration) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "First Response Time"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:129
+msgid "First name"
+msgstr ""
+
+#. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Form"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:19
+msgid "Form Script updated successfully"
+msgstr ""
+
+#. Name of a Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Frappe CRM"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Friday"
+msgstr ""
+
+#. Label of the from (Data) field in DocType 'CRM Call Log'
+#. Label of the from (Data) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "From"
+msgstr ""
+
+#. Label of the from_date (Date) field in DocType 'CRM Holiday List'
+#. Label of the from_date (Datetime) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "From Date"
+msgstr ""
+
+#. Label of the from_user (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "From User"
+msgstr ""
+
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
+#. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Fulfilled"
+msgstr ""
+
+#. Label of the full_name (Data) field in DocType 'CRM Contacts'
+#. Label of the lead_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Full Name"
+msgstr ""
+
+#. Label of the gender (Link) field in DocType 'CRM Contacts'
+#. Label of the gender (Link) field in DocType 'CRM Deal'
+#. Label of the gender (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Gender"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:91 frontend/src/pages/Lead.vue:141
+msgid "Go to website"
+msgstr ""
+
+#. Label of the group_by_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ViewControls.vue:290
+#: frontend/src/components/ViewControls.vue:502 frontend/src/utils/view.js:16
+msgid "Group By"
+msgstr ""
+
+#. Label of the group_by_field (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Group By Field"
+msgstr ""
+
+#: frontend/src/components/GroupBy.vue:8
+msgid "Group By: "
+msgstr ""
+
+#: frontend/src/components/CommunicationArea.vue:58
+msgid "Hi John, \\n\\nCan you please provide more details on this..."
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:195
+msgid "Hide"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:71
+msgid "Hide Recording"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:34
+#: frontend/src/components/Settings/SidePanelModal.vue:28
+msgid "Hide preview"
+msgstr ""
+
+#. Option for the 'Priority' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "High"
+msgstr ""
+
+#. Label of the holiday_list (Link) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Holiday List"
+msgstr ""
+
+#. Label of the holiday_list_name (Data) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Holiday List Name"
+msgstr ""
+
+#. Label of the holidays_section (Section Break) field in DocType 'CRM Holiday
+#. List'
+#. Label of the holidays (Table) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Holidays"
+msgstr ""
+
+#. Label of the id (Data) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: frontend/src/components/ViewControls.vue:589
+msgid "ID"
+msgstr ""
+
+#. Label of the icon (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Icon"
+msgstr ""
+
+#. Label of the image (Attach Image) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Image"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:273
+#: frontend/src/components/Filter.vue:294
+#: frontend/src/components/Filter.vue:309
+#: frontend/src/components/Filter.vue:322
+#: frontend/src/components/Filter.vue:336
+msgid "In"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "In Progress"
+msgstr ""
+
+#: frontend/src/components/SLASection.vue:75
+msgid "In less than a minute"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:35
+msgid "Inbound Call"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Incoming"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:40
+msgid "Incoming call..."
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Industries"
+msgstr ""
+
+#. Label of the industry (Link) field in DocType 'CRM Deal'
+#. Label of the industry (Data) field in DocType 'CRM Industry'
+#. Label of the industry (Link) field in DocType 'CRM Lead'
+#. Label of the industry (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Industry"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Initiated"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:35
+msgid "Initiating call..."
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:75
+msgid "Integrations"
+msgstr ""
+
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.py:33
+msgid "Invalid Account SID or Auth Token."
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:195
+#: frontend/src/components/Modals/LeadModal.vue:147
+msgid "Invalid Email"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:68
+msgid "Invite Members"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:22
+msgid "Invite as"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:8
+msgid "Invite by email"
+msgstr ""
+
+#. Label of the invited_by (Link) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Invited By"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:275
+#: frontend/src/components/Filter.vue:284
+#: frontend/src/components/Filter.vue:296
+#: frontend/src/components/Filter.vue:311
+#: frontend/src/components/Filter.vue:324
+#: frontend/src/components/Filter.vue:338
+#: frontend/src/components/Filter.vue:347
+msgid "Is"
+msgstr ""
+
+#. Label of the is_default (Check) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Is Default"
+msgstr ""
+
+#. Label of the is_erpnext_in_different_site (Check) field in DocType 'ERPNext
+#. CRM Settings'
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+msgid "Is ERPNext installed on a different site?"
+msgstr ""
+
+#. Label of the is_group (Check) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Is Group"
+msgstr ""
+
+#. Label of the is_primary (Check) field in DocType 'CRM Contacts'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+msgid "Is Primary"
+msgstr ""
+
+#. Label of the is_standard (Check) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Is Standard"
+msgstr ""
+
+#. Label of the job_title (Data) field in DocType 'CRM Deal'
+#. Label of the job_title (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Job Title"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:73 frontend/src/components/Filter.vue:106
+#: frontend/src/components/Modals/AssignmentModal.vue:35
+#: frontend/src/components/Modals/TaskModal.vue:77
+msgid "John Doe"
+msgstr ""
+
+#. Label of the kanban_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ViewControls.vue:295
+#: frontend/src/components/ViewControls.vue:491 frontend/src/utils/view.js:20
+msgid "Kanban"
+msgstr ""
+
+#. Label of the kanban_columns (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Kanban Columns"
+msgstr ""
+
+#. Label of the kanban_fields (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Kanban Fields"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanSettings.vue:3
+#: frontend/src/components/Kanban/KanbanSettings.vue:11
+msgid "Kanban Settings"
+msgstr ""
+
+#. Label of the key (Data) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Key"
+msgstr ""
+
+#. Label of the label (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ColumnSettings.vue:103
+msgid "Label"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:615
+msgid "Last 6 Months"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:607
+msgid "Last Month"
+msgstr ""
+
+#. Label of the last_name (Data) field in DocType 'CRM Deal'
+#. Label of the last_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Last Name"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:611
+msgid "Last Quarter"
+msgstr ""
+
+#. Label of the last_status_change_log (Link) field in DocType 'CRM Status
+#. Change Log'
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "Last Status Change Log"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:603
+msgid "Last Week"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:619
+msgid "Last Year"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:451 frontend/src/pages/Organization.vue:531
+#: frontend/src/pages/Organization.vue:559
+msgid "Last modified"
+msgstr ""
+
+#. Label of the layout (Code) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Layout"
+msgstr ""
+
+#. Label of the lead (Link) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Tasks.vue:130
+msgid "Lead"
+msgstr ""
+
+#. Label of the lead_details_tab (Tab Break) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Lead Details"
+msgstr ""
+
+#. Label of the lead_name (Data) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Lead Name"
+msgstr ""
+
+#. Label of the lead_owner (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Lead Owner"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:64
+msgid "Lead Owner cannot be same as the Lead Email Address"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Lead Sources"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Lead Statuses"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/api.py:15
+msgid "Lead not found"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:404 frontend/src/pages/MobileLead.vue:285
+msgid "Lead updated"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Lead.vue:436 frontend/src/pages/MobileLead.vue:317
+msgid "Leads"
+msgstr ""
+
+#. Label of the lft (Int) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Left"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:271
+#: frontend/src/components/Filter.vue:282
+#: frontend/src/components/Filter.vue:292
+#: frontend/src/components/Filter.vue:320
+#: frontend/src/components/Filter.vue:334
+msgid "Like"
+msgstr ""
+
+#. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
+#. Label of the list_tab (Tab Break) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/ViewControls.vue:285
+#: frontend/src/components/ViewControls.vue:480 frontend/src/utils/view.js:12
+msgid "List"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:71
+msgid "Listen"
+msgstr ""
+
+#. Label of the load_default_columns (Check) field in DocType 'CRM View
+#. Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Load Default Columns"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanView.vue:138
+msgid "Load More"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:21
+#: frontend/src/pages/Deal.vue:176 frontend/src/pages/MobileDeal.vue:116
+msgid "Loading..."
+msgstr ""
+
+#. Label of the log_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the log_tab (Tab Break) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Log"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:104
+msgid "Log out"
+msgstr ""
+
+#. Option for the 'Priority' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Low"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:82
+msgid "Make Call"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:912
+msgid "Make Private"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:912
+msgid "Make Public"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:342
+#: frontend/src/components/Activities/ActivityHeader.vue:36
+#: frontend/src/components/Activities/ActivityHeader.vue:128
+#: frontend/src/pages/Deals.vue:490 frontend/src/pages/Leads.vue:507
+msgid "Make a Call"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:74 frontend/src/pages/Lead.vue:116
+msgid "Make a call"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:25
+#: frontend/src/components/Settings/InviteMemberPage.vue:101
+msgid "Manager Access"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:19
+#: frontend/src/pages/MobileNotification.vue:11
+#: frontend/src/pages/MobileNotification.vue:14
+msgid "Mark all as read"
+msgstr ""
+
+#. Label of the medium (Data) field in DocType 'CRM Call Log'
+#. Option for the 'Priority' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Medium"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Mention"
+msgstr ""
+
+#. Label of the message (HTML Editor) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Message"
+msgstr ""
+
+#. Label of the middle_name (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Middle Name"
+msgstr ""
+
+#. Label of the mobile_no (Data) field in DocType 'CRM Contacts'
+#. Label of the mobile_no (Data) field in DocType 'CRM Deal'
+#. Label of the mobile_no (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Mobile No"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:191
+#: frontend/src/components/Modals/LeadModal.vue:143
+msgid "Mobile No should be a number"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:441 frontend/src/pages/Organization.vue:521
+msgid "Mobile no"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Monday"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:129 frontend/src/pages/Organization.vue:132
+msgid "More"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:42
+msgid "My Open Deals"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:21
+#: frontend/src/pages/Organization.vue:539
+msgid "Name"
+msgstr ""
+
+#. Label of the naming_series (Select) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Naming Series"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:76
+msgid "New"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:94
+msgid "New Address"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:357
+#: frontend/src/components/Activities/ActivityHeader.vue:26
+#: frontend/src/components/Activities/ActivityHeader.vue:123
+msgid "New Comment"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:352
+#: frontend/src/components/Activities/ActivityHeader.vue:16
+#: frontend/src/components/Activities/ActivityHeader.vue:118
+msgid "New Email"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:67
+msgid "New Message"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:46
+#: frontend/src/components/Activities/ActivityHeader.vue:134
+#: frontend/src/pages/Deals.vue:496 frontend/src/pages/Leads.vue:513
+msgid "New Note"
+msgstr ""
+
+#: frontend/src/components/Modals/OrganizationModal.vue:187
+msgid "New Organization"
+msgstr ""
+
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:107
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:127
+msgid "New Section"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:56
+#: frontend/src/components/Activities/ActivityHeader.vue:139
+#: frontend/src/pages/Deals.vue:501 frontend/src/pages/Leads.vue:518
+msgid "New Task"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:144
+msgid "New WhatsApp Message"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:265 frontend/src/pages/MobileLead.vue:167
+msgid "New contact will be created based on the person's details"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:239 frontend/src/pages/MobileLead.vue:141
+msgid "New organization will be created based on the data in details section"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:663
+msgid "Next 6 Months"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:655
+msgid "Next Month"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:659
+msgid "Next Quarter"
+msgstr ""
+
+#. Label of the next_step (Data) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Next Step"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:651
+msgid "Next Week"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:667
+msgid "Next Year"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "No Answer"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanView.vue:101
+#: frontend/src/pages/Deals.vue:106 frontend/src/pages/Leads.vue:122
+#: frontend/src/pages/Tasks.vue:68
+msgid "No Title"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:264 frontend/src/pages/MobileDeal.vue:204
+msgid "No contacts added"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:86 frontend/src/pages/Lead.vue:136
+msgid "No email set"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:684
+msgid "No mobile number set"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:83
+#: frontend/src/pages/MobileNotification.vue:67
+msgid "No new notifications"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:123
+msgid "No phone number set"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:679
+msgid "No primary contact set"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:52
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:42
+msgid "No templates found"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:98 frontend/src/pages/Lead.vue:148
+msgid "No website set"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:162
+msgid "No {0} Available"
+msgstr ""
+
+#: frontend/src/pages/CallLogs.vue:50 frontend/src/pages/Contact.vue:203
+#: frontend/src/pages/Contacts.vue:56 frontend/src/pages/Deals.vue:232
+#: frontend/src/pages/EmailTemplates.vue:57 frontend/src/pages/Leads.vue:258
+#: frontend/src/pages/Notes.vue:92 frontend/src/pages/Organization.vue:213
+#: frontend/src/pages/Organizations.vue:56 frontend/src/pages/Tasks.vue:181
+msgid "No {0} Found"
+msgstr ""
+
+#. Label of the no_of_employees (Select) field in DocType 'CRM Deal'
+#. Label of the no_of_employees (Select) field in DocType 'CRM Lead'
+#. Label of the no_of_employees (Select) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "No. of Employees"
+msgstr ""
+
+#: frontend/src/components/Activities/AudioPlayer.vue:148
+msgid "Normal"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:270
+#: frontend/src/components/Filter.vue:291
+#: frontend/src/components/Filter.vue:308
+#: frontend/src/components/Filter.vue:319
+#: frontend/src/components/Filter.vue:346
+msgid "Not Equals"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:274
+#: frontend/src/components/Filter.vue:295
+#: frontend/src/components/Filter.vue:310
+#: frontend/src/components/Filter.vue:323
+#: frontend/src/components/Filter.vue:337
+msgid "Not In"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:272
+#: frontend/src/components/Filter.vue:283
+#: frontend/src/components/Filter.vue:293
+#: frontend/src/components/Filter.vue:321
+#: frontend/src/components/Filter.vue:335
+msgid "Not Like"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:10
+#: frontend/src/components/Settings/SettingsPage.vue:7
+#: frontend/src/components/Settings/SidePanelModal.vue:10
+msgid "Not Saved"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:204
+msgid "Not allowed to add contact to Deal"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_lead/crm_lead.py:340
+msgid "Not allowed to convert Lead to Deal"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:214
+msgid "Not allowed to remove contact from Deal"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:224
+msgid "Not allowed to set primary contact for Deal"
+msgstr ""
+
+#. Label of the note (Link) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Note"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:550 frontend/src/pages/Lead.vue:496
+#: frontend/src/pages/MobileDeal.vue:467 frontend/src/pages/MobileLead.vue:377
+msgid "Notes"
+msgstr ""
+
+#: frontend/src/pages/Notes.vue:20
+msgid "Notes View"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:13
+msgid "Notification"
+msgstr ""
+
+#. Label of the notification_text (Text) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Notification Text"
+msgstr ""
+
+#. Label of the notification_type_doc (Dynamic Link) field in DocType 'CRM
+#. Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Notification Type Doc"
+msgstr ""
+
+#. Label of the notification_type_doctype (Link) field in DocType 'CRM
+#. Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Notification Type Doctype"
+msgstr ""
+
+#: frontend/src/components/Layouts/AppSidebar.vue:13
+#: frontend/src/components/Mobile/MobileSidebar.vue:21
+#: frontend/src/components/Notifications.vue:17
+#: frontend/src/pages/MobileNotification.vue:6
+msgid "Notifications"
+msgstr ""
+
+#. Label of the old_parent (Link) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Old Parent"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:329 frontend/src/pages/Lead.vue:525
+#: frontend/src/pages/Organization.vue:335
+msgid "Only PNG and JPG images are allowed"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.py:55
+msgid "Only one {0} can be set as primary."
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:26
+#: frontend/src/components/Modals/TaskModal.vue:26
+msgid "Open Deal"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:27
+#: frontend/src/components/Modals/TaskModal.vue:27
+msgid "Open Lead"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_deal/crm_deal.js:6
+#: crm/fcrm/doctype/crm_lead/crm_lead.js:6
+msgid "Open in Portal"
+msgstr ""
+
+#: frontend/src/components/Kanban/KanbanView.vue:220
+#: frontend/src/components/ViewControls.vue:128
+msgid "Options"
+msgstr ""
+
+#. Label of the order_by_tab (Tab Break) field in DocType 'CRM View Settings'
+#. Label of the order_by (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Order By"
+msgstr ""
+
+#. Label of the organization (Link) field in DocType 'CRM Deal'
+#. Label of the organization_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the organization (Data) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json frontend/src/pages/Contact.vue:421
+#: frontend/src/pages/Lead.vue:221 frontend/src/pages/MobileLead.vue:123
+#: frontend/src/pages/Organization.vue:501
+#: frontend/src/pages/Organization.vue:554
+msgid "Organization"
+msgstr ""
+
+#. Label of the organization_details_section (Section Break) field in DocType
+#. 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Organization Details"
+msgstr ""
+
+#. Label of the organization_logo (Attach Image) field in DocType 'CRM
+#. Organization'
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Organization Logo"
+msgstr ""
+
+#. Label of the organization_name (Data) field in DocType 'CRM Deal'
+#. Label of the organization_name (Data) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Organization Name"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:57
+msgid "Organization logo"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+#: frontend/src/pages/Organization.vue:295
+msgid "Organizations"
+msgstr ""
+
+#. Label of the organization_tab (Tab Break) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Others"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:36
+msgid "Outbound Call"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Outgoing"
+msgstr ""
+
+#. Label of the log_owner (Link) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "Owner"
+msgstr ""
+
+#. Label of the parent_crm_territory (Link) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Parent CRM Territory"
+msgstr ""
+
+#: crm/api/demo.py:21 crm/api/demo.py:31
+msgid "Password cannot be reset by Demo User {}"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:28
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:11
+msgid "Payment Reminder"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:50
+msgid "Payment Reminder from Frappé - (#{{ name }})"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Pending"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:34
+msgid "Pending Invites"
+msgstr ""
+
+#. Label of the person_section (Section Break) field in DocType 'CRM Deal'
+#. Label of the person_tab (Tab Break) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Person"
+msgstr ""
+
+#. Label of the phone (Data) field in DocType 'CRM Contacts'
+#. Label of the phone (Data) field in DocType 'CRM Deal'
+#. Label of the phone (Data) field in DocType 'CRM Lead'
+#. Option for the 'Device' (Select) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/crm_contacts/crm_contacts.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+#: frontend/src/pages/Organization.vue:549
+msgid "Phone"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:904
+msgid "Pin View"
+msgstr ""
+
+#. Label of the pinned (Check) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Pinned"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:568
+msgid "Pinned Views"
+msgstr ""
+
+#: frontend/src/components/Activities/AudioPlayer.vue:176
+msgid "Playback speed"
+msgstr ""
+
+#: crm/integrations/twilio/twilio_handler.py:124
+msgid "Please enable twilio settings before making a call."
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:565 frontend/src/pages/MobileLead.vue:438
+msgid "Please select an existing contact"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:575 frontend/src/pages/MobileLead.vue:448
+msgid "Please select an existing organization"
+msgstr ""
+
+#. Label of the position (Int) field in DocType 'CRM Deal Status'
+#. Label of the position (Int) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "Position"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:208 frontend/src/pages/MobileDeal.vue:148
+msgid "Primary"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:654 frontend/src/pages/MobileDeal.vue:571
+msgid "Primary contact set"
+msgstr ""
+
+#. Label of the priorities (Table) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Priorities"
+msgstr ""
+
+#. Label of the priority (Link) field in DocType 'CRM Service Level Priority'
+#. Label of the priority (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Priority"
+msgstr ""
+
+#. Label of the probability (Percent) field in DocType 'CRM Deal'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+msgid "Probability"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:63
+msgid "Profile"
+msgstr ""
+
+#. Label of the public (Check) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Public"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:563
+msgid "Public Views"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Queued"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Quick Entry"
+msgstr ""
+
+#. Label of the read (Check) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Read"
+msgstr ""
+
+#. Label of the record_calls (Check) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Record Calls"
+msgstr ""
+
+#. Label of the recording_url (Data) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Recording URL"
+msgstr ""
+
+#. Label of the reference_name (Dynamic Link) field in DocType 'CRM
+#. Notification'
+#. Label of the reference_docname (Dynamic Link) field in DocType 'CRM Task'
+#. Label of the reference_docname (Dynamic Link) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "Reference Doc"
+msgstr ""
+
+#. Label of the reference_doctype (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Reference Doctype"
+msgstr ""
+
+#. Label of the reference_doctype (Link) field in DocType 'CRM Call Log'
+#. Label of the reference_doctype (Link) field in DocType 'CRM Task'
+#. Label of the reference_doctype (Link) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "Reference Document Type"
+msgstr ""
+
+#. Label of the reference_docname (Dynamic Link) field in DocType 'CRM Call
+#. Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Reference Name"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:25
+#: frontend/src/components/ViewControls.vue:87
+msgid "Refresh"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:24
+#: frontend/src/components/Settings/InviteMemberPage.vue:100
+msgid "Regular Access"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:103
+msgid "Reject"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:599
+msgid "Remove"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:37 frontend/src/pages/Lead.vue:89
+#: frontend/src/pages/Organization.vue:40
+msgid "Remove image"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:31
+#: frontend/src/components/CommunicationArea.vue:8
+msgid "Reply"
+msgstr ""
+
+#: frontend/src/components/Activities/EmailArea.vue:44
+msgid "Reply All"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:56
+#: frontend/src/components/Settings/SidePanelModal.vue:71
+msgid "Reset"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:76
+msgid "Reset Changes"
+msgstr ""
+
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:7
+msgid "Reset ERPNext Form Script"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:87
+msgid "Reset to Default"
+msgstr ""
+
+#. Label of the response_by (Datetime) field in DocType 'CRM Deal'
+#. Label of the response_by (Datetime) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Response By"
+msgstr ""
+
+#. Label of the response_details_section (Section Break) field in DocType 'CRM
+#. Deal'
+#. Label of the response_details_section (Section Break) field in DocType 'CRM
+#. Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Response Details"
+msgstr ""
+
+#. Label of the section_break_ufaf (Section Break) field in DocType 'CRM
+#. Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Response and Follow Up"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:14
+msgid "Restore"
+msgstr ""
+
+#. Label of the restore_defaults (Button) field in DocType 'FCRM Settings'
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:13
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+msgid "Restore Defaults"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:62
+msgid "Rich Text"
+msgstr ""
+
+#. Label of the rgt (Int) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Right"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+msgid "Ringing"
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:37 frontend/src/components/CallUI.vue:146
+msgid "Ringing..."
+msgstr ""
+
+#. Label of the role (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+msgid "Role"
+msgstr ""
+
+#. Label of the route_name (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Route Name"
+msgstr ""
+
+#. Label of the rows (Code) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Rows"
+msgstr ""
+
+#. Label of the sla_tab (Tab Break) field in DocType 'CRM Deal'
+#. Label of the sla (Link) field in DocType 'CRM Deal'
+#. Label of the sla_tab (Tab Break) field in DocType 'CRM Lead'
+#. Label of the sla (Link) field in DocType 'CRM Lead'
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "SLA"
+msgstr ""
+
+#. Label of the sla_creation (Datetime) field in DocType 'CRM Deal'
+#. Label of the sla_creation (Datetime) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "SLA Creation"
+msgstr ""
+
+#. Label of the sla_name (Data) field in DocType 'CRM Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "SLA Name"
+msgstr ""
+
+#. Label of the sla_status (Select) field in DocType 'CRM Deal'
+#. Label of the sla_status (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "SLA Status"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:75
+msgid "SUBJECT"
+msgstr ""
+
+#. Name of a role
+#. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Sales Manager"
+msgstr ""
+
+#. Name of a role
+#. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_industry/crm_industry.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+msgid "Sales User"
+msgstr ""
+
+#. Label of the salutation (Link) field in DocType 'CRM Deal'
+#. Label of the salutation (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Salutation"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Saturday"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:99
+#: frontend/src/components/Modals/OrganizationModal.vue:194
+#: frontend/src/components/Modals/QuickEntryModal.vue:52
+#: frontend/src/components/Settings/ProfileSettings.vue:52
+#: frontend/src/components/Settings/SidePanelModal.vue:67
+msgid "Save"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:13
+#: frontend/src/components/ViewControls.vue:57
+#: frontend/src/components/ViewControls.vue:84
+msgid "Save Changes"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:558
+msgid "Saved Views"
+msgstr ""
+
+#. Label of the script (Code) field in DocType 'CRM Form Script'
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.json
+msgid "Script"
+msgstr ""
+
+#: frontend/src/components/Fields.vue:244
+msgid "Select {0}"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:155
+msgid "Send"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:67
+msgid "Send Invites"
+msgstr ""
+
+#: frontend/src/components/Settings/InviteMemberPage.vue:4
+msgid "Send Invites To"
+msgstr ""
+
+#: frontend/src/components/Activities/ActivityHeader.vue:60
+msgid "Send Template"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:79 frontend/src/pages/Lead.vue:129
+msgid "Send an email"
+msgstr ""
+
+#. Label of the naming_series (Select) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Series"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:68
+msgid "Set an organization"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:607 frontend/src/pages/MobileDeal.vue:524
+msgid "Set as Primary Contact"
+msgstr ""
+
+#: frontend/src/pages/Lead.vue:110
+msgid "Set first name"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:7
+#: frontend/src/components/Settings/SettingsModal.vue:59
+#: frontend/src/components/UserDropdown.vue:99
+msgid "Settings"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:195
+msgid "Show"
+msgstr ""
+
+#: frontend/src/components/Modals/QuickEntryModal.vue:34
+#: frontend/src/components/Settings/SidePanelModal.vue:28
+msgid "Show preview"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+msgid "Side Panel"
+msgstr ""
+
+#. Description of the 'Condition' (Code) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Simple Python Expression, Example: doc.status == 'Open' and doc.lead_source == 'Ads'"
+msgstr ""
+
+#: frontend/src/components/SortBy.vue:10 frontend/src/components/SortBy.vue:22
+#: frontend/src/components/SortBy.vue:240
+msgid "Sort"
+msgstr ""
+
+#. Label of the source (Link) field in DocType 'CRM Deal'
+#. Label of the source (Link) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: frontend/src/components/Modals/EditValueModal.vue:10
+msgid "Source"
+msgstr ""
+
+#. Label of the source_name (Data) field in DocType 'CRM Lead Source'
+#: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
+msgid "Source Name"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.js:15
+msgid "Standard Form Scripts can not be modified, duplicate the Form Script instead."
+msgstr ""
+
+#. Label of the start_date (Date) field in DocType 'CRM Service Level
+#. Agreement'
+#. Label of the start_date (Date) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Start Date"
+msgstr ""
+
+#. Label of the start_time (Datetime) field in DocType 'CRM Call Log'
+#. Label of the start_time (Time) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Start Time"
+msgstr ""
+
+#. Label of the status (Select) field in DocType 'CRM Call Log'
+#. Label of the status (Data) field in DocType 'CRM Communication Status'
+#. Label of the status (Link) field in DocType 'CRM Deal'
+#. Label of the deal_status (Data) field in DocType 'CRM Deal Status'
+#. Label of the status (Select) field in DocType 'CRM Invitation'
+#. Label of the status (Link) field in DocType 'CRM Lead'
+#. Label of the lead_status (Data) field in DocType 'CRM Lead Status'
+#. Label of the status (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+#: crm/fcrm/doctype/crm_task/crm_task.json frontend/src/pages/Contact.vue:431
+#: frontend/src/pages/Organization.vue:511
+msgid "Status"
+msgstr ""
+
+#. Label of the status_change_log (Table) field in DocType 'CRM Deal'
+#. Label of the status_change_log (Table) field in DocType 'CRM Lead'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+msgid "Status Change Log"
+msgstr ""
+
+#: frontend/src/components/Modals/DealModal.vue:199
+#: frontend/src/components/Modals/LeadModal.vue:151
+msgid "Status is required"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateModal.vue:43
+msgid "Subject"
+msgstr ""
+
+#: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:31
+msgid "Subject: {0}"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsPage.vue:82
+msgid "Success"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Sunday"
+msgstr ""
+
+#: frontend/src/components/UserDropdown.vue:83
+msgid "Support"
+msgstr ""
+
+#. Name of a role
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+#: crm/fcrm/doctype/crm_invitation/crm_invitation.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "System Manager"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:22
+msgid "TO"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "Task"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:545 frontend/src/pages/Lead.vue:491
+#: frontend/src/pages/MobileDeal.vue:462 frontend/src/pages/MobileLead.vue:372
+msgid "Tasks"
+msgstr ""
+
+#. Label of a shortcut in the Frappe CRM Workspace
+#: crm/fcrm/workspace/frappe_crm/frappe_crm.json
+msgid "Territories"
+msgstr ""
+
+#. Label of the territory (Link) field in DocType 'CRM Deal'
+#. Label of the territory (Link) field in DocType 'CRM Lead'
+#. Label of the territory (Link) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Territory"
+msgstr ""
+
+#. Label of the territory_manager (Link) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Territory Manager"
+msgstr ""
+
+#. Label of the territory_name (Data) field in DocType 'CRM Territory'
+#: crm/fcrm/doctype/crm_territory/crm_territory.json
+msgid "Territory Name"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:46
+msgid "The Condition '{0}' is invalid: {1}"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.js:14
+msgid "There can only be one default priority in Priorities table"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:639
+msgid "This Month"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:643
+msgid "This Quarter"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:635
+msgid "This Week"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:647
+msgid "This Year"
+msgstr ""
+
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:114
+msgid "This section is not editable"
+msgstr ""
+
+#: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:9
+msgid "This will restore (if not exist) all the default statuses, custom fields and layouts. Delete & Restore will delete default layouts and then restore them."
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Thursday"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:353
+msgid "Timespan"
+msgstr ""
+
+#. Label of the title (Data) field in DocType 'CRM Task'
+#. Label of the title (Data) field in DocType 'FCRM Note'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+#: crm/fcrm/doctype/fcrm_note/fcrm_note.json
+#: frontend/src/components/Modals/NoteModal.vue:40
+#: frontend/src/components/Modals/TaskModal.vue:40
+msgid "Title"
+msgstr ""
+
+#. Label of the title_field (Data) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: frontend/src/components/Kanban/KanbanSettings.vue:31
+msgid "Title Field"
+msgstr ""
+
+#. Label of the to (Data) field in DocType 'CRM Call Log'
+#. Label of the to (Data) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+#: frontend/src/components/Activities/EmailArea.vue:63
+msgid "To"
+msgstr ""
+
+#. Label of the to_date (Date) field in DocType 'CRM Holiday List'
+#. Label of the to_date (Datetime) field in DocType 'CRM Status Change Log'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+msgid "To Date"
+msgstr ""
+
+#. Label of the to_user (Link) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+msgid "To User"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:627
+msgid "Today"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'CRM Task'
+#: crm/fcrm/doctype/crm_task/crm_task.json
+msgid "Todo"
+msgstr ""
+
+#: frontend/src/components/Settings/SidePanelModal.vue:58
+msgid "Toggle on for preview"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:631
+msgid "Tomorrow"
+msgstr ""
+
+#: frontend/src/components/Modals/NoteModal.vue:58
+#: frontend/src/components/Modals/TaskModal.vue:60
+msgid "Took a call with John Doe and discussed the new project."
+msgstr ""
+
+#. Label of the total_holidays (Int) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Total Holidays"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Tuesday"
+msgstr ""
+
+#. Label of the twiml_sid (Data) field in DocType 'Twilio Settings'
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "TwiML SID"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsModal.vue:78
+msgid "Twilio"
+msgstr ""
+
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.py:61
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.py:62
+msgid "Twilio API credential creation error."
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Twilio Agents"
+msgstr ""
+
+#. Label of the twilio_number (Data) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "Twilio Number"
+msgstr ""
+
+#. Name of a DocType
+#: crm/fcrm/doctype/twilio_settings/twilio_settings.json
+msgid "Twilio Settings"
+msgstr ""
+
+#. Label of the type (Select) field in DocType 'CRM Call Log'
+#. Label of the type (Select) field in DocType 'CRM Fields Layout'
+#. Label of the type (Select) field in DocType 'CRM Notification'
+#. Label of the type (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_call_log/crm_call_log.json
+#: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "Type"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:85
+msgid "Type your message here..."
+msgstr ""
+
+#: frontend/src/components/CallUI.vue:316
+msgid "Unknown"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:904
+msgid "Unpin View"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:762
+msgid "Unsaved Changes"
+msgstr ""
+
+#: frontend/src/components/Modals/AddressModal.vue:8
+#: frontend/src/components/Modals/ContactModal.vue:8
+#: frontend/src/components/Modals/OrganizationModal.vue:8
+#: frontend/src/components/QuickEntryLayoutBuilder.vue:14
+#: frontend/src/components/Section.vue:13
+#: frontend/src/components/Settings/SidePanelLayoutBuilder.vue:19
+#: frontend/src/pages/Deal.vue:62 frontend/src/pages/Deal.vue:70
+#: frontend/src/pages/Deal.vue:508 frontend/src/pages/Lead.vue:71
+#: frontend/src/pages/Lead.vue:112 frontend/src/pages/Lead.vue:454
+#: frontend/src/pages/MobileDeal.vue:425 frontend/src/pages/MobileLead.vue:335
+msgid "Untitled"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:132
+#: frontend/src/components/Modals/AssignmentModal.vue:17
+#: frontend/src/components/Modals/EmailTemplateModal.vue:9
+#: frontend/src/components/Modals/NoteModal.vue:8
+#: frontend/src/components/Modals/TaskModal.vue:8
+#: frontend/src/components/Settings/SettingsPage.vue:26
+#: frontend/src/components/ViewControls.vue:767
+msgid "Update"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:30
+msgid "Update {0} Records"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:132
+msgid "Upload Document"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:140
+msgid "Upload Image"
+msgstr ""
+
+#: frontend/src/components/Activities/WhatsAppBox.vue:148
+msgid "Upload Video"
+msgstr ""
+
+#: frontend/src/pages/Contact.vue:32 frontend/src/pages/Lead.vue:84
+#: frontend/src/pages/Organization.vue:35
+msgid "Upload image"
+msgstr ""
+
+#. Label of the user (Link) field in DocType 'CRM View Settings'
+#. Label of the user (Link) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "User"
+msgstr ""
+
+#. Label of the user_name (Data) field in DocType 'Twilio Agents'
+#: crm/fcrm/doctype/twilio_agents/twilio_agents.json
+msgid "User Name"
+msgstr ""
+
+#. Label of the section_break_nevd (Section Break) field in DocType 'CRM
+#. Service Level Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Validity"
+msgstr ""
+
+#: frontend/src/components/Modals/EditValueModal.vue:14
+msgid "Value"
+msgstr ""
+
+#: frontend/src/components/Modals/ViewModal.vue:25
+msgid "View Name"
+msgstr ""
+
+#. Label of the website (Data) field in DocType 'CRM Deal'
+#. Label of the website (Data) field in DocType 'CRM Lead'
+#. Label of the website (Data) field in DocType 'CRM Organization'
+#: crm/fcrm/doctype/crm_deal/crm_deal.json
+#: crm/fcrm/doctype/crm_lead/crm_lead.json
+#: crm/fcrm/doctype/crm_organization/crm_organization.json
+msgid "Website"
+msgstr ""
+
+#. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
+#. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Wednesday"
+msgstr ""
+
+#. Label of the weekly_off (Check) field in DocType 'CRM Holiday'
+#. Label of the weekly_off (Select) field in DocType 'CRM Holiday List'
+#: crm/fcrm/doctype/crm_holiday/crm_holiday.json
+#: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
+msgid "Weekly Off"
+msgstr ""
+
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:11
+msgid "Welcome Message"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM Notification'
+#: crm/fcrm/doctype/crm_notification/crm_notification.json
+#: frontend/src/components/Settings/SettingsModal.vue:83
+#: frontend/src/pages/Deal.vue:555 frontend/src/pages/Lead.vue:501
+#: frontend/src/pages/MobileDeal.vue:472 frontend/src/pages/MobileLead.vue:382
+msgid "WhatsApp"
+msgstr ""
+
+#: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:4
+msgid "WhatsApp Templates"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:42 frontend/src/components/Filter.vue:80
+msgid "Where"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:111
+msgid "Width"
+msgstr ""
+
+#: frontend/src/components/ColumnSettings.vue:116
+msgid "Width can be in number, pixel or rem (eg. 3, 30px, 10rem)"
+msgstr ""
+
+#. Label of the workday (Select) field in DocType 'CRM Service Day'
+#: crm/fcrm/doctype/crm_service_day/crm_service_day.json
+msgid "Workday"
+msgstr ""
+
+#. Label of the section_break_rmgo (Section Break) field in DocType 'CRM
+#. Service Level Agreement'
+#. Label of the working_hours (Table) field in DocType 'CRM Service Level
+#. Agreement'
+#: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
+msgid "Working Hours"
+msgstr ""
+
+#: frontend/src/components/Filter.vue:623
+msgid "Yesterday"
+msgstr ""
+
+#: crm/api/whatsapp.py:221 crm/api/whatsapp.py:240
+#: frontend/src/components/Activities/WhatsAppArea.vue:34
+#: frontend/src/components/Activities/WhatsAppBox.vue:14
+msgid "You"
+msgstr ""
+
+#: frontend/src/components/ViewControls.vue:763
+msgid "You have unsaved changes. Do you want to save them?"
+msgstr ""
+
+#: crm/fcrm/doctype/crm_form_script/crm_form_script.py:24
+msgid "You need to be in developer mode to edit a Standard Form Script"
+msgstr ""
+
+#: crm/api/todo.py:24
+msgid "Your assignment on {0} {1} has been removed by {2}"
+msgstr ""
+
+#: frontend/src/components/Activities/CommentArea.vue:9
+msgid "added a"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "amber"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "black"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "blue"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:197
+msgid "changes from"
+msgstr ""
+
+#: frontend/src/components/Activities/CommentArea.vue:11
+msgid "comment"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "cyan"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "gray"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "green"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "group_by"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:16
+msgid "has made a call"
+msgstr ""
+
+#: frontend/src/components/Activities/CallArea.vue:15
+msgid "has reached out"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "kanban"
+msgstr ""
+
+#: crm/api/doc.py:35 crm/api/doc.py:155 crm/api/doc.py:412
+msgid "label"
+msgstr ""
+
+#. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
+#: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
+msgid "list"
+msgstr ""
+
+#: frontend/src/components/Notifications.vue:65
+#: frontend/src/pages/MobileNotification.vue:52
+msgid "mentioned you in {0}"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "orange"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "pink"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "purple"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "red"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "teal"
+msgstr ""
+
+#: frontend/src/components/Activities/Activities.vue:239
+#: frontend/src/components/Activities/Activities.vue:302
+msgid "to"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "violet"
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
+#. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
+#: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+#: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
+msgid "yellow"
+msgstr ""
+
+#: crm/api/todo.py:28
+msgid "{0} assigned a {1} {2} to you"
+msgstr ""
+
+#: frontend/src/pages/Deal.vue:480 frontend/src/pages/Lead.vue:426
+#: frontend/src/pages/MobileDeal.vue:397 frontend/src/pages/MobileLead.vue:307
+msgid "{0} is a required field"
+msgstr ""
+
+#: frontend/src/components/EmailEditor.vue:28
+#: frontend/src/components/EmailEditor.vue:58
+#: frontend/src/components/EmailEditor.vue:70
+#: frontend/src/components/Settings/InviteMemberPage.vue:14
+msgid "{0} is an invalid email address"
+msgstr ""
+
+#: frontend/src/components/Settings/SettingsPage.vue:156
+msgid "{0} is mandatory"
+msgstr ""
+


### PR DESCRIPTION
This PR is a complete translation of frappe CRM in French.
Every pair in the *.po file has been completed except where it was the same (but I could do that as well if you prefer).

A lot of translations are still missing in the UI but I wonder if they may come from ERPNext or Frappe ? 
Let me know and I'll go fix it wherever I can.

Thanks for an awesome work on Frappe CRM, it's a joy to use.
Antoine.