### PR TITLE
fix(WhatsApp): prevent TypeError when concatenating first and last name

### DIFF
--- a/crm/api/whatsapp.py
+++ b/crm/api/whatsapp.py
@@ -335,5 +335,5 @@ def get_from_name(message):
 		else:
 			from_name = doc.get("lead_name")
 	else:
-		from_name = doc.get("first_name") + " " + doc.get("last_name")
+		from_name = " ".join(filter(None, [doc.get("first_name"), doc.get("last_name")]))
 	return from_name


### PR DESCRIPTION
The last name on CRM Leads can be empty. In cases where it is, an error occurs: can only concatenate str (not "NoneType") to str. This prevents retrieving messages until a last name is added.