### PR TITLE
fix: add error for status change

### DIFF
--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
@@ -264,6 +264,9 @@ def create_customer_in_erpnext(doc, method):
 	):
 		return
 
+	if not doc.organization:
+		frappe.throw(_("Organization is required to create a customer"))
+
 	contacts = get_contacts(doc)
 	address = get_organization_address(doc.organization)
 	customer = {


### PR DESCRIPTION
Add a check to prevent users from changing the status to create customer when "Create customer on status change" is enabled and the organization is not set in the deal