### PR TITLE
Clear contact details when switching from existing to new contact

### DIFF
--- a/frontend/src/components/Modals/DealModal.vue
+++ b/frontend/src/components/Modals/DealModal.vue
@@ -190,6 +190,24 @@ function createDeal() {
   if (deal.website && !deal.website.startsWith('http')) {
     deal.website = 'https://' + deal.website
   }
+  if (chooseExistingContact.value) {
+    const contactDetailsFields = new Set(
+      tabs.data.flatMap((tab) =>
+        tab.sections
+          .filter((section) => section.name === 'contact_details_section')
+          .flatMap((section) =>
+            section.columns.flatMap((column) =>
+              column.fields.map((field) => field.fieldname),
+            ),
+          ),
+      ),
+    )
+    
+    contactDetailsFields.forEach((field) => {
+      deal[field] = null
+    })
+  } else deal['contact'] = null
+
   createResource({
     url: 'crm.fcrm.doctype.crm_deal.crm_deal.create_deal',
     params: { args: deal },

--- a/frontend/src/components/Modals/DealModal.vue
+++ b/frontend/src/components/Modals/DealModal.vue
@@ -191,21 +191,10 @@ function createDeal() {
     deal.website = 'https://' + deal.website
   }
   if (chooseExistingContact.value) {
-    const contactDetailsFields = new Set(
-      tabs.data.flatMap((tab) =>
-        tab.sections
-          .filter((section) => section.name === 'contact_details_section')
-          .flatMap((section) =>
-            section.columns.flatMap((column) =>
-              column.fields.map((field) => field.fieldname),
-            ),
-          ),
-      ),
-    )
-    
-    contactDetailsFields.forEach((field) => {
-      deal[field] = null
-    })
+    deal['first_name'] = null
+    deal['last_name'] = null
+    deal['email'] = null
+    deal['mobile_no'] = null
   } else deal['contact'] = null
 
   createResource({


### PR DESCRIPTION
This PR fixes an issue #598  where previously selected contact details remain in the form data even after switching to a new contact. Now, all contact-related fields are cleared when toggling the "Choose Existing Contact" option.

###  **Changes Made:**
✅ Clears all contact-related fields when chooseExistingContact is checked
✅ Ensures contact field is null when chooseExistingContact is unchecked
✅ Prevents unnecessary data from being sent to the API

###  **Existing Code:**
```js
...
function createDeal() {
  if (deal.website && !deal.website.startsWith('http')) {
    deal.website = 'https://' + deal.website
  }
  createResource({
    url: 'crm.fcrm.doctype.crm_deal.crm_deal.create_deal',
    params: { args: deal },
...
```
###  **Fixed Code:**
```js
...
function createDeal() {
if (deal.website && !deal.website.startsWith('http')) {
  deal.website = 'https://' + deal.website
}
if (chooseExistingContact.value) {
  const contactDetailsFields = new Set(
    tabs.data.flatMap((tab) =>
      tab.sections
        .filter((section) => section.name === 'contact_details_section')
        .flatMap((section) =>
          section.columns.flatMap((column) =>
            column.fields.map((field) => field.fieldname),
          ),
        ),
    ),
  );

  contactDetailsFields.forEach((field) => {
    deal[field] = null;
  });
} else {
  deal['contact'] = null;
}
createResource({
  url: 'crm.fcrm.doctype.crm_deal.crm_deal.create_deal',
  params: { args: deal },
...
```
###  **Impact:**
✅ Prevents unnecessary data submission
✅ Ensures correct behavior when switching between existing and new contacts
✅ Improves form validation and API efficiency

