### PR TITLE
fix(notes): stop click propagation on overflow menu trigger in NoteArea

### DIFF
--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -6,24 +6,26 @@
       <div class="truncate text-lg font-medium text-ink-gray-8">
         {{ note.title }}
       </div>
-      <Dropdown
-        :options="[
-          {
-            label: __('Delete'),
-            icon: 'trash-2',
-            onClick: () => deleteNote(note.name),
-          },
-        ]"
-        @click.stop
-        class="h-6 w-6"
-      >
-        <Button
-          icon="more-horizontal"
-          variant="ghosted"
-          class="!h-6 !w-6 hover:bg-surface-gray-2"
-          @click.stop.prevent
-        />
-      </Dropdown>
+      <div class="h-6 w-6" @click.stop>
+        <Dropdown
+          :options="[
+            {
+              label: __('Delete'),
+              icon: 'trash-2',
+              onClick: () => deleteNote(note.name),
+            },
+          ]"
+          @click.stop
+          class="h-6 w-6"
+        >
+          <Button
+            icon="more-horizontal"
+            variant="ghosted"
+            class="!h-6 !w-6 hover:bg-surface-gray-2"
+            @click.stop.prevent
+          />
+        </Dropdown>
+      </div>
     </div>
     <TextEditor
       v-if="note.content"


### PR DESCRIPTION
Fixes note card interaction where clicking ...  also trigger note edit modal.

![delete](https://github.com/user-attachments/assets/2451cfaa-a699-4548-b0cf-5144d7e73805)
