### PR TITLE
fix: converted deal using browser cached data 

### DIFF
--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -80,6 +80,15 @@ export function useDocument(doctype, docname, resourceOverrides = {}) {
     }
   }
 
+  if (!docname) {
+    onUnmounted(() => {
+      delete documentsCache[doctype][docname || '']
+      delete assigneesCache[doctype][docname || '']
+      delete permissionsCache[doctype][docname || '']
+      delete controllersCache[doctype]?.[docname || '']
+    })
+  }
+
   assigneesCache[doctype] = assigneesCache[doctype] || {}
 
   if (!assigneesCache[doctype][docname || '']) {
@@ -109,13 +118,6 @@ export function useDocument(doctype, docname, resourceOverrides = {}) {
       initialData: { permissions: {} },
     })
   }
-
-  onUnmounted(() => {
-    delete documentsCache[doctype][docname || '']
-    delete assigneesCache[doctype][docname || '']
-    delete permissionsCache[doctype][docname || '']
-    delete controllersCache[doctype]?.[docname || '']
-  })
 
   async function setupFormScript() {
     if (

--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -4,7 +4,7 @@ import { getMeta } from '@/stores/meta'
 import { showSettings, activeSettingsPage } from '@/composables/settings'
 import { runSequentially, parseAssignees, evaluateExpression } from '@/utils'
 import { createDocumentResource, createResource, toast } from 'frappe-ui'
-import { ref, reactive } from 'vue'
+import { ref, reactive, onUnmounted } from 'vue'
 
 const documentsCache = {}
 const controllersCache = {}
@@ -109,6 +109,13 @@ export function useDocument(doctype, docname, resourceOverrides = {}) {
       initialData: { permissions: {} },
     })
   }
+
+  onUnmounted(() => {
+    delete documentsCache[doctype][docname || '']
+    delete assigneesCache[doctype][docname || '']
+    delete permissionsCache[doctype][docname || '']
+    delete controllersCache[doctype]?.[docname || '']
+  })
 
   async function setupFormScript() {
     if (


### PR DESCRIPTION
Fixes #1487 

ConvertLeadToDealModal.vue does not have onMount() same with LeadModal or DealModal so when open that Modal cached deal data can not be clean. 

So we add onUnmounted() on useDocument(), so whenever DealModal or LeadModal closed data will not be stored inside browser cache.