### PR TITLE
fix: handle unknown sender in WhatsApp hook. (backport #1439)

### DIFF
--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -117,6 +117,7 @@ def get_contact_lead_or_deal_from_number(number):
 			doctype = "CRM Deal"
 			docname = contact.get("deal")
 		return docname, doctype
+	return None, None
 
 @frappe.whitelist()
 def get_contact_by_phone_number(phone_number):


### PR DESCRIPTION
Return (None, None) from get_contact_lead_or_deal_from_number when no matching contact, lead, or deal is found. Prevents TypeError when unpacking the result from unknown numbers.

Backport #1439 