### PR TITLE
Display No Answer in UI of call logs instead of Missed call

### DIFF
--- a/frontend/src/utils/callLog.js
+++ b/frontend/src/utils/callLog.js
@@ -68,7 +68,7 @@ export const statusLabelMap = {
   Queued: 'Queued',
   Canceled: 'Canceled',
   Ringing: 'Ringing',
-  'No Answer': 'Missed Call',
+  'No Answer': 'No Answer', //changed missed to 'No Answer'
   'In Progress': 'In Progress',
 }
 


### PR DESCRIPTION
Changed  Missed call to No Answer in call logs ui.
Now the filter will work perfectly after clicking **NO ANSWER** 

fixes #932


https://github.com/user-attachments/assets/17a9297c-3199-427e-b103-78c99d9927e8

