### PR TITLE
fix: assignment rule number field's value bug

### DIFF
--- a/frontend/src/components/ConditionsFilter/CFCondition.vue
+++ b/frontend/src/components/ConditionsFilter/CFCondition.vue
@@ -280,7 +280,7 @@ function updateValue(value) {
   if (condition[1] === 'between') {
     condition[2] = [value.split(',')[0], value.split(',')[1]]
   } else {
-    condition[2] = value + ''
+    condition[2] = isNaN(value) ? value : Number(value)
   }
 }
 

--- a/frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue
+++ b/frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue
@@ -79,6 +79,7 @@ import {
   toast,
 } from 'frappe-ui'
 import { inject, ref, reactive, watch } from 'vue'
+import { ConfirmDelete } from '../../../utils'
 
 const assignmentRulesList = inject('assignmentRulesList')
 const updateStep = inject('updateStep')
@@ -136,23 +137,10 @@ const dropdownOptions = [
     },
     icon: 'copy',
   },
-  {
-    label: __('Delete'),
-    icon: 'trash-2',
-    onClick: (e) => {
-      e.preventDefault()
-      e.stopImmediatePropagation()
-      isConfirmingDelete.value = true
-    },
-    condition: () => !isConfirmingDelete.value,
-  },
-  {
-    label: __('Confirm Delete'),
-    icon: 'trash-2',
-    theme: 'red',
-    onClick: () => deleteAssignmentRule(),
-    condition: () => isConfirmingDelete.value,
-  },
+  ...ConfirmDelete({
+    onConfirmDelete: () => deleteAssignmentRule(),
+    isConfirmingDelete,
+  }),
 ]
 
 const duplicate = () => {


### PR DESCRIPTION
Fix a bug where in the conditions filter, the number field's value was getting stored as `string` instead of `number`.

Fixes: #1719