### PR TITLE
fix: remove "read only" flag for primary email, mobile & phone no

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -129,15 +129,13 @@
    "fieldname": "email",
    "fieldtype": "Data",
    "label": "Primary Email",
-   "options": "Email",
-   "read_only": 1
+   "options": "Email"
   },
   {
    "fieldname": "mobile_no",
    "fieldtype": "Data",
    "label": "Primary Mobile No",
-   "options": "Phone",
-   "read_only": 1
+   "options": "Phone"
   },
   {
    "default": "Qualification",
@@ -251,8 +249,7 @@
    "fieldname": "phone",
    "fieldtype": "Data",
    "label": "Primary Phone",
-   "options": "Phone",
-   "read_only": 1
+   "options": "Phone"
   },
   {
    "fieldname": "log_tab",
@@ -435,7 +432,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-13 11:54:20.608489",
+ "modified": "2025-08-26 12:12:56.324245",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Deal",


### PR DESCRIPTION
Fix primary email, mobile & phone number not visible in deals data tab and new deal modal by removing "read only" flag for them