### PR TITLE
fix: delete orphaned files on discard and clear after send

### DIFF
--- a/frontend/src/components/CommunicationArea.vue
+++ b/frontend/src/components/CommunicationArea.vue
@@ -123,7 +123,17 @@ const newComment = useStorage(
 const newEmailEditor = ref(null)
 const newCommentEditor = ref(null)
 const sendEmailRef = ref(null)
-const attachments = ref([])
+const attachments = useStorage(
+  `attachments-${getUser().email}-${props.doctype}-${doc.value.name}`,
+  [],
+  localStorage,
+  {
+    serializer: {
+      read: (v) => v ? JSON.parse(v) : [],
+      write: (v) => JSON.stringify(v)
+    }
+  }
+)
 
 const subject = computed(() => {
   let prefix = ''


### PR DESCRIPTION
 This PR fixes 3 issues
  ### 1. Orphaned files when discarding drafts
  **Steps to reproduce:**
  1. Click "Reply" or "Comment"
  2. Attach a file (uploads to database immediately)
  3. Click "Discard"
  4. **Result:** File remains in database permanently (orphaned)

  ### 2. Lost attachments after page refresh
  **Steps to reproduce:**
  1. Click "Reply" or "Comment"
  2. Attach a file
  3. Refresh the page
  4. **Result:** Draft text persists, but attachments are gone (not user-friendly)
  5. User re-uploads same file (creates duplicates in database)

  ### 3. Attachments remain in editor after send
  **Steps to reproduce:**
  1. Attach file and send email/comment
  2. Click "Reply" or "Comment" again
  3. **Result:** Previously sent attachments still appear in editor

  ## Solution

  ### 1. Delete files on discard
  - Deletes all uploaded files from database when user clicks "Discard"
  - No unwanted files remain in database

  ### 2. Persist attachments to localStorage
  - Both draft text and files persist across refresh (user-friendly)
  - No need for user to re-upload (prevents duplicates)
  - Can be deleted even after refresh using "Discard" if needed

  ### 3. Clear attachments after successful send
  - Empty attachments array after email/comment is sent
  - Prevents old attachments from appearing in new drafts
  
  closes: #1365
  closes: #1370 

