### PR TITLE
fix: stopPropagation not found error in mobile view

### DIFF
--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -71,7 +71,7 @@
                 <component
                   :is="getValueControl(f)"
                   v-model="f.value"
-                  @change.stop="(v) => updateValue(v, f)"
+                  @change="(v) => updateValue(v, f)"
                   :placeholder="__('John Doe')"
                 />
               </div>


### PR DESCRIPTION
## Fix: Remove `stopPropagation` in Filters Component  

### Issue  
In the mobile view, `event.stopPropagation` was not found in the `Filters` component, causing unexpected behavior.  

### Fix  
- Removed `stopPropagation` to resolve the issue.  

https://github.com/user-attachments/assets/0623411f-35e8-4d39-b32d-62191089f3ee


