### PR TITLE
Fix/details height behaviour

### DIFF
--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -31,7 +31,7 @@
             <slot v-bind="{ section }">
               <FadedScrollableDiv
                 v-if="section.columns?.[0].fields.length"
-                class="flex-1 flex flex-col gap-1.5 min-h-0"
+                class="column flex flex-col gap-1.5 overflow-y-auto"
               >
                 <template
                   v-for="field in section.columns[0].fields || []"
@@ -564,7 +564,7 @@ function firstVisibleIndex() {
 }
 
 .sections .section .column {
-  max-height: 300px;
+  max-height: 440px;
 }
 .sections .section:last-of-type .column {
   max-height: none;


### PR DESCRIPTION
This solves the problem of  height behavior of detail view.

fixes #986

before 

<img width="350" height="1094" alt="image" src="https://github.com/user-attachments/assets/67498df7-21be-4f67-8e7b-425fe779d17e" />

Now 

<img width="447" height="852" alt="image" src="https://github.com/user-attachments/assets/1ed009fb-f1ea-438b-923e-93bc354f1514" />
