### PR TITLE
fix: Hide delete button on mobile Contact and Organization pages when user lacks   permission

### DIFF
--- a/frontend/src/pages/MobileContact.vue
+++ b/frontend/src/pages/MobileContact.vue
@@ -76,6 +76,7 @@
                   @click="callEnabled && makeCall(contact.doc.mobile_no)"
                 />
                 <Button
+                  v-if="canDelete"
                   :label="__('Delete')"
                   theme="red"
                   size="sm"
@@ -206,7 +207,9 @@ const props = defineProps({
 const route = useRoute()
 const router = useRouter()
 
-const { document: contact } = useDocument('Contact', props.contactId)
+const { document: contact, permissions } = useDocument('Contact', props.contactId)
+
+const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
 const breadcrumbs = computed(() => {
   let items = [{ label: __('Contacts'), route: { name: 'Contacts' } }]

--- a/frontend/src/pages/MobileOrganization.vue
+++ b/frontend/src/pages/MobileOrganization.vue
@@ -69,6 +69,7 @@
                   <FeatherIcon name="link" class="h-4 w-4" />
                 </Button>
                 <Button
+                  v-if="canDelete"
                   :label="__('Delete')"
                   theme="red"
                   size="sm"
@@ -196,10 +197,12 @@ const { doctypeMeta } = getMeta('CRM Organization')
 const route = useRoute()
 const router = useRouter()
 
-const { document: organization } = useDocument(
+const { document: organization, permissions } = useDocument(
   'CRM Organization',
   props.organizationId,
 )
+
+const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
 const breadcrumbs = computed(() => {
   let items = [{ label: __('Organizations'), route: { name: 'Organizations' } }]


### PR DESCRIPTION
The delete button is visible to all users on mobile Contact and Organization pages,
  regardless of their permissions.

Related: #1372 (desktop pages fix)