### PR TITLE
fix: (#2) improper currency formatting issue in kanban view

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -473,6 +473,8 @@ def get_data(
 			"fieldtype": field.fieldtype,
 			"fieldname": field.fieldname,
 			"options": field.options,
+			"type": field.fieldtype,
+   			"key": field.fieldname,
 		}
 		for field in fields
 		if field.label and field.fieldname


### PR DESCRIPTION
### ISSUE:
In the Kanban view, the currency formatting was not being applied correctly. It worked fine in other views.

### CAUSE:
The root cause was due to the mismatch in the metadata used by the `getKanbanRows` function inside pages like `Leads.vue` and `Deals.vue`. The `fields` array, which is passed into the `getKanbanRows` function, contained `fieldname` and `fieldtype,` whereas other views were using `columns` where the field information was stored with the keys `key` and `type.` This caused the `fieldType` variable inside the `parseRows` function to be undefined, resulting in the issue.

### FIX:
I modified the API to include `type` and `key` in the fields metadata. This ensures that the Kanban view now receives the necessary `type` and `key` properties for each field, which were previously missing. By updating the API to include these properties, the currency field and other types can be correctly formatted.

BEFORE FIX:
![before kanban](https://github.com/user-attachments/assets/de4bcd2f-4a27-4edd-bbcc-59c957c39286)

AFTER FIX:
![kanban after](https://github.com/user-attachments/assets/57816971-2ffe-44da-a3ea-2587d3eb752a)
