### PR TITLE
fix: docker install steps in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,41 @@
 
 ## Getting Started
 
-### Cloud Hosting
+### Managed Hosting
 
 Get started with your personal or business site with a few clicks on [Frappe Cloud](https://frappecloud.com/marketplace/apps/crm).
+
+### Docker (Recommended)
+
+The quickest way to set up Frappe CRM and take it for a test ride.
+
+Frappe framework is multi-tenant and supports multiple apps by default. This docker compose is just a standalone version with Frappe CRM pre-installed. Just put it behind your desired reverse-proxy if needed, and you're good to go.  
+  
+If you wish to use multiple Frappe apps or need multi-tenancy. Take a look at our production ready self-hosted workflow, or join us on Frappe Cloud to get first party support and hassle-free hosting.
+
+**Step 1**: Setup folder and download the required files
+
+    mkdir frappe-crm
+    cd frappe-crm
+
+**Step 2**: Download the required files
+
+Docker Compose File:
+
+    wget -O docker-compose.yml https://raw.githubusercontent.com/frappe/crm/develop/docker/docker-compose.yml
+
+Frappe CRM bench setup script
+
+    wget -O init.sh https://raw.githubusercontent.com/frappe/crm/develop/docker/init.sh
+
+**Step 3**: Run the container and daemonize it
+
+    docker compose up -d
+
+**Step 4**: The site [http://crm.localhost](http://crm.localhost) should now be available. The default credentials are:
+
+> username: administrator  
+> password: admin
 
 ### Self-hosting
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 name: crm
 services:
   mariadb:
-    image: mariadb:10.6
+    image: mariadb:10.8
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -22,7 +22,7 @@ bench set-redis-socketio-host redis:6379
 sed -i '/redis/d' ./Procfile
 sed -i '/watch/d' ./Procfile
 
-bench get-app crm
+bench get-app crm --branch develop
 
 bench new-site crm.localhost \
     --force \
@@ -34,7 +34,6 @@ bench --site crm.localhost install-app crm
 bench --site crm.localhost set-config developer_mode 1
 bench --site crm.localhost clear-cache
 bench --site crm.localhost set-config mute_emails 1
-bench --site crm.localhost add-user alex@example.com --first-name Alex --last-name Scott --password 123 --user-type 'System User' --add-role 'crm Admin'
 bench use crm.localhost
 
 bench start


### PR DESCRIPTION
### Docker (Recommended)

The quickest way to set up Frappe CRM and take it for a test ride.

Frappe framework is multi-tenant and supports multiple apps by default. This docker compose is just a standalone version with Frappe CRM pre-installed. Just put it behind your desired reverse-proxy if needed, and you're good to go.  

If you wish to use multiple Frappe apps or need multi-tenancy. Take a look at our production ready self-hosted workflow, or join us on Frappe Cloud to get first party support and hassle-free hosting.

**Step 1**: Setup folder and download the required files

    mkdir frappe-crm
    cd frappe-crm

**Step 2**: Download the required files

Docker Compose File:

    wget -O docker-compose.yml https://raw.githubusercontent.com/frappe/crm/develop/docker/docker-compose.yml

Frappe CRM bench setup script

    wget -O init.sh https://raw.githubusercontent.com/frappe/crm/develop/docker/init.sh

**Step 3**: Run the container and daemonize it

    docker compose up -d

**Step 4**: The site [http://crm.localhost/](http://crm.localhost/) should now be available. The default credentials are:

> username: administrator  
> password: admin