### PR TITLE
fix: show empty state for contacts with no email or phone

### DIFF
--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -235,16 +235,26 @@
                         </div>
                       </div>
                     </template>
-                    <div
-                      class="flex flex-col gap-1.5 text-base text-ink-gray-8"
-                    >
-                      <div class="flex items-center gap-3 pb-1.5 pl-1 pt-4">
+                    <div class="flex flex-col gap-1.5 text-base">
+                      <div
+                        v-if="contact.email"
+                        class="flex items-center gap-3 pb-1.5 pl-1 pt-4 text-ink-gray-8"
+                      >
                         <Email2Icon class="h-4 w-4" />
                         {{ contact.email }}
                       </div>
-                      <div class="flex items-center gap-3 p-1 py-1.5">
+                      <div
+                        v-if="contact.mobile_no"
+                        class="flex items-center gap-3 p-1 py-1.5 text-ink-gray-8"
+                      >
                         <PhoneIcon class="h-4 w-4" />
                         {{ contact.mobile_no }}
+                      </div>
+                      <div
+                        v-if="!contact.email && !contact.mobile_no"
+                        class="flex items-center justify-center py-4 text-sm text-ink-gray-4"
+                      >
+                        {{ __('No details added') }}
                       </div>
                     </div>
                   </Section>


### PR DESCRIPTION
**Fixes:** #486

**Changes**
  Shows "No details added" when contact has no email or phone in deal's contact section.
  - Hide email row when empty
  - Hide phone row when empty
  - Show empty state message when both are missing
 

**before**

<img width="357" height="343" alt="Screenshot 2025-11-04 at 9 05 32 PM" src="https://github.com/user-attachments/assets/c5e4e8f8-aa46-4d5b-8d77-4fdfa5949c46" />
<img width="347" height="338" alt="Screenshot 2025-11-04 at 9 09 29 PM" src="https://github.com/user-attachments/assets/d7876e77-c835-4dbf-adad-dacd9cc3dbbc" />



**after**

<img width="349" height="315" alt="Screenshot 2025-11-04 at 9 07 17 PM" src="https://github.com/user-attachments/assets/3f58cc81-ca6b-4f8e-8398-87255488c6ad" />

<img width="349" height="295" alt="Screenshot 2025-11-04 at 9 08 02 PM" src="https://github.com/user-attachments/assets/97898da6-0638-497c-9df0-4e7700f774dc" />

