### PR TITLE
fix: updating annual_revenue field to deal_value

### DIFF
--- a/frontend/src/pages/Contact.vue
+++ b/frontend/src/pages/Contact.vue
@@ -521,7 +521,7 @@ const dealColumns = [
   },
   {
     label: __('Amount'),
-    key: 'annual_revenue',
+    key: 'deal_value',
     align: 'right',
     width: '9rem',
   },


### PR DESCRIPTION

Fixes #1581 On the Contact page, the "Deals" list shows "Amount" column using annual_revenue field instead of deal_value