### PR TITLE
chore: renamed Amount to Annual Revenue

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -73,7 +73,7 @@
    "fetch_from": ".annual_revenue",
    "fieldname": "annual_revenue",
    "fieldtype": "Currency",
-   "label": "Amount",
+   "label": "Annual Revenue",
    "options": "currency"
   },
   {
@@ -338,7 +338,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-17 18:34:15.873610",
+ "modified": "2024-12-11 14:31:41.058895",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Deal",


### PR DESCRIPTION
Renamed `Amount` to `Annual Revenue` to keep it consistent over Lead & Deal.