### PR TITLE
Fix: Gender not auto-populated in Contact DocType from Deal #1678    

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -412,7 +412,7 @@ def create_contact(doc):
 			"last_name": doc.get("last_name"),
 			"salutation": doc.get("salutation"),
 			"company_name": doc.get("organization") or doc.get("organization_name"),
-			"gender": doc.get("gender")
+			"gender": doc.get("gender"),
 		}
 	)
 


### PR DESCRIPTION
**Description**

This PR fixes an issue where the Gender field was not being populated in the Contact doctype when creating or linking a Contact from a Deal.

Although Gender was available in the Deal, it was skipped during the Contact mapping process, resulting in empty values on the Contact record.

This change ensures that Gender is correctly transferred from Deal to Contact, keeping data consistent across CRM records.

**Testing Steps**

Add this under Testing in your PR:

**Testing**

- Navigate to CRM > Deals.
- Create a new Deal (or open an existing one).
- Set the Gender field in the Deal.
- Create a Contact from the Deal (or link a new Contact).
- Open the Contact record.

**Result**

- Gender is automatically populated in the Contact.
- Other mapped fields continue to work as expected.
- No regression observed in Deal → Contact flow.

**Screenshot**

https://github.com/user-attachments/assets/34f736e9-967e-4789-bf69-413e22736663

