### PR TITLE
fix: resolve ModuleNotFoundError for frappe.pulse for frappe version-15 (fixes #1594)

### DIFF
--- a/crm/utils/__init__.py
+++ b/crm/utils/__init__.py
@@ -269,9 +269,8 @@ def sales_user_only(fn):
 
 
 def is_frappe_version(version: str, above: bool = False, below: bool = False):
-	from frappe.pulse.utils import get_frappe_version
 
-	current_version = get_frappe_version()
+	current_version = frappe.__version__
 	major_version = int(current_version.split(".")[0])
 	target_version = int(version.split(".")[0])
 


### PR DESCRIPTION
- Replaced the import from frappe.pulse.utils.get_frappe_version() with frappe.__version__ in the is_frappe_version function. 
- The frappe.pulse module doesn't exist in Frappe v15.76.0 and below or maybe some versions above, causing a ModuleNotFoundError when accessing the CRM page.