### PR TITLE
Fix unnecessary notification API reloads for all users

### DIFF
--- a/crm/fcrm/doctype/crm_notification/crm_notification.py
+++ b/crm/fcrm/doctype/crm_notification/crm_notification.py
@@ -8,7 +8,8 @@ from frappe.model.document import Document
 
 class CRMNotification(Document):
 	def on_update(self):
-		frappe.publish_realtime("crm_notification")
+		if self.to_user:
+			frappe.publish_realtime("crm_notification", user= self.to_user)
 
 def notify_user(args):
 	"""


### PR DESCRIPTION
This PR fixes the issue #594  where every user received a WebSocket event for all CRM notifications, causing unnecessary API reloads. Now, the event is emitted only for the intended recipient, reducing server load and improving efficiency.

###  **Changes Made:**
Updated `frappe.publish_realtime("crm_notification")` to send the event only to the relevant user.
<br>

###  **Before (Inefficient, Broadcasts to All Users)**
```py
frappe.publish_realtime("crm_notification")
 ```
<br>

###  **After (Optimized, Sends Only to Intended User)**
```py
frappe.publish_realtime("crm_notification", user=self.recipient)
```