### PR TITLE
Call button for Contacts in a deal

### DIFF
--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -428,7 +428,7 @@ watch(error, (err) => {
     errorTitle.value = __(
       err.exc_type == 'DoesNotExistError'
         ? 'Document not found'
-        : 'Error occurred',
+        : 'Error occurred'
     )
     errorMessage.value = __(err.messages?.[0] || 'An error occurred')
   } else {
@@ -456,7 +456,7 @@ watch(
       document._statuses = s.statuses || []
     }
   },
-  { once: true },
+  { once: true }
 )
 
 const organizationDocument = ref(null)
@@ -467,12 +467,12 @@ watch(
     if (org && !organizationDocument.value?.doc) {
       let { document: _organizationDocument } = useDocument(
         'CRM Organization',
-        org,
+        org
       )
       organizationDocument.value = _organizationDocument
     }
   },
-  { immediate: true },
+  { immediate: true }
 )
 
 const organization = computed(() => organizationDocument.value?.doc || {})
@@ -636,6 +636,15 @@ function contactOptions(contact) {
       onClick: () => removeContact(contact.name),
     },
   ]
+
+  // Add Call option for each linked contact (uses global makeCall)
+  if (contact.mobile_no) {
+    options.unshift({
+      label: __('Call'),
+      icon: h(PhoneIcon, { class: 'h-4 w-4' }),
+      onClick: () => makeCall(contact.mobile_no),
+    })
+  }
 
   if (!contact.is_primary) {
     options.push({

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -17,7 +17,7 @@
               document.statuses?.length
                 ? document.statuses
                 : document._statuses,
-              triggerStatusChange,
+              triggerStatusChange
             )
           "
         >
@@ -318,7 +318,7 @@ import { ref, computed, h, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const { brand } = getSettings()
-const { $dialog, $socket } = globalStore()
+const { $dialog, $socket, makeCall } = globalStore()
 const { statusOptions, getDealStatus } = statusesStore()
 const { doctypeMeta } = getMeta('CRM Deal')
 const route = useRoute()
@@ -337,7 +337,7 @@ const showDeleteLinkedDocModal = ref(false)
 
 const { triggerOnChange, assignees, document, scripts, error } = useDocument(
   'CRM Deal',
-  props.dealId,
+  props.dealId
 )
 
 const doc = computed(() => document.doc || {})
@@ -347,7 +347,7 @@ watch(error, (err) => {
     errorTitle.value = __(
       err.exc_type == 'DoesNotExistError'
         ? 'Document not found'
-        : 'Error occurred',
+        : 'Error occurred'
     )
     errorMessage.value = __(err.messages?.[0] || 'An error occurred')
   } else {
@@ -375,7 +375,7 @@ watch(
       document._statuses = s.statuses || []
     }
   },
-  { once: true },
+  { once: true }
 )
 
 const reload = ref(false)
@@ -520,7 +520,21 @@ function contactOptions(contact) {
     },
   ]
 
-  if (!contact.is_primary) {
+  // Add Call option for each linked contact (uses global makeCall)
+  const phone =
+    typeof contact === 'string'
+      ? dealContacts.data?.find((c) => c.name === contact)?.mobile_no
+      : contact?.mobile_no
+
+  if (phone) {
+    options.unshift({
+      label: __('Call'),
+      icon: h(PhoneIcon, { class: 'h-4 w-4' }),
+      onClick: () => makeCall(phone),
+    })
+  }
+
+  if (typeof contact !== 'string' && !contact.is_primary) {
     options.push({
       label: __('Set as Primary Contact'),
       icon: h(SuccessIcon, { class: 'h-4 w-4' }),
@@ -576,7 +590,7 @@ const dealContacts = createResource({
   auto: true,
   onSuccess: (data) => {
     let contactSection = sections.data?.find(
-      (section) => section.name == 'contacts_section',
+      (section) => section.name == 'contacts_section'
     )
     if (!contactSection) return
     contactSection.contacts = data.map((contact) => {


### PR DESCRIPTION
## Summary

- Adds a "Call" action for each linked contact on the Deal page and Mobile Deal page.
- Reuses existing `makeCall` logic used for primary contact calls.
- No backend, schema, or API changes required.

## Why

Currently, users can only call the primary contact from a Deal.
This change allows calling any linked contact directly from the Deal page, avoiding workarounds like changing the primary contact.

## Changes

- Deal.vue: Adds "Call" option in contact dropdown when a mobile number exists.
- MobileDeal.vue: Mirrors the same behavior for mobile view.

## Linked Issue

Closes frappe/crm#1454
