### PR TITLE
fix: allow Table fieldtype while converting Lead to Deal

### DIFF
--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -211,7 +211,6 @@ class CRMLead(Document):
 			"HTML",
 			"Button",
 			"Attach",
-			"Table",
 		]
 		restricted_map_fields = [
 			"name",
@@ -233,6 +232,7 @@ class CRMLead(Document):
 			"first_responded_on",
 			"communication_status",
 			"sla_creation",
+			"status_change_log",
 		]
 
 		for field in self.meta.fields:


### PR DESCRIPTION
### **Summary of Changes:**
Removed `Table` from `restricted_fieldtypes` to allow child tables in Lead-to-Deal conversion.
Added `status_change_log` to `restricted_map_fields` to prevent log data transfer.
This update ensures better flexibility in handling related data while maintaining necessary restrictions.

in class decl. of  CRM Lead, in `create_deal `function.
### Before
```python
restricted_fieldtypes = [
			"Tab Break",
			"Section Break",
			"Column Break",
			"HTML",
			"Button",
			"Attach",
			"Table",
		]
		restricted_map_fields = [
			"name",
			"naming_series",
			"creation",
			"owner",
			"modified",
			"modified_by",
			"idx",
			"docstatus",
			"status",
			"email",
			"mobile_no",
			"phone",
			"sla",
			"sla_status",
			"response_by",
			"first_response_time",
			"first_responded_on",
			"communication_status",
			"sla_creation",
		]
```
### After
```python
restricted_fieldtypes = [
			"Tab Break",
			"Section Break",
			"Column Break",
			"HTML",
			"Button",
			"Attach",
--		]
		restricted_map_fields = [
			"name",
			"naming_series",
			"creation",
			"owner",
			"modified",
			"modified_by",
			"idx",
			"docstatus",
			"status",
			"email",
			"mobile_no",
			"phone",
			"sla",
			"sla_status",
			"response_by",
			"first_response_time",
			"first_responded_on",
			"communication_status",
			"sla_creation",
++			"status_change_log",
		]
```