### PR TITLE
fix: is_fc_site fallback for old Frappe

### DIFF
--- a/crm/api/compat.py
+++ b/crm/api/compat.py
@@ -1,0 +1,11 @@
+import frappe
+
+try:
+    from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
+except ImportError:
+    def is_fc_site() -> bool:
+        try:
+            is_system_manager = frappe.get_roles(frappe.session.user).count("System Manager")
+            return bool(is_system_manager and frappe.conf.get("fc_communication_secret"))
+        except Exception:
+            return False

--- a/crm/www/crm.py
+++ b/crm/www/crm.py
@@ -5,9 +5,10 @@ import subprocess
 
 import frappe
 from frappe import safe_decode
-from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 from frappe.utils import cint, get_system_timezone
 from frappe.utils.telemetry import capture
+
+from crm.api.compat import is_fc_site
 
 no_cache = 1
 


### PR DESCRIPTION
### Problem
CRM crashes on older Frappe versions with:

ModuleNotFoundError: No module named 'frappe.integrations.frappe_providers.frappecloud_billing'

### Cause
The function `is_fc_site` exists only in newer Frappe versions, but CRM imports it directly.

### Fix
- Added `crm/api/compat.py` with a fallback for `is_fc_site`.
- Updated `crm/www/crm.py` to import from the compat layer.

This keeps CRM working on both old and new Frappe versions.
