### PR TITLE
Fix: Email draft content shared across documents

### DIFF
--- a/frontend/src/components/CommunicationArea.vue
+++ b/frontend/src/components/CommunicationArea.vue
@@ -110,8 +110,14 @@ const { updateOnboardingStep } = useOnboarding('frappecrm')
 
 const showEmailBox = ref(false)
 const showCommentBox = ref(false)
-const newEmail = computed(() => useStorage(`emailBoxContent-${getUser().email}-${props.doctype}-${doc.value.name}`, ''))
-const newComment = computed(() => useStorage(`commentBoxContent-${getUser().email}-${props.doctype}-${doc.value.name}`, ''))
+const newEmail = useStorage(
+  `emailBoxContent-${getUser().email}-${props.doctype}-${doc.value.name}`,
+  '',
+)
+const newComment = useStorage(
+  `commentBoxContent-${getUser().email}-${props.doctype}-${doc.value.name}`,
+  '',
+)
 const newEmailEditor = ref(null)
 const newCommentEditor = ref(null)
 const sendEmailRef = ref(null)


### PR DESCRIPTION
Email/comment drafts were stored globally, causing content to appear in wrong documents.

**Fix**
Scoped storage keys to: `emailBoxContent-{doctype}-{docname}`

**Testing**
1. Open Lead-001, type draft
2. Navigate to Lead-002
3. Verify draft is empty (not showing Lead-001 content)

Fixes #1369 

https://github.com/user-attachments/assets/55833932-a1af-4546-8471-537e45829682

https://github.com/user-attachments/assets/444ab41e-a096-4042-818e-48c0f7bf698a



