### PR TITLE
refactor: Dashboard & categories deal status

### DIFF
--- a/crm/api/dashboard.py
+++ b/crm/api/dashboard.py
@@ -734,8 +734,10 @@ def get_deals_by_stage(from_date="", to_date="", user="", deal_conds=""):
 		f"""
 		SELECT
 			d.status AS stage,
-			COUNT(*) AS count
+			COUNT(*) AS count,
+			s.type AS status_type
 		FROM `tabCRM Deal` AS d
+		JOIN `tabCRM Deal Status` s ON d.status = s.name
 		WHERE DATE(d.creation) BETWEEN %(from)s AND %(to)s
 		{deal_conds}
 		GROUP BY d.status

--- a/crm/api/dashboard.py
+++ b/crm/api/dashboard.py
@@ -202,7 +202,7 @@ def get_won_deal_count(from_date, to_date, user="", conds="", return_result=Fals
 		f"""
 		SELECT
 			COUNT(CASE
-				WHEN d.closed_on >= %(from_date)s AND d.closed_on < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
+				WHEN d.closed_date >= %(from_date)s AND d.closed_date < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
 					AND s.type = 'Won'
 					{conds}
 				THEN d.name
@@ -210,7 +210,7 @@ def get_won_deal_count(from_date, to_date, user="", conds="", return_result=Fals
 			END) as current_month_deals,
 
 			COUNT(CASE
-				WHEN d.closed_on >= %(prev_from_date)s AND d.closed_on < %(from_date)s
+				WHEN d.closed_date >= %(prev_from_date)s AND d.closed_date < %(from_date)s
 					AND s.type = 'Won'
 					{conds}
 				THEN d.name
@@ -218,7 +218,7 @@ def get_won_deal_count(from_date, to_date, user="", conds="", return_result=Fals
 			END) as prev_month_deals,
 
 			AVG(CASE
-				WHEN d.closed_on >= %(from_date)s AND d.closed_on < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
+				WHEN d.closed_date >= %(from_date)s AND d.closed_date < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
 					AND s.type = 'Won'
 					{conds}
 				THEN d.deal_value * IFNULL(d.exchange_rate, 1)
@@ -226,7 +226,7 @@ def get_won_deal_count(from_date, to_date, user="", conds="", return_result=Fals
 			END) as current_month_avg_value,
 
 			AVG(CASE
-				WHEN d.closed_on >= %(prev_from_date)s AND d.closed_on < %(from_date)s
+				WHEN d.closed_date >= %(prev_from_date)s AND d.closed_date < %(from_date)s
 					AND s.type = 'Won'
 					{conds}
 				THEN d.deal_value * IFNULL(d.exchange_rate, 1)
@@ -353,18 +353,18 @@ def get_average_time_to_close(from_date, to_date, user="", conds="", return_resu
 	result = frappe.db.sql(
 		f"""
 		SELECT
-			AVG(CASE WHEN d.closed_on >= %(from_date)s AND d.closed_on < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
-				THEN TIMESTAMPDIFF(DAY, COALESCE(l.creation, d.creation), d.closed_on) END) as current_avg_lead,
-			AVG(CASE WHEN d.closed_on >= %(prev_from_date)s AND d.closed_on < %(prev_to_date)s
-				THEN TIMESTAMPDIFF(DAY, COALESCE(l.creation, d.creation), d.closed_on) END) as prev_avg_lead,
-			AVG(CASE WHEN d.closed_on >= %(from_date)s AND d.closed_on < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
-				THEN TIMESTAMPDIFF(DAY, d.creation, d.closed_on) END) as current_avg_deal,
-			AVG(CASE WHEN d.closed_on >= %(prev_from_date)s AND d.closed_on < %(prev_to_date)s
-				THEN TIMESTAMPDIFF(DAY, d.creation, d.closed_on) END) as prev_avg_deal
+			AVG(CASE WHEN d.closed_date >= %(from_date)s AND d.closed_date < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
+				THEN TIMESTAMPDIFF(DAY, COALESCE(l.creation, d.creation), d.closed_date) END) as current_avg_lead,
+			AVG(CASE WHEN d.closed_date >= %(prev_from_date)s AND d.closed_date < %(prev_to_date)s
+				THEN TIMESTAMPDIFF(DAY, COALESCE(l.creation, d.creation), d.closed_date) END) as prev_avg_lead,
+			AVG(CASE WHEN d.closed_date >= %(from_date)s AND d.closed_date < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
+				THEN TIMESTAMPDIFF(DAY, d.creation, d.closed_date) END) as current_avg_deal,
+			AVG(CASE WHEN d.closed_date >= %(prev_from_date)s AND d.closed_date < %(prev_to_date)s
+				THEN TIMESTAMPDIFF(DAY, d.creation, d.closed_date) END) as prev_avg_deal
 		FROM `tabCRM Deal` AS d
 		JOIN `tabCRM Deal Status` s ON d.status = s.name
 		LEFT JOIN `tabCRM Lead` l ON d.lead = l.name
-		WHERE d.closed_on IS NOT NULL AND s.type = 'Won'
+		WHERE d.closed_date IS NOT NULL AND s.type = 'Won'
 			{conds}
 		""",
 		{

--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -18,10 +18,11 @@
   "lost_notes",
   "section_break_jgpm",
   "probability",
+  "expected_deal_value",
   "deal_value",
   "column_break_kpxa",
-  "close_date",
-  "closed_on",
+  "expected_closure_date",
+  "closed_date",
   "contacts_tab",
   "contacts",
   "contact",
@@ -94,11 +95,6 @@
    "fieldname": "website",
    "fieldtype": "Data",
    "label": "Website"
-  },
-  {
-   "fieldname": "close_date",
-   "fieldtype": "Date",
-   "label": "Close Date"
   },
   {
    "fieldname": "next_step",
@@ -413,22 +409,33 @@
    "mandatory_depends_on": "eval: doc.lost_reason == \"Other\""
   },
   {
-   "fieldname": "closed_on",
-   "fieldtype": "Datetime",
-   "label": "Closed On"
-  },
-  {
    "default": "1",
    "description": "The rate used to convert the deal\u2019s currency to your crm's base currency (set in CRM Settings). It is set once when the currency is first added and doesn't change automatically.",
    "fieldname": "exchange_rate",
    "fieldtype": "Float",
    "label": "Exchange Rate"
+  },
+  {
+   "fieldname": "expected_deal_value",
+   "fieldtype": "Currency",
+   "label": "Expected Deal Value",
+   "options": "currency"
+  },
+  {
+   "fieldname": "expected_closure_date",
+   "fieldtype": "Date",
+   "label": "Expected Closure Date"
+  },
+  {
+   "fieldname": "closed_date",
+   "fieldtype": "Date",
+   "label": "Closed Date"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-09 17:58:55.956639",
+ "modified": "2025-07-13 11:54:20.608489",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Deal",

--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -166,7 +166,7 @@ class CRMDeal(Document):
 		"""
 		Validate the lost reason if the status is set to "Lost".
 		"""
-		if self.status == "Lost":
+		if self.status and frappe.get_cached_value("CRM Deal Status", self.status, "type") == "Lost":
 			if not self.lost_reason:
 				frappe.throw(_("Please specify a reason for losing the deal."), frappe.ValidationError)
 			elif self.lost_reason == "Other" and not self.lost_notes:

--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -25,8 +25,8 @@ class CRMDeal(Document):
 			self.assign_agent(self.deal_owner)
 		if self.has_value_changed("status"):
 			add_status_change_log(self)
-			if self.status == "Won":
-				self.closed_on = frappe.utils.now_datetime()
+			if frappe.db.get_value("CRM Deal Status", self.status, "type") == "Won":
+				self.closed_date = frappe.utils.nowdate()
 		self.validate_forcasting_fields()
 		self.validate_lost_reason()
 		self.update_exchange_rate()

--- a/crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
+++ b/crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
@@ -7,9 +7,11 @@
  "engine": "InnoDB",
  "field_order": [
   "deal_status",
-  "color",
+  "type",
   "position",
-  "probability"
+  "column_break_ojiu",
+  "probability",
+  "color"
  ],
  "fields": [
   {
@@ -39,12 +41,24 @@
    "fieldtype": "Percent",
    "in_list_view": 1,
    "label": "Probability"
+  },
+  {
+   "default": "Open",
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Type",
+   "options": "Open\nOngoing\nOn Hold\nWon\nLost"
+  },
+  {
+   "fieldname": "column_break_ojiu",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-01 12:06:42.937440",
+ "modified": "2025-07-11 16:03:28.077955",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Deal Status",

--- a/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
+++ b/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
@@ -160,7 +160,7 @@ def add_forecasting_section(layout, doctype):
 					"columns": [
 						{
 							"name": "column_" + str(random_string(4)),
-							"fields": ["close_date", "probability", "deal_value"],
+							"fields": ["expected_closure_date", "probability", "expected_deal_value"],
 						}
 					],
 				},

--- a/crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
+++ b/crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
@@ -13,6 +13,8 @@
   "column_break_mwmz",
   "duration",
   "last_status_change_log",
+  "from_type",
+  "to_type",
   "log_owner"
  ],
  "fields": [
@@ -61,17 +63,30 @@
    "fieldtype": "Link",
    "label": "Owner",
    "options": "User"
+  },
+  {
+   "fieldname": "from_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "From Type"
+  },
+  {
+   "fieldname": "to_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "To Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-01-06 13:26:40.597277",
+ "modified": "2025-07-13 12:37:41.278584",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Status Change Log",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.py
+++ b/crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-import frappe
 from datetime import datetime
-from frappe.utils import add_to_date, get_datetime
+
+import frappe
 from frappe.model.document import Document
+from frappe.utils import add_to_date, get_datetime
 
 
 class CRMStatusChangeLog(Document):
 	pass
+
 
 def get_duration(from_date, to_date):
 	if not isinstance(from_date, datetime):
@@ -18,28 +20,44 @@ def get_duration(from_date, to_date):
 	duration = to_date - from_date
 	return duration.total_seconds()
 
+
 def add_status_change_log(doc):
 	if not doc.is_new():
 		previous_status = doc.get_doc_before_save().status if doc.get_doc_before_save() else None
+		previous_status_type = (
+			frappe.db.get_value("CRM Deal Status", previous_status, "type") if previous_status else None
+		)
 		if not doc.status_change_log and previous_status:
 			now_minus_one_minute = add_to_date(datetime.now(), minutes=-1)
-			doc.append("status_change_log", {
-				"from": previous_status,
-				"to": "",
-				"from_date": now_minus_one_minute,
-				"to_date": "",
-				"log_owner": frappe.session.user,
-			})
+			doc.append(
+				"status_change_log",
+				{
+					"from": previous_status,
+					"from_type": previous_status_type,
+					"to": "",
+					"to_type": "",
+					"from_date": now_minus_one_minute,
+					"to_date": "",
+					"log_owner": frappe.session.user,
+				},
+			)
+		to_status_type = frappe.db.get_value("CRM Deal Status", doc.status, "type")
 		last_status_change = doc.status_change_log[-1]
 		last_status_change.to = doc.status
+		last_status_change.to_type = to_status_type
 		last_status_change.to_date = datetime.now()
 		last_status_change.log_owner = frappe.session.user
 		last_status_change.duration = get_duration(last_status_change.from_date, last_status_change.to_date)
 
-	doc.append("status_change_log", {
-		"from": doc.status,
-		"to": "",
-		"from_date": datetime.now(),
-		"to_date": "",
-		"log_owner": frappe.session.user,
-	})
+	doc.append(
+		"status_change_log",
+		{
+			"from": doc.status,
+			"from_type": to_status_type,
+			"to": "",
+			"to_type": "",
+			"from_date": datetime.now(),
+			"to_date": "",
+			"log_owner": frappe.session.user,
+		},
+	)

--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -61,7 +61,7 @@
   },
   {
    "default": "0",
-   "description": "It will make deal's \"Close Date\" & \"Deal Value\" mandatory to get accurate forecasting insights",
+   "description": "It will make deal's \"Expected Closure Date\" & \"Expected Deal Value\" mandatory to get accurate forecasting insights",
    "fieldname": "enable_forecasting",
    "fieldtype": "Check",
    "label": "Enable Forecasting"
@@ -77,7 +77,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-10 16:35:25.030011",
+ "modified": "2025-07-13 11:58:34.857638",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "FCRM Settings",

--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
@@ -38,24 +38,24 @@ class FCRMSettings(Document):
 				delete_property_setter(
 					"CRM Deal",
 					"reqd",
-					"close_date",
+					"expected_closure_date",
 				)
 				delete_property_setter(
 					"CRM Deal",
 					"reqd",
-					"deal_value",
+					"expected_deal_value",
 				)
 			else:
 				make_property_setter(
 					"CRM Deal",
-					"close_date",
+					"expected_closure_date",
 					"reqd",
 					1 if self.enable_forecasting else 0,
 					"Check",
 				)
 				make_property_setter(
 					"CRM Deal",
-					"deal_value",
+					"expected_deal_value",
 					"reqd",
 					1 if self.enable_forecasting else 0,
 					"Check",

--- a/crm/install.py
+++ b/crm/install.py
@@ -69,36 +69,43 @@ def add_default_deal_statuses():
 	statuses = {
 		"Qualification": {
 			"color": "gray",
+			"type": "Open",
 			"probability": 10,
 			"position": 1,
 		},
 		"Demo/Making": {
 			"color": "orange",
+			"type": "Ongoing",
 			"probability": 25,
 			"position": 2,
 		},
 		"Proposal/Quotation": {
 			"color": "blue",
+			"type": "Ongoing",
 			"probability": 50,
 			"position": 3,
 		},
 		"Negotiation": {
 			"color": "yellow",
+			"type": "Ongoing",
 			"probability": 70,
 			"position": 4,
 		},
 		"Ready to Close": {
 			"color": "purple",
+			"type": "Ongoing",
 			"probability": 90,
 			"position": 5,
 		},
 		"Won": {
 			"color": "green",
+			"type": "Won",
 			"probability": 100,
 			"position": 6,
 		},
 		"Lost": {
 			"color": "red",
+			"type": "Lost",
 			"probability": 0,
 			"position": 7,
 		},
@@ -111,6 +118,7 @@ def add_default_deal_statuses():
 		doc = frappe.new_doc("CRM Deal Status")
 		doc.deal_status = status
 		doc.color = statuses[status]["color"]
+		doc.type = statuses[status]["type"]
 		doc.probability = statuses[status]["probability"]
 		doc.position = statuses[status]["position"]
 		doc.insert()

--- a/crm/patches.txt
+++ b/crm/patches.txt
@@ -14,3 +14,4 @@ crm.patches.v1_0.update_layouts_to_new_format
 crm.patches.v1_0.move_twilio_agent_to_telephony_agent
 crm.patches.v1_0.create_default_scripts # 13-06-2025
 crm.patches.v1_0.update_deal_status_probabilities
+crm.patches.v1_0.update_deal_status_type

--- a/crm/patches/v1_0/update_deal_status_type.py
+++ b/crm/patches/v1_0/update_deal_status_type.py
@@ -1,0 +1,44 @@
+import frappe
+
+
+def execute():
+	deal_statuses = frappe.get_all("CRM Deal Status", fields=["name", "type", "deal_status"])
+
+	openStatuses = ["New", "Open", "Unassigned", "Qualification"]
+	ongoingStatuses = [
+		"Demo/Making",
+		"Proposal/Quotation",
+		"Negotiation",
+		"Ready to Close",
+		"Demo Scheduled",
+		"Follow Up",
+	]
+	onHoldStatuses = ["On Hold", "Paused", "Stalled", "Awaiting Reply"]
+	wonStatuses = ["Won", "Closed Won", "Successful", "Completed"]
+	lostStatuses = [
+		"Lost",
+		"Closed",
+		"Closed Lost",
+		"Junk",
+		"Unqualified",
+		"Disqualified",
+		"Cancelled",
+		"No Response",
+	]
+
+	for status in deal_statuses:
+		if status.type is None or status.type == "":
+			if status.deal_status in openStatuses:
+				type = "Open"
+			elif status.deal_status in ongoingStatuses:
+				type = "Ongoing"
+			elif status.deal_status in onHoldStatuses:
+				type = "On Hold"
+			elif status.deal_status in wonStatuses:
+				type = "Won"
+			elif status.deal_status in lostStatuses:
+				type = "Lost"
+			else:
+				type = "Ongoing"
+
+			frappe.db.set_value("CRM Deal Status", status.name, "type", type)

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -339,7 +339,7 @@ const dealsBySalesperson = createResource({
     return {
       data: r.data || [],
       title: __('Deals by Salesperson'),
-      subtitle: 'Number of deals and total value per salesperson',
+      subtitle: __('Number of deals and total value per salesperson'),
       xAxis: {
         title: __('Salesperson'),
         key: 'salesperson',

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -59,7 +59,7 @@
         doctype="User"
         :filters="{ name: ['in', users.data.crmUsers?.map((u) => u.name)] }"
         @change="(v) => updateFilter('user', v)"
-        :placeholder="__('Sales User')"
+        :placeholder="__('Sales user')"
         :hideMe="true"
       >
         <template #prefix>
@@ -110,8 +110,14 @@
           <div v-if="funnelConversion.data" class="border rounded-md min-h-80">
             <AxisChart :config="funnelConversion.data" />
           </div>
-          <div v-if="lostDealReasons.data" class="border rounded-md">
-            <AxisChart :config="lostDealReasons.data" />
+          <div v-if="dealsByStage.data" class="border rounded-md">
+            <AxisChart :config="dealsByStage.data.bar" />
+          </div>
+          <div v-if="dealsByStage.data" class="border rounded-md">
+            <DonutChart :config="dealsByStage.data.donut" />
+          </div>
+          <div v-if="leadsBySource.data" class="border rounded-md">
+            <DonutChart :config="leadsBySource.data" />
           </div>
           <div v-if="dealsByTerritory.data" class="border rounded-md">
             <AxisChart :config="dealsByTerritory.data" />
@@ -119,11 +125,8 @@
           <div v-if="dealsBySalesperson.data" class="border rounded-md">
             <AxisChart :config="dealsBySalesperson.data" />
           </div>
-          <div v-if="dealsByStage.data" class="border rounded-md">
-            <DonutChart :config="dealsByStage.data" />
-          </div>
-          <div v-if="leadsBySource.data" class="border rounded-md">
-            <DonutChart :config="leadsBySource.data" />
+          <div v-if="lostDealReasons.data" class="border rounded-md">
+            <AxisChart :config="lostDealReasons.data" />
           </div>
         </div>
       </div>
@@ -266,7 +269,7 @@ const salesTrend = createResource({
   transform(data = []) {
     return {
       data: data,
-      title: __('Sales Trend'),
+      title: __('Sales trend'),
       subtitle: __('Daily performance of leads, deals, and wins'),
       xAxis: {
         title: __('Date'),
@@ -300,7 +303,7 @@ const funnelConversion = createResource({
   transform(data = []) {
     return {
       data: data,
-      title: __('Funnel Conversion'),
+      title: __('Funnel conversion'),
       subtitle: __('Lead to deal conversion pipeline'),
       xAxis: {
         title: __('Stage'),
@@ -338,7 +341,7 @@ const dealsBySalesperson = createResource({
   transform(r = { data: [], currency_symbol: '$' }) {
     return {
       data: r.data || [],
-      title: __('Deals by Salesperson'),
+      title: __('Deals by salesperson'),
       subtitle: __('Number of deals and total value per salesperson'),
       xAxis: {
         title: __('Salesperson'),
@@ -346,10 +349,10 @@ const dealsBySalesperson = createResource({
         type: 'category' as const,
       },
       yAxis: {
-        title: __('Number of Deals'),
+        title: __('Number of deals'),
       },
       y2Axis: {
-        title: __('Deal Value') + ` (${r.currency_symbol})`,
+        title: __('Deal value') + ` (${r.currency_symbol})`,
       },
       series: [
         { name: 'deals', type: 'bar' as const },
@@ -378,7 +381,7 @@ const dealsByTerritory = createResource({
   transform(r = { data: [], currency_symbol: '$' }) {
     return {
       data: r.data || [],
-      title: __('Deals by Territory'),
+      title: __('Deals by territory'),
       subtitle: __('Geographic distribution of deals and revenue'),
       xAxis: {
         title: __('Territory'),
@@ -386,10 +389,10 @@ const dealsByTerritory = createResource({
         type: 'category' as const,
       },
       yAxis: {
-        title: __('Number of Deals'),
+        title: __('Number of deals'),
       },
       y2Axis: {
-        title: __('Deal Value') + ` (${r.currency_symbol})`,
+        title: __('Deal value') + ` (${r.currency_symbol})`,
       },
       series: [
         { name: 'deals', type: 'bar' as const },
@@ -418,7 +421,7 @@ const lostDealReasons = createResource({
   transform(data = []) {
     return {
       data: data,
-      title: __('Lost Deal Reasons'),
+      title: __('Lost deal reasons'),
       subtitle: __('Common reasons for losing deals'),
       xAxis: {
         title: __('Reason'),
@@ -444,7 +447,7 @@ const forecastedRevenue = createResource({
   transform(r = { data: [], currency_symbol: '$' }) {
     return {
       data: r.data || [],
-      title: __('Revenue Forecast'),
+      title: __('Revenue forecast'),
       subtitle: __('Projected vs actual revenue based on deal probability'),
       xAxis: {
         title: __('Month'),
@@ -476,11 +479,26 @@ const dealsByStage = createResource({
   auto: true,
   transform(data = []) {
     return {
-      data: data,
-      title: __('Deals by Stage'),
-      subtitle: __('Current pipeline distribution'),
-      categoryColumn: 'stage',
-      valueColumn: 'count',
+      donut: {
+        data: data,
+        title: __('Deals by stage'),
+        subtitle: __('Current pipeline distribution'),
+        categoryColumn: 'stage',
+        valueColumn: 'count',
+      },
+      bar: {
+        data: data.filter((d) => d.status_type != 'Lost'),
+        title: __('Deals by ongoing & won stage'),
+        xAxis: {
+          title: __('Stage'),
+          key: 'stage',
+          type: 'category' as const,
+        },
+        yAxis: {
+          title: __('Count'),
+        },
+        series: [{ name: 'count', type: 'bar' as const }],
+      },
     }
   },
 })
@@ -499,7 +517,7 @@ const leadsBySource = createResource({
   transform(data = []) {
     return {
       data: data,
-      title: __('Leads by Source'),
+      title: __('Leads by source'),
       subtitle: __('Lead generation channel analysis'),
       categoryColumn: 'source',
       valueColumn: 'count',

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -783,7 +783,7 @@ const showLostReasonModal = ref(false)
 
 function setLostReason() {
   if (
-    document.doc.status !== 'Lost' ||
+    getDealStatus(document.doc.status).type !== 'Lost' ||
     (document.doc.lost_reason && document.doc.lost_reason !== 'Other') ||
     (document.doc.lost_reason === 'Other' && document.doc.lost_notes)
   ) {
@@ -795,7 +795,7 @@ function setLostReason() {
 }
 
 function beforeStatusChange(data) {
-  if (data?.hasOwnProperty('status') && data.status == 'Lost') {
+  if (data?.hasOwnProperty('status') && getDealStatus(data.status).type == 'Lost') {
     setLostReason()
   } else {
     document.save.submit(null, {

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -643,7 +643,7 @@ const showLostReasonModal = ref(false)
 
 function setLostReason() {
   if (
-    document.doc.status !== 'Lost' ||
+    getDealStatus(document.doc.status).type !== 'Lost' ||
     (document.doc.lost_reason && document.doc.lost_reason !== 'Other') ||
     (document.doc.lost_reason === 'Other' && document.doc.lost_notes)
   ) {
@@ -655,7 +655,7 @@ function setLostReason() {
 }
 
 function beforeStatusChange(data) {
-  if (data?.hasOwnProperty('status') && data.status == 'Lost') {
+  if (data?.hasOwnProperty('status') && getDealStatus(data.status).type == 'Lost') {
     setLostReason()
   } else {
     document.save.submit(null, {

--- a/frontend/src/stores/statuses.js
+++ b/frontend/src/stores/statuses.js
@@ -28,7 +28,7 @@ export const statusesStore = defineStore('crm-statuses', () => {
 
   const dealStatuses = createListResource({
     doctype: 'CRM Deal Status',
-    fields: ['name', 'color', 'position'],
+    fields: ['name', 'color', 'position', 'type'],
     orderBy: 'position asc',
     cache: 'deal-statuses',
     initialData: [],


### PR DESCRIPTION
- [x] Deal status now has a type option ["Open", "Ongoing", "On Hold", "Won", "Lost"]
		Based on `type` we can handle `Won` or `Lost` deals for forecasting, lost reason trigger features and to get accurate data in dashboard charts & number card
		<kbd><img width="1164" height="413" alt="Screenshot 2025-07-13 at 3 11 51 PM" src="https://github.com/user-attachments/assets/ee1390d2-7a42-4b28-9317-3eed56c059e5" /></kbd>
- [x] Lost reason capturing is now triggered if status with type "Lost" is set.
- [x] Renamed `close_date` -> `closed_date` & removed `closed_on` and set `closed_date` when status with type "Won" is set.
- [x] Added "Expected Deal Value" & "Expected Closure Date" for forecasting.
		<kbd><img width="442" height="173" alt="Screenshot 2025-07-13 at 3 12 59 PM" src="https://github.com/user-attachments/assets/65385afc-daf3-468e-853c-1d108ca1f526" /><kbd>
- [x] Added new and updated existing number cards & charts in dashboard
		1. "Total deals" is now "Ongoing deals" and added average deal value number card for ongoing deals
		2. "Won deals" is based on `closed_date` field and added average deal value number card for won deals
		3. Separated "Average time to close" into "Average time to close a lead" & "Average time to close a deal"
		4. Revenue forecast chart now uses `expected_deal_value` for forecasted & `deal_value` for actual.
		5. Funnel conversion now shows the deal status change pipeline based on "Status Change Log" data for each deal.
		6. Added "Deals by ongoing & won stage" chart
		<kbd><img width="1251" height="751" alt="Screenshot 2025-07-13 at 3 13 52 PM" src="https://github.com/user-attachments/assets/cd7be0bb-e245-4e0a-829e-09abea1f43af" /><kbd>
