### PR TITLE
Fix: Ensure Vue 3 reactivity for form scripts after document save/reload

### DIFF
--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -1,6 +1,7 @@
 import { getScript } from '@/data/script'
 import { runSequentially } from '@/utils'
 import { createDocumentResource, toast } from 'frappe-ui'
+import { watch } from 'vue'
 
 const documentsCache = {}
 const controllersCache = {}
@@ -38,6 +39,20 @@ export function useDocument(doctype, docname) {
       documentsCache[doctype][docname],
     )
   }
+
+  // --- Ensure controllers/proxies are always up-to-date after document changes ---
+  watch(
+    () => documentsCache[doctype][docname]?.doc,
+    () => {
+      // Ensure the cache object exists
+      if (!controllersCache[doctype]) {
+        controllersCache[doctype] = {}
+      }
+      controllersCache[doctype][docname] = setupScript(documentsCache[doctype][docname])
+    },
+    { immediate: true }
+  )
+  // -----------------------------------------------------------------------------
 
   function getControllers(row = null) {
     const _doctype = row?.doctype || doctype


### PR DESCRIPTION
## What does this PR do?

- After any document update or reload (such as after saving or fetching from the server), the form scripts and their trigger methods are automatically re-initialized.
- This ensures that all injected business logic (e.g., product calculations, update_total, etc.) continues to work correctly even after saving or reloading a document.

## Why is this important?

- Previously, after saving or reloading a document, the injected business logic (such as totals calculation in product grids) would stop working because the methods and proxies were lost.
- With this change, controllers are always up-to-date, and all calculations and triggers remain functional and reactive.

## Who is this for?

- Developers using custom scripts and backend-injected business logic in the Vue 3 frontend.
- Users who experienced issues where automatic calculations and business logic stopped working after saving a document.

## How to test

1. Open any document with a grid (e.g., products).
2. Change some values — calculations should update as expected.
3. Save the document.
4. Change values again — calculations and business logic should still work as before.

---

**File changed:**  
- frontend/src/data/document.js

---

This PR does not change any business logic or affect other files. It only improves the reactivity and reliability of injected scripts after document changes.