### PR TITLE
fix: split by comma in 'in' filter

### DIFF
--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -535,6 +535,11 @@ function parseFilters(filters) {
     if (['equals', '='].includes(c.operator)) {
       p[c.fieldname] =
         c.value == 'Yes' ? true : c.value == 'No' ? false : c.value
+    } else if (c.operator === 'in' || c.operator === 'not in') {
+      p[c.fieldname] = [
+        operatorMap[c.operator],
+        c.value.split(',').map((v) => v.trim()),
+      ]
     } else {
       p[c.fieldname] = [operatorMap[c.operator.toLowerCase()], c.value]
     }


### PR DESCRIPTION
Earlier the "in" filter used to send this data to backend (single string):
<img width="697" alt="image" src="https://github.com/user-attachments/assets/2e54393a-0c28-4bdf-ae17-5a2d4a671da8" />

the value of the filter is a single string which should be separated by comma like this:
<img width="889" alt="image" src="https://github.com/user-attachments/assets/e094a4cd-a952-4805-bcb1-87956b8af1f0" />
