### PR TITLE
feat: Add configurable defaults for Deal modal switches

### DIFF
--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -9,6 +9,9 @@
   "restore_defaults",
   "enable_forecasting",
   "auto_update_expected_deal_value",
+  "deal_settings_section",
+  "default_choose_existing_organization",
+  "default_choose_existing_contact",
   "currency_tab",
   "currency",
   "exchange_rate_provider_section",
@@ -113,12 +116,31 @@
    "fieldname": "auto_update_expected_deal_value",
    "fieldtype": "Check",
    "label": "Auto Update Expected Deal Value"
+  },
+  {
+   "fieldname": "deal_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Deal Defaults"
+  },
+  {
+   "default": "0",
+   "description": "When creating a new deal, the \"Choose Existing Organization\" switch will be checked by default",
+   "fieldname": "default_choose_existing_organization",
+   "fieldtype": "Check",
+   "label": "Default Choose Existing Organization"
+  },
+  {
+   "default": "0",
+   "description": "When creating a new deal, the \"Choose Existing Contact\" switch will be checked by default",
+   "fieldname": "default_choose_existing_contact",
+   "fieldtype": "Check",
+   "label": "Default Choose Existing Contact"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-16 17:33:26.406549",
+ "modified": "2025-11-15 13:43:22.406654",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "FCRM Settings",

--- a/frontend/src/components/Settings/DealDefaultsSettings.vue
+++ b/frontend/src/components/Settings/DealDefaultsSettings.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="flex h-full flex-col gap-6 py-8 px-6 text-ink-gray-8">
+    <div class="flex flex-col gap-1 px-2">
+      <h2 class="flex gap-2 text-xl font-semibold leading-none h-5">
+        {{ __('Deal Defaults') }}
+      </h2>
+      <p class="text-p-base text-ink-gray-6">
+        {{
+          __(
+            'Configure default behavior when creating new deals',
+          )
+        }}
+      </p>
+    </div>
+
+    <div class="flex-1 flex flex-col overflow-y-auto">
+      <div class="flex items-center justify-between py-3 px-2">
+        <div class="flex flex-col">
+          <div class="text-p-base font-medium text-ink-gray-7 truncate">
+            {{ __('Default Choose Existing Organization') }}
+          </div>
+          <div class="text-p-sm text-ink-gray-5 truncate">
+            {{
+              __(
+                'When creating a new deal, the "Choose Existing Organization" switch will be checked by default',
+              )
+            }}
+          </div>
+        </div>
+        <div>
+          <Switch
+            size="sm"
+            v-model="defaultChooseExistingOrganization"
+            @update:modelValue="saveDefaultChooseExistingOrganization"
+          />
+        </div>
+      </div>
+      <div class="h-px border-t mx-2 border-outline-gray-modals" />
+      <div class="flex items-center justify-between py-3 px-2">
+        <div class="flex flex-col">
+          <div class="text-p-base font-medium text-ink-gray-7 truncate">
+            {{ __('Default Choose Existing Contact') }}
+          </div>
+          <div class="text-p-sm text-ink-gray-5 truncate">
+            {{
+              __(
+                'When creating a new deal, the "Choose Existing Contact" switch will be checked by default',
+              )
+            }}
+          </div>
+        </div>
+        <div>
+          <Switch
+            size="sm"
+            v-model="defaultChooseExistingContact"
+            @update:modelValue="saveDefaultChooseExistingContact"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { getSettings } from '@/stores/settings'
+import { Switch, toast } from 'frappe-ui'
+import { computed } from 'vue'
+
+const { _settings: settings } = getSettings()
+
+// Convert numeric values (0/1) to boolean for Switch component
+const defaultChooseExistingOrganization = computed({
+  get: () => Boolean(settings.doc.default_choose_existing_organization),
+  set: (value) => {
+    settings.doc.default_choose_existing_organization = value ? 1 : 0
+  },
+})
+
+const defaultChooseExistingContact = computed({
+  get: () => Boolean(settings.doc.default_choose_existing_contact),
+  set: (value) => {
+    settings.doc.default_choose_existing_contact = value ? 1 : 0
+  },
+})
+
+function saveDefaultChooseExistingOrganization(newValue) {
+  settings.save.submit(null, {
+    onSuccess: () => {
+      // Reload settings to ensure all components get the updated values
+      settings.reload()
+      toast.success(
+        newValue
+          ? __('Default choose existing organization enabled')
+          : __('Default choose existing organization disabled'),
+      )
+    },
+    onError: (error) => {
+      // Revert on error
+      defaultChooseExistingOrganization.value = !newValue
+      toast.error(__('Failed to save setting: ') + error.message)
+    },
+  })
+}
+
+function saveDefaultChooseExistingContact(newValue) {
+  settings.save.submit(null, {
+    onSuccess: () => {
+      // Reload settings to ensure all components get the updated values
+      settings.reload()
+      toast.success(
+        newValue
+          ? __('Default choose existing contact enabled')
+          : __('Default choose existing contact disabled'),
+      )
+    },
+    onError: (error) => {
+      // Revert on error
+      defaultChooseExistingContact.value = !newValue
+      toast.error(__('Failed to save setting: ') + error.message)
+    },
+  })
+}
+</script>

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -62,6 +62,7 @@ import LeadSyncSourcePage from '@/components/Settings/LeadSyncing/LeadSyncSource
 import BrandSettings from '@/components/Settings/BrandSettings.vue'
 import HomeActions from '@/components/Settings/HomeActions.vue'
 import ForecastingSettings from '@/components/Settings/ForecastingSettings.vue'
+import DealDefaultsSettings from '@/components/Settings/DealDefaultsSettings.vue'
 import CurrencySettings from '@/components/Settings/CurrencySettings.vue'
 import EmailTemplatePage from '@/components/Settings/EmailTemplate/EmailTemplatePage.vue'
 import TelephonySettings from '@/components/Settings/TelephonySettings.vue'
@@ -107,6 +108,11 @@ const tabs = computed(() => {
           label: __('Forecasting'),
           component: markRaw(ForecastingSettings),
           icon: TrendingUpDownIcon,
+        },
+        {
+          label: __('Deal Defaults'),
+          component: markRaw(DealDefaultsSettings),
+          icon: 'file-text',
         },
         {
           label: __('Currency & Exchange Rate'),


### PR DESCRIPTION
Added settings to control default state of "Choose Existing Organization" and "Choose Existing Contact" switches in the Deal creation modal.

Backend:
- Added Deal Defaults section to FCRM Settings doctype
- Added default_choose_existing_organization field (Check)
- Added default_choose_existing_contact field (Check)

Frontend:
- Created DealDefaultsSettings component for managing defaults
- Updated DealModal to respect configured default values
- Added settings reload to ensure instant updates across components
- Fixed null reference error in DealModal watcher
- Implemented proper boolean/integer conversion for Switch components