### PR TITLE
Added support for outgoing whatsapp messages from other apps

### DIFF
--- a/crm/api/whatsapp.py
+++ b/crm/api/whatsapp.py
@@ -36,7 +36,7 @@ def on_update(doc, method):
 def notify_agent(doc):
 	if doc.type == "Incoming":
 		doctype = doc.reference_doctype
-		if doctype and doctype.startswith("CRM "): #checks if there is a valid doctype, this is required because for making sure notification is triggered only for whatsapp message with a valid doctype assiged by validate fundtion. in absence of this ("doctype and ") addition, it stops creation of new whatsapp message.
+		if doctype and doctype.startswith("CRM "):
 			doctype = doctype[4:].lower()
 		notification_text = f"""
             <div class="mb-2 leading-5 text-ink-gray-5">

--- a/crm/api/whatsapp.py
+++ b/crm/api/whatsapp.py
@@ -10,8 +10,15 @@ from crm.fcrm.doctype.crm_notification.crm_notification import notify_user
 def validate(doc, method):
 	if doc.type == "Incoming" and doc.get("from"):
 		name, doctype = get_lead_or_deal_from_number(doc.get("from"))
-		doc.reference_doctype = doctype
-		doc.reference_name = name
+		if name != None: # only assignes a doctype and name if matching number is found, else does not obstruct creation of new message in whatsapp message doctype (frappe_whatsapp app) which is required for other chat applications
+			doc.reference_doctype = doctype 
+			doc.reference_name = name
+
+	if doc.type == "Outgoing" and doc.get("to"):
+		name, doctype = get_lead_or_deal_from_number(doc.get("to"))
+		if name != None:
+			doc.reference_doctype = doctype
+			doc.reference_name = name
 
 
 def on_update(doc, method):
@@ -29,7 +36,7 @@ def on_update(doc, method):
 def notify_agent(doc):
 	if doc.type == "Incoming":
 		doctype = doc.reference_doctype
-		if doctype.startswith("CRM "):
+		if doctype and doctype.startswith("CRM "): #checks if there is a valid doctype, this is required because for making sure notification is triggered only for whatsapp message with a valid doctype assiged by validate fundtion. in absence of this ("doctype and ") addition, it stops creation of new whatsapp message.
 			doctype = doctype[4:].lower()
 		notification_text = f"""
             <div class="mb-2 leading-5 text-ink-gray-5">

--- a/crm/api/whatsapp.py
+++ b/crm/api/whatsapp.py
@@ -10,7 +10,7 @@ from crm.fcrm.doctype.crm_notification.crm_notification import notify_user
 def validate(doc, method):
 	if doc.type == "Incoming" and doc.get("from"):
 		name, doctype = get_lead_or_deal_from_number(doc.get("from"))
-		if name != None: # only assignes a doctype and name if matching number is found, else does not obstruct creation of new message in whatsapp message doctype (frappe_whatsapp app) which is required for other chat applications
+		if name != None:
 			doc.reference_doctype = doctype 
 			doc.reference_name = name
 


### PR DESCRIPTION
made changes so that:
1. whatsapp message is created (app: frappe_whatsapp) even if no phone number match is found in CRM Deal & CRM Lead.
2. Also assigns reference doctype and name for Outgoing whatsappe messages which are not sent via CRM app.
3. added a "if doctype and" check to make sure notify_agent does not fail whatsapp message creation if whatsapp message is being created as per step 1.
4. 
Also solves this: https://github.com/shridarpatil/whatsapp_chat/issues/4