### PR TITLE
fix: remove unexpected dot in email reply

### DIFF
--- a/frontend/src/components/Activities/EmailArea.vue
+++ b/frontend/src/components/Activities/EmailArea.vue
@@ -129,7 +129,6 @@ function reply(email, reply_all = false) {
   editor.editor
     .chain()
     .clearContent()
-    .insertContent('<p>.</p>')
     .updateAttributes('paragraph', { class: 'reply-to-content' })
     .insertContent(repliedMessage)
     .focus('all')


### PR DESCRIPTION
Remove unnecessary `<p>.</p>` while replying to an email

Fixes: #1671