### PR TITLE
fix: org page ui bugs

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -303,7 +303,10 @@
             class="flex flex-col gap-0.5"
           >
             <div
-              v-for="activity in [activity, ...activity.other_versions]"
+              v-for="activity in sortByCreation([
+                activity,
+                ...activity.other_versions,
+              ])"
               class="flex items-start justify-stretch gap-2 py-1.5 text-base"
             >
               <div class="inline-flex flex-wrap gap-1 text-ink-gray-5">

--- a/frontend/src/components/CommunicationArea.vue
+++ b/frontend/src/components/CommunicationArea.vue
@@ -90,7 +90,7 @@ import Email2Icon from '@/components/Icons/Email2Icon.vue'
 import { usersStore } from '@/stores/users'
 import { useStorage } from '@vueuse/core'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import { call, createResource } from 'frappe-ui'
+import { call, createResource, toast } from 'frappe-ui'
 import { ref, watch, computed } from 'vue'
 
 const props = defineProps({
@@ -256,7 +256,11 @@ async function deleteAttachedFiles() {
 async function submitEmail() {
   if (emailEmpty.value) return
   showEmailBox.value = false
-  await sendMail()
+  await toast.promise(sendMail(), {
+    loading: __('Sending email...'),
+    success: __('Email sent!'),
+    error: (e) => e?.messages?.[0] || __('Failed to send email!'),
+  })
   newEmail.value = ''
   attachments.value = []
   reload.value = true
@@ -268,7 +272,11 @@ async function submitEmail() {
 async function submitComment() {
   if (commentEmpty.value) return
   showCommentBox.value = false
-  await sendComment()
+  await toast.promise(sendComment(), {
+    loading: __('Sending comment...'),
+    success: __('Comment sent!'),
+    error: (e) => e?.messages?.[0] || __('Failed to send comment!'),
+  })
   newComment.value = ''
   attachments.value = []
   reload.value = true

--- a/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
@@ -23,7 +23,7 @@
             () => {
               show = false
               showSettings = true
-              activeSettingsPage = 'Email Templates'
+              activeSettingsPage = 'Templates'
             }
           "
         />
@@ -72,7 +72,7 @@
               () => {
                 show = false
                 showSettings = true
-                activeSettingsPage = 'Email Templates'
+                activeSettingsPage = 'Templates'
               }
             "
           />

--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -115,7 +115,7 @@
                         />
                         <FormControl
                           v-else-if="field.fieldtype === 'Select'"
-                          class="form-control cursor-pointer [&_select]:cursor-pointer truncate"
+                          class="form-control cursor-pointer [&_select]:cursor-pointer truncate [&>*]:!ring-0"
                           type="select"
                           v-model="doc[field.fieldname]"
                           :options="field.options"


### PR DESCRIPTION
#### Fixes 

- Fix the borders of "No of employees field".
- After opening "email templates" and clicking on "new" it now opens Email template module in settings modal
- Show loading toast notification after sending reply
- Show toast when user tries to reply but email account is not set
- Fix the order of sub-activities of the activity, newer are now shown at the bottom