### PR TITLE
fix(Org Modal): Setting loading false in case of Validation Error

### DIFF
--- a/frontend/src/components/Modals/OrganizationModal.vue
+++ b/frontend/src/components/Modals/OrganizationModal.vue
@@ -109,6 +109,7 @@ async function createOrganization() {
       onError: (err) => {
         if (err.error.exc_type == 'ValidationError') {
           error.value = err.error?.messages?.[0]
+          loading.value = false
         }
       },
     },


### PR DESCRIPTION
In this case user can add the details and save the form again instead of refreshing and then trying again for fresh.