### PR TITLE
Fix Infinite API Calls in updatePageLength

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -1053,6 +1053,7 @@ function updateCustomView() {
 }
 
 function updatePageLength(value, loadMore = false) {
+  if (list.value.loading) return
   if (!defaultParams.value) {
     defaultParams.value = getParams()
   }


### PR DESCRIPTION
This PR fixes a critical issue #628 where `crm.api.doc.get_data` was being called infinitely when pagination or refresh was clicked while a previous request was still pending.  

## **Root Cause**  
The `updatePageLength` function was not checking if a request was already in progress, leading to uncontrolled API calls.  

## **Solution**  
Added the following check at the beginning of `updatePageLength`:  
```javascript
if (list.value.loading) return
```
This prevents new API calls if a request is already in progress, effectively solving the issue.
I don't know if this is the right solution, but this seems to have fixed the problem for now.