### PR TITLE
Fix: COUNT_NAME condition for version check

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -15,7 +15,7 @@ from crm.utils import get_dynamic_linked_docs, get_linked_docs, is_frappe_versio
 
 COUNT_NAME = (
 	{"COUNT": "name", "as": "total_count"}
-	if is_frappe_version("16", above=True)
+	if is_frappe_version("16") or is_frappe_version("16", above=True)
 	else "count(name) as total_count"
 )
 


### PR DESCRIPTION

This pull request makes a minor adjustment to the `COUNT_NAME` assignment in `crm/api/doc.py` to improve compatibility with Frappe version 16 and above. The change ensures that the correct count expression is used for both version 16 and any versions above it.

- Compatibility update:
  * Modified the condition in the `COUNT_NAME` assignment to apply the dictionary-based count expression for Frappe version 16 as well as versions above 16.

Frappe Framework: v16.0.0-dev (version-16)
ERPNext: v16.0.0 (version-16)
Frappe CRM: v1.57.4 (main)