### PR TITLE
fix(crm): organization create modal not opening when navigating from …

### DIFF
--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -600,19 +600,34 @@ const sections = createResource({
   cache: ['sidePanelSections', 'CRM Deal'],
   params: { doctype: 'CRM Deal' },
   transform: (data) => getParsedSections(data),
+  auto : true,
 })
+
+watch(
+  () => sections.data,
+  (data) => {
+    if (data) {
+      getParsedSections(data)
+    }
+  },
+  { immediate: true, deep: true }
+)
+
 
 if (!sections.data) sections.fetch()
 
 function getParsedSections(_sections) {
+  if (!_sections) return _sections
   _sections.forEach((section) => {
     if (section.name == 'contacts_section') return
     section.columns[0].fields.forEach((field) => {
       if (field.fieldname == 'organization') {
         field.create = (value, close) => {
-          _organization.value.organization_name = value
-          showOrganizationModal.value = true
+          _organization.value = { organization_name: value }
           close()
+          nextTick(() => {
+            showOrganizationModal.value = true
+          })
         }
         field.link = (org) =>
           router.push({


### PR DESCRIPTION
Fixes #1691

**Description**

Fixes an issue where the Organization “Create New” modal does not open on the Deal details page when navigating to a Deal from the Deal list. The modal previously only worked after a manual page refresh.

This PR ensures the modal opens correctly on the initial Deal load without requiring refresh.

**Changes Made**

- Fixed initialization/trigger issue for the Organization “Create New” action on Deal navigation.
- Ensured modal opens consistently when accessing Deals from the list view.
- Verified existing Deal workflows remain unaffected.

**Steps to Test**

- Go to CRM → Deals.
- Open any Deal from the Deal list.
- Scroll to Organization Details in the right sidebar.
- Click "Create New" in the Organization field.

**Expected Result**

The Organization modal opens immediately (no refresh required).

**Actual Result (before fix)**

The modal did not open on initial navigation and required a manual refresh.

**Screenshots**

bug: 

https://github.com/user-attachments/assets/932d9d52-dd77-46a1-a1ef-b680cbd3e755

fix:


https://github.com/user-attachments/assets/07a63633-d095-4168-85fd-8bf556eceaa4



**Additional Context**

This issue occurred only when navigating to a Deal from the Deal list. After refreshing the Deal page, the Organization modal worked as expected. A screen recording is attached for reference.