### PR TITLE
fix: react emoji icon is getting cut

### DIFF
--- a/frontend/src/components/Activities/WhatsAppArea.vue
+++ b/frontend/src/components/Activities/WhatsAppArea.vue
@@ -159,7 +159,9 @@
             @click="() => (reaction = true) && togglePopover()"
             class="rounded-full !size-6 mt-0.5"
           >
-            <ReactIcon class="text-ink-gray-3" />
+            <template #icon>
+              <ReactIcon class="text-ink-gray-3" />
+            </template>
           </Button>
         </IconPicker>
       </div>
@@ -240,7 +242,7 @@ function messageOptions(message) {
         replyMode.value = true
         reply.value = {
           ...message,
-          message: formatWhatsAppMessage(message.message)
+          message: formatWhatsAppMessage(message.message),
         }
       },
     },


### PR DESCRIPTION
Before:
<img width="414" height="134" alt="Screenshot 2025-11-10 at 2 57 44 PM" src="https://github.com/user-attachments/assets/4693e2c5-3f06-48b4-8e34-0bd93f02985c" />

After:
<img width="394" height="130" alt="Screenshot 2025-11-10 at 2 57 24 PM" src="https://github.com/user-attachments/assets/50db0b30-0555-4d0f-90c1-1c54e246d0c1" />
