### PR TITLE
feat: add ability to refresh Facebook forms after sync source creation

### DIFF
--- a/crm/lead_syncing/doctype/lead_sync_source/facebook.py
+++ b/crm/lead_syncing/doctype/lead_sync_source/facebook.py
@@ -151,6 +151,7 @@ def fetch_and_store_pages_from_facebook(access_token: str) -> list[dict]:
 	for page in pages:
 		page_id = page["id"]
 		already_synced = frappe.db.exists("Facebook Page", page_id)
+		page["is_new"] = not already_synced
 		if not already_synced:
 			create_facebook_page_in_db(page, account_details)
 		forms = fetch_and_store_leadgen_forms_from_facebook(page_id, page["access_token"])
@@ -195,6 +196,7 @@ def fetch_and_store_leadgen_forms_from_facebook(page_id: str, page_access_token:
 	for form in forms:
 		form_id = form["id"]
 		already_synced = frappe.db.exists("Facebook Lead Form", form_id)
+		form["is_new"] = not already_synced
 		if already_synced:
 			continue
 		create_facebook_lead_form_in_db(form, page_id)
@@ -222,3 +224,35 @@ def get_pages_with_forms() -> list[dict]:
 		forms = frappe.db.get_all("Facebook Lead Form", filters={"page": page["id"]}, fields=["id", "name"])
 		page["forms"] = forms
 	return pages
+
+
+@frappe.whitelist()
+def refresh_facebook_forms(source_name: str) -> dict:
+	"""Refresh Facebook pages and forms for an existing sync source.
+
+	This fetches any new pages and forms that were created on Facebook
+	after the sync source was initially set up.
+	"""
+	source = frappe.get_doc("Lead Sync Source", source_name)
+	if source.type != "Facebook":
+		frappe.throw(frappe._("This sync source is not a Facebook source"))
+
+	access_token = source.get_password("access_token")
+	if not access_token:
+		frappe.throw(frappe._("Access token is required"))
+
+	pages = fetch_and_store_pages_from_facebook(access_token)
+
+	new_forms_count = 0
+	new_pages_count = 0
+	for page in pages:
+		if page.get("is_new"):
+			new_pages_count += 1
+		for form in page.get("forms", []):
+			if form.get("is_new"):
+				new_forms_count += 1
+
+	return {
+		"new_pages_count": new_pages_count,
+		"new_forms_count": new_forms_count,
+	}

--- a/frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue
+++ b/frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue
@@ -62,8 +62,16 @@
 						<FormControl v-if="!isLocal && sourceDoc && sourceDoc.last_synced_at"
 							:modelValue="formatDate(sourceDoc.last_synced_at)" disabled type="datetime" :label="__('Last Synced At')" />
 
-						<Link v-if="!isLocal" label="Facebook Page" v-model="syncSource.facebook_page"
-							doctype="Facebook Page" />
+						<div v-if="!isLocal" class="flex items-end gap-2">
+							<Link class="flex-1" label="Facebook Page" v-model="syncSource.facebook_page"
+								doctype="Facebook Page" />
+							<Button variant="outline" :loading="refreshFormsResource.loading"
+								@click="refreshForms" :title="__('Refresh pages and forms from Facebook')">
+								<template #icon>
+									<LucideRefreshCw class="size-4" />
+								</template>
+							</Button>
+						</div>
 
 						<Link v-if="!isLocal && syncSource.facebook_page" label="Lead Form"
 							v-model="syncSource.facebook_lead_form" doctype="Facebook Lead Form" :filters="{
@@ -112,6 +120,7 @@ import { getMeta } from "@/stores/meta";
 import Link from "@/components/Controls/Link.vue";
 import Grid from "@/components/Controls/Grid.vue";
 import LucideCircleQuestionMark from '~icons/lucide/circle-question-mark';
+import LucideRefreshCw from '~icons/lucide/refresh-cw';
 import FailureLogs from "./FailureLogs.vue";
 import DetailsIcon from '@/components/Icons/DetailsIcon.vue'
 import RefreshIcon from '@/components/Icons/RefreshIcon.vue'
@@ -318,6 +327,26 @@ const leadFields = createResource({
 		return data.filter((field) => !restrictedFields.includes(field.fieldname));
 	},
 });
+
+const refreshFormsResource = createResource({
+	url: "crm.lead_syncing.doctype.lead_sync_source.facebook.refresh_facebook_forms",
+	onSuccess: (data) => {
+		if (data.new_forms_count > 0 || data.new_pages_count > 0) {
+			toast.success(__("{0} new page(s) and {1} new form(s) synced", [data.new_pages_count, data.new_forms_count]));
+		} else {
+			toast.info(__("No new pages or forms found"));
+		}
+	},
+	onError: (e) => {
+		toast.error(e.messages?.[0] || __("Error refreshing forms"));
+	},
+});
+
+function refreshForms() {
+	refreshFormsResource.submit({
+		source_name: syncSource.value.name,
+	});
+}
 
 const getCRMLeadFields = computed(() => {
 	if (leadFields.data) {


### PR DESCRIPTION
## Summary
- After adding a sync source, if new forms are created on Facebook, there was previously no way to sync those new forms
- This adds a refresh button next to the Facebook Page dropdown that re-fetches pages and forms from Facebook and creates any new ones

## Changes
- Add `refresh_facebook_forms` API endpoint in `facebook.py`
- Add `is_new` flag to track newly synced pages/forms
- Add refresh button with loading state in `LeadSyncSourceForm.vue`
- Display toast messages showing count of new pages/forms synced

## Test plan
- [ ] Create a Facebook Lead Sync Source with an access token
- [ ] Create a new form on Facebook Lead Ads
- [ ] Click the refresh button next to the Facebook Page dropdown
- [ ] Verify the new form appears in the Lead Form dropdown
- [ ] Verify appropriate toast messages are shown