### PR TITLE
fix: show call tab on mobile screens

### DIFF
--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -356,7 +356,6 @@ const tabs = computed(() => {
       name: 'Calls',
       label: __('Calls'),
       icon: PhoneIcon,
-      condition: () => callEnabled.value,
     },
     {
       name: 'Tasks',


### PR DESCRIPTION
### Issue
The call tab was not visible on mobile screens if telephony was not enabled 

### Fix
Removed the condition to show the call tab even if the telephony is disabled

<img width="350" height="648" alt="image" src="https://github.com/user-attachments/assets/927cf697-b4da-462c-a0ab-6bb2e07cf7d8" />
