### PR TITLE
fix: improper currency formatting issue in kanban view

### DIFF
--- a/frontend/src/pages/Deals.vue
+++ b/frontend/src/pages/Deals.vue
@@ -387,9 +387,17 @@ function parseRows(rows, columns = []) {
     deals.value.data.rows.forEach((row) => {
       _rows[row] = deal[row]
 
-      let fieldType = columns?.find(
-        (col) => (col.key || col.value) == row,
-      )?.type
+      let fieldType;
+      if (deals.value.data.view_type === 'kanban') {
+        fieldType = columns?.find(
+          (col) => (col.fieldname || col.value) == row,
+        )?.fieldtype
+      }
+      else {
+        fieldType = columns?.find(
+          (col) => (col.key || col.value) == row,
+        )?.type
+      }
 
       if (
         fieldType &&

--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -407,9 +407,17 @@ function parseRows(rows, columns = []) {
     leads.value?.data.rows.forEach((row) => {
       _rows[row] = lead[row]
 
-      let fieldType = columns?.find(
-        (col) => (col.key || col.value) == row,
-      )?.type
+      let fieldType;
+      if (leads.value.data.view_type === 'kanban') {
+        fieldType = columns?.find(
+          (col) => (col.fieldname || col.value) == row,
+        )?.fieldtype
+      }
+      else {
+        fieldType = columns?.find(
+          (col) => (col.key || col.value) == row,
+        )?.type
+      }
 
       if (
         fieldType &&

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -262,9 +262,17 @@ function parseRows(rows, columns = []) {
     tasks.value?.data.rows.forEach((row) => {
       _rows[row] = task[row]
 
-      let fieldType = columns?.find(
-        (col) => (col.key || col.value) == row,
-      )?.type
+      let fieldType;
+      if (tasks.value.data.view_type === 'kanban') {
+        fieldType = columns?.find(
+          (col) => (col.fieldname || col.value) == row,
+        )?.fieldtype
+      }
+      else {
+        fieldType = columns?.find(
+          (col) => (col.key || col.value) == row,
+        )?.type
+      }
 
       if (
         fieldType &&


### PR DESCRIPTION
### ISSUE:
Currency is not being formatted inside kanban view. In other views its fine.

### CAUSE:

- Inside the `parseRows` function, the `fieldType` was being populated using the array passed into the function(`columns = []`), which contains `key` and `type.` This worked fine for other views.
- However, the Kanban view was passing a different array (`fields`) into the `getKanbanRows` function, which contains `fieldname` and `fieldtype` instead. This caused `fieldType` to be undefined for the Kanban view, as the `parseRows` function expected `key` and `type` , but `fieldname` and `fieldtype` were provided instead. As a result, currency and other fields were not formatted correctly in the Kanban view.

### FIX:
A conditional check was added in the `parseRows` function to handle different structures of the array passed into the function:

- For the Kanban view, the `fieldType` is now populated using `fieldname` and `fieldtype.`
- Else, the `fieldType` is populated using `key` and `type`.

This ensures that the `fieldType` is correctly set in both Kanban and other views, allowing proper formatting for fields like currency, date, and percent.

### ADDITIONAL INFO:

- This fix was tested to ensure that currency and other fields (like Date, Percent, and Float) are now correctly formatted in both the Kanban and other views.
- The changes do not affect the functionality or formatting in other parts of the application, and only fix the issue related to the Kanban view’s fieldtype handling.
- This anyhow is a fix limited to the pages the changes were made. Any future implications of new pages or views might not benefit from this. I shall be posting an alternative fix as well.

### BEFORE FIX:

![before kanban](https://github.com/user-attachments/assets/9ace1982-b67d-44b2-ac4e-3cc24d72f3d1)

### AFTER FIX:
![kanban after](https://github.com/user-attachments/assets/25714d15-ea5c-4c26-a9c3-3b6745664e3f)


