### PR TITLE
fix: Correct HTTP method types for API calls

### DIFF
--- a/crm/api/__init__.py
+++ b/crm/api/__init__.py
@@ -7,7 +7,7 @@ from frappe.utils.modules import get_modules_from_all_apps_for_user
 from frappe.utils.telemetry import POSTHOG_HOST_FIELD, POSTHOG_PROJECT_FIELD
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(methods=["GET"], allow_guest=True)
 def get_translations():
 	if frappe.session.user != "Guest":
 		language = frappe.db.get_value("User", frappe.session.user, "language")
@@ -50,7 +50,7 @@ def get_user_signature():
 	return content
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_posthog_settings():
 	return {
 		"posthog_project_id": frappe.conf.get(POSTHOG_PROJECT_FIELD),

--- a/crm/api/session.py
+++ b/crm/api/session.py
@@ -1,7 +1,7 @@
 import frappe
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_users():
 	users = frappe.qb.get_query(
 		"User",

--- a/crm/www/crm.py
+++ b/crm/www/crm.py
@@ -29,7 +29,7 @@ def get_context():
 	return context
 
 
-@frappe.whitelist(methods=["POST"], allow_guest=True)
+@frappe.whitelist(methods=["GET", "POST"], allow_guest=True)
 def get_context_for_dev():
 	if not frappe.conf.developer_mode:
 		frappe.throw(_("This method is only meant for developer mode"))

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -55,7 +55,7 @@ app.config.globalProperties.$dialog = createDialog
 
 let socket
 if (import.meta.env.DEV) {
-  frappeRequest({ url: '/api/method/crm.www.crm.get_context_for_dev' }).then(
+  frappeRequest({ url: '/api/method/crm.www.crm.get_context_for_dev', method: 'GET' }).then(
     (values) => {
       for (let key in values) {
         window[key] = values[key]

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -12,6 +12,7 @@ export const usersStore = defineStore('crm-users', () => {
 
   const users = createResource({
     url: 'crm.api.session.get_users',
+     method: 'GET',
     cache: 'crm-users',
     initialData: [],
     auto: true,

--- a/frontend/src/telemetry.ts
+++ b/frontend/src/telemetry.ts
@@ -24,6 +24,7 @@ let posthog: typeof window.posthog = window.posthog
 // Posthog Settings
 let posthogSettings = createResource({
   url: 'crm.api.get_posthog_settings',
+  method: 'GET',
   cache: 'posthog_settings',
   onSuccess: (ps: PosthogSettings) => initPosthog(ps),
 })

--- a/frontend/src/translation.js
+++ b/frontend/src/translation.js
@@ -38,6 +38,7 @@ function translate(message, replace, context = null) {
 function fetchTranslations(lang) {
   createResource({
     url: 'crm.api.get_translations',
+    method: 'GET',
     cache: 'translations',
     auto: true,
     transform: (data) => {


### PR DESCRIPTION
Fixing CSRF Error on Page Refresh/reload by using Correct HTTP method