### PR TITLE
fix: Correct field name from 'agent' to 'user' in CRM Telephony Agent…

### DIFF
--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -35,7 +35,7 @@ def set_default_calling_medium(medium):
 		frappe.get_doc(
 			{
 				"doctype": "CRM Telephony Agent",
-				"agent": frappe.session.user,
+				"user": frappe.session.user,
 				"default_medium": medium,
 			}
 		).insert(ignore_permissions=True)


### PR DESCRIPTION
… creation

- The `CRM Telephony Agent` doctype requires the field `user` (not `agent`) as per its schema (`reqd: 1` + `autoname: field:user`).
- This fixes the `ValidationError: User is required` by using the correct field name when creating a new agent.

This resolves #1049