### PR TITLE
fix: authenticate user role for portal access

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -134,7 +134,7 @@ let router = createRouter({
 
 router.beforeEach(async (to, from, next) => {
   const { isLoggedIn } = sessionStore()
-  const { users, isWebsiteUser } = usersStore()
+  const { users, isCrmUser } = usersStore()
 
   if (isLoggedIn && !users.fetched) {
     try {
@@ -143,8 +143,8 @@ router.beforeEach(async (to, from, next) => {
       console.error('Error loading users', error)
     }
   }
-
-  if (isLoggedIn && to.name !== 'Not Permitted' && isWebsiteUser()) {
+  
+  if (isLoggedIn && to.name !== 'Not Permitted' && !isCrmUser()) {
     next({ name: 'Not Permitted' })
   } else if (to.name === 'Home' && isLoggedIn) {
     const { views, getDefaultView } = viewsStore()

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { createResource } from 'frappe-ui'
 import { sessionStore } from './session'
-import { reactive } from 'vue'
+import { computed, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 
 export const usersStore = defineStore('crm-users', () => {
@@ -77,8 +77,15 @@ export const usersStore = defineStore('crm-users', () => {
     return null
   }
 
+  const isCrmUser = (user)=>{
+    user = user || session.user
+    return users.data.crmUsers?.find(u=>u.name === user)
+  }
+
   return {
     users,
+    allUsers: computed(() => users.data.allUsers),
+    crmUsers: computed(() => users.data.crmUsers),
     getUser,
     isAdmin,
     isManager,
@@ -86,5 +93,6 @@ export const usersStore = defineStore('crm-users', () => {
     isTelephonyAgent,
     getUserRole,
     isWebsiteUser,
+    isCrmUser,
   }
 })


### PR DESCRIPTION
Prevent users without role `Sales User`, `Sales Manager` or `System Manager` from accessing CRM Portal

Fixes: #366 