### PR TITLE
fix: handle loading state

### DIFF
--- a/frontend/src/components/Modals/TaskModal.vue
+++ b/frontend/src/components/Modals/TaskModal.vue
@@ -97,7 +97,6 @@
             </Button>
           </Dropdown>
         </div>
-        <ErrorMessage class="mt-4" v-if="error" :message="__(error)" />
       </div>
     </template>
     <template #actions>
@@ -105,6 +104,7 @@
         <Button
           :label="editMode ? __('Update') : __('Create')"
           variant="solid"
+          :loading="createTaskResource.loading || updateTaskResource.loading"
           @click="updateTask"
         />
       </div>
@@ -121,7 +121,13 @@ import Link from '@/components/Controls/Link.vue'
 import { taskStatusOptions, taskPriorityOptions, getFormat } from '@/utils'
 import { usersStore } from '@/stores/users'
 import { useTelemetry } from 'frappe-ui/frappe'
-import { TextEditor, Dropdown, Tooltip, call, DateTimePicker } from 'frappe-ui'
+import {
+  TextEditor,
+  Dropdown,
+  Tooltip,
+  DateTimePicker,
+  createResource,
+} from 'frappe-ui'
 import { useOnboarding } from 'frappe-ui/frappe'
 import { ref, watch, nextTick, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
@@ -151,7 +157,6 @@ const { users, getUser } = usersStore()
 const { updateOnboardingStep } = useOnboarding('frappecrm')
 const { capture } = useTelemetry()
 
-const error = ref(null)
 const title = ref(null)
 const editMode = ref(false)
 const _task = ref({
@@ -163,6 +168,47 @@ const _task = ref({
   priority: 'Low',
   reference_doctype: props.doctype,
   reference_docname: null,
+})
+
+const createTaskResource = createResource({
+  url: 'frappe.client.insert',
+  makeParams() {
+    return {
+      doc: {
+        doctype: 'CRM Task',
+        reference_doctype: props.doctype,
+        reference_docname: props.doc || null,
+        ..._task.value,
+      },
+    }
+  },
+  onSuccess(d) {
+    if (d.name) {
+      updateOnboardingStep('create_first_task')
+      capture('task_created')
+      tasks.value?.reload()
+      emit('after', d, true)
+      show.value = false
+    }
+  },
+})
+
+const updateTaskResource = createResource({
+  url: 'frappe.client.set_value',
+  makeParams() {
+    return {
+      doctype: 'CRM Task',
+      name: _task.value.name,
+      fieldname: _task.value,
+    }
+  },
+  onSuccess(d) {
+    if (d.name) {
+      tasks.value?.reload()
+      emit('after', d)
+      show.value = false
+    }
+  },
 })
 
 function updateTaskStatus(status) {
@@ -188,42 +234,10 @@ async function updateTask() {
     _task.value.assigned_to = getUser().name
   }
   if (_task.value.name) {
-    let d = await call('frappe.client.set_value', {
-      doctype: 'CRM Task',
-      name: _task.value.name,
-      fieldname: _task.value,
-    })
-    if (d.name) {
-      tasks.value?.reload()
-      emit('after', d)
-    }
+    updateTaskResource.submit()
   } else {
-    let d = await call(
-      'frappe.client.insert',
-      {
-        doc: {
-          doctype: 'CRM Task',
-          reference_doctype: props.doctype,
-          reference_docname: props.doc || null,
-          ..._task.value,
-        },
-      },
-      {
-        onError: (err) => {
-          if (err.error.exc_type == 'MandatoryError') {
-            error.value = 'Title is mandatory'
-          }
-        },
-      },
-    )
-    if (d.name) {
-      updateOnboardingStep('create_first_task')
-      capture('task_created')
-      tasks.value?.reload()
-      emit('after', d, true)
-    }
+    createTaskResource.submit()
   }
-  show.value = false
 }
 
 function render() {

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -341,7 +341,7 @@ function showTask(name) {
     name: t.name,
     title: t.title,
     description: t.description,
-    assigned_to: t.assigned_to?.email || '',
+    assigned_to: t.assigned_to?.name || '',
     due_date: t.due_date,
     status: t.status,
     priority: t.priority,


### PR DESCRIPTION
Add a loading state to the "Create" button to prevent multiple tasks from being created

Fixes: #1674