### PR TITLE
Field.vue changes in read only of vue

### DIFF
--- a/frontend/src/components/FieldLayout/Field.vue
+++ b/frontend/src/components/FieldLayout/Field.vue
@@ -326,6 +326,9 @@ const field = computed(() => {
       field.mandatory_depends_on,
       data.value,
     ),
+    read_only: field.read_only_depends_on 
+      ? evaluateDependsOnValue(field.read_only_depends_on, data.value)
+      : field.read_only,
   }
 
   _field.visible = isFieldVisible(_field)


### PR DESCRIPTION
Describing the bug
The read_only_depends_on property defined in a DocType JSON is not being evaluated in the CRM Vue.js portal, while mandatory_depends_on works correctly under the same condition. This causes fields to remain editable when they should become read-only. The issue occurs only in the CRM Vue portal and not in Frappe Desk.
