### PR TITLE
Add method to clear old logs in failed_lead_sync_log 

### DIFF
--- a/crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.py
+++ b/crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.py
@@ -39,3 +39,12 @@ class FailedLeadSyncLog(Document):
 		self.type = "Synced"
 		self.save()
 		return crm_lead
+	@staticmethod
+	def clear_old_logs(days=180):
+		from frappe.query_builder import Interval
+		from frappe.query_builder.functions import Now
+		
+		table = frappe.qb.DocType("Custom Logging Doctype")
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))
+
+


### PR DESCRIPTION
Added a static method to clear old logs older than a specified number of days.
