### PR TITLE
fix: transfer assignees from lead to deal on conversion

### DIFF
--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -347,6 +347,11 @@ class CRMLead(Document):
 			new_deal.update(deal)
 
 		new_deal.insert(ignore_permissions=True)
+
+		for user in self.get_assigned_users():
+			if user and user != new_deal.deal_owner:
+				new_deal.assign_agent(user)
+
 		return new_deal.name
 
 	def set_sla(self):

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -486,6 +486,27 @@ class TestCRMLead(IntegrationTestCase):
 		self.assertEqual(deal.annual_revenue, 750000)
 		self.assertEqual(deal.job_title, "CEO")
 
+	def test_assignees_transferred_on_conversion(self):
+		"""Test that additional assignees are transferred from lead to deal on conversion"""
+		lead = create_lead(
+			first_name="Transfer",
+			lead_owner="Administrator",
+		)
+
+		lead.assign_agent("crm.user1@example.com")
+
+		lead_assignees = lead.get_assigned_users()
+
+		self.assertIn("Administrator", lead_assignees)
+		self.assertIn("crm.user1@example.com", lead_assignees)
+
+		deal_name = lead.convert_to_deal()
+		deal = frappe.get_doc("CRM Deal", deal_name)
+
+		deal_assignees = deal.get_assigned_users()
+		self.assertIn("Administrator", deal_assignees)
+		self.assertIn("crm.user1@example.com", deal_assignees)
+
 
 def create_lead(**kwargs):
 	"""Helper function to create a CRM Lead for testing"""


### PR DESCRIPTION
When converting a lead to a deal, additional assignees were lost. Only the lead owner was carried over as deal owner.Now all assignees are transferred to the new deal.

**Before**

https://github.com/user-attachments/assets/8c1bc8ce-80e2-4710-95ab-3a7246322e61


**After**

https://github.com/user-attachments/assets/4ea49f95-c90c-466a-b2b9-04f65381f651





