### PR TITLE
fix(mobile): ensure status dropdown loads on initial render for Lead and Deal

### DIFF
--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -10,17 +10,9 @@
       </Breadcrumbs>
       <div class="absolute right-0">
         <Dropdown
-          v-if="doc"
-          :options="
-            statusOptions(
-              'deal',
-              document.statuses?.length
-                ? document.statuses
-                : document._statuses,
-              triggerStatusChange,
-            )
-          "
-        >
+        v-if="doc && document.statuses"
+        :options="statuses"
+      >
           <template #default="{ open }">
             <Button
               v-if="doc.status"
@@ -342,6 +334,14 @@ const { triggerOnChange, assignees, document, scripts, error } = useDocument(
 )
 
 const doc = computed(() => document.doc || {})
+
+const statuses = computed(() => {
+  let customStatuses = document.statuses?.length
+    ? document.statuses
+    : document._statuses || []
+  return statusOptions('deal', customStatuses, triggerStatusChange)
+})
+
 
 watch(error, (err) => {
   if (err) {

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -10,17 +10,9 @@
       </Breadcrumbs>
       <div class="absolute right-0">
         <Dropdown
-          v-if="doc"
-          :options="
-            statusOptions(
-              'lead',
-              document.statuses?.length
-                ? document.statuses
-                : document._statuses,
-              triggerStatusChange,
-            )
-          "
-        >
+        v-if="doc && document.statuses"
+        :options="statuses"
+      >
           <template #default="{ open }">
             <Button
               v-if="doc.status"
@@ -234,6 +226,13 @@ watch(
 )
 
 const reload = ref(false)
+
+const statuses = computed(() => {
+  let customStatuses = document.statuses?.length
+    ? document.statuses
+    : document._statuses || []
+  return statusOptions('lead', customStatuses, triggerStatusChange)
+})
 
 const breadcrumbs = computed(() => {
   let items = [{ label: __('Leads'), route: { name: 'Leads' } }]


### PR DESCRIPTION
#1790 
Fixes an issue where the status dropdown in mobile Lead and Deal views did not open on initial render.

On first load in mobile layout, clicking the status field would not display the list of available statuses. After switching tabs or triggering a re-render, the dropdown would function correctly.

This was caused by evaluating `statusOptions()` inline in the template, which resulted in the dropdown mounting before options were properly resolved.

## Changes

- Replaced inline `statusOptions()` call in template with a computed `statuses` property.
- Bound `<Dropdown>` to `:options="statuses"` instead of calling the function directly.
- Applied fix to:
  - `MobileLead.vue`
  - `MobileDeal.vue`

## Result

- Status dropdown now opens correctly on first interaction.
- Consistent behavior between mobile and desktop views.
- No backend changes.

Fixes #1790