### PR TITLE
fix(whatsapp) send notification only if it's an existing deal or lead

### DIFF
--- a/crm/api/whatsapp.py
+++ b/crm/api/whatsapp.py
@@ -67,6 +67,10 @@ def notify_agent(doc):
                 <span class="font-medium text-ink-gray-9">{doc.reference_name}</span>
             </div>
         """
+		
+		if not doc.reference_doctype or not doc.reference_name:
+			return False
+		
 		assigned_users = get_assigned_users(doc.reference_doctype, doc.reference_name)
 		for user in assigned_users:
 			notify_user(


### PR DESCRIPTION
Fixed error "Argument 'doctype' in 'crm.api.doc.get_assigned_users' should be of type 'str' but got 'NoneType' instead." when someone sends a WhatsApp message from an unknown number (No deal or lead exist).
Check Issue: #1830 https://github.com/frappe/crm/issues/1830