### PR TITLE
Fix: Currency Formatting Issue in Kanban View

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -528,6 +528,13 @@ list.value = createResource({
       page_length_count: params.page_length_count,
     }
   },
+  transform(data){
+    data.fields.forEach((field)=>{
+      field.type=field.fieldtype
+      field.key=field.fieldname
+    })
+    return data
+  }
 })
 
 onMounted(() => useDebounceFn(reload, 100)())


### PR DESCRIPTION
### Issue:
In the Kanban view, currency values were not being formatted correctly. However, formatting worked fine in List view and Group By view.

### Cause:
The `parseRows()` function relies on columns to retrieve the type of each field using:
`let fieldType = columns?.find(
  (col) => (col.key || col.value) == row,
)?.type
`

In List view and Group By view, the function was passed columns, where each object contains:
`{ key: "fieldname", type: "fieldtype" }
`

However, in Kanban view, the `getKanbanRows()` function was incorrectly passing fields instead of columns. The fields objects contain:
`{ fieldname: "fieldname", fieldtype: "fieldtype" }
`
This mismatch caused fieldType to remain undefined, breaking the formatting logic.


### Fix:
Updated the transform function in [ViewControls.vue](url) to modify fields before use:
`transform(data) {
  data.fields.forEach((field) => {
    field.type = field.fieldtype;
    field.key = field.fieldname;
  });
  return data;
}
`

Now, fields are transformed to match the expected structure of columns, ensuring the `parseRows` function can correctly apply formatting.




