### PR TITLE
Error on migrate when installing crm

### DIFF
--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
@@ -41,7 +41,9 @@ def sync_table(key, hook):
 	count = 0  # maintain count because list may come from seperate apps
 	for item in frappe.get_hooks(hook):
 		if item.get("name1") not in existing_items:
-			crm_settings.append(key, item, count)
+			new_item = item.copy()
+            		new_item["count"] = count
+            		crm_settings.append(key, new_item)
 		new_standard_items[item.get("name1")] = True
 		count += 1
 


### PR DESCRIPTION
frappe@tif:~/frappe-bench/apps$ bench migrate
Migrating [tif.com](http://tif.com/)
Updating DocTypes for frappe : [========================================] 100%
Updating DocTypes for payments : [========================================] 100%
Updating DocTypes for erpnext : [========================================] 100%
Updating DocTypes for hrms : [========================================] 100%
Updating DocTypes for account_addon : [========================================] 100%
Updating DocTypes for accounts_addon_1: [========================================] 100%
Updating DocTypes for crm : [========================================] 100%
Updating Dashboard for frappe
Updating Dashboard for payments
Updating Dashboard for erpnext
Updating Dashboard for hrms
Updating Dashboard for account_addon
Updating Dashboard for accounts_addon_1
Updating Dashboard for crm
Updating customizations for Address
Updating customizations for Contact
Queued rebuilding of search index for [tif.com](http://tif.com/)

Traceback (most recent call last):
File “/usr/lib/python3.10/runpy.py”, line 196, in _run_module_as_main
return _run_code(code, main_globals, None,
File “/usr/lib/python3.10/runpy.py”, line 86, in _run_code
exec(code, run_globals)
File “/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 114, in
main()
File “/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 20, in main
click.Group(commands=commands)(prog_name=“bench”)
File “/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py”, line 1161, in call
return self.main(*args, **kwargs)
File “/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py”, line 1082, in main
rv = self.invoke(ctx)
File “/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py”, line 1697, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py”, line 1697, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py”, line 1443, in invoke
return ctx.invoke(self.callback, **ctx.params)
File “/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py”, line 788, in invoke
return __callback(*args, **kwargs)
File “/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/decorators.py”, line 33, in new_func
return f(get_current_context(), *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/init.py”, line 29, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py”, line 686, in migrate
SiteMigration(
File “/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py”, line 187, in run
self.post_schema_updates()
File “/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py”, line 52, in wrapper
raise e
File “/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py”, line 44, in wrapper
ret = method(*args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py”, line 152, in post_schema_updates
frappe.get_attr(fn)()
File “/home/frappe/frappe-bench/apps/crm/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py”, line 32, in after_migrate
sync_table(“dropdown_items”, “standard_dropdown_items”)
File “/home/frappe/frappe-bench/apps/crm/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py”, line 44, in sync_table
crm_settings.append(key, item, count)
TypeError: BaseDocument.append() takes from 2 to 3 positional arguments but 4 were given
frappe@tif:~/frappe-bench/apps$