### PR TITLE
fix: restrict update_modified_timestamp to specific document types

### DIFF
--- a/crm/utils/__init__.py
+++ b/crm/utils/__init__.py
@@ -292,16 +292,13 @@ def update_modified_timestamp(doc: Communication | Comment, method: str | None =
 	if not (doc.reference_doctype and doc.reference_name):
 		return
 
+	if doc.reference_doctype not in ["CRM Lead", "CRM Deal"]:
+		return
+
 	elif doc.doctype not in ["Comment", "Communication"]:
 		return
 
-	frappe.db.set_value(
-		dt=doc.reference_doctype,
-		dn=doc.reference_name,
-		field="modified",
-		val=now(),
-		update_modified=False,
-	)
+	frappe.db.set_value(dt=doc.reference_doctype, dn=doc.reference_name, field="modified", val=now())
 
 
 def update_communication_status(doc: Communication, method: str | None = None):


### PR DESCRIPTION
Fixes: https://github.com/frappe/crm/issues/1901
Fixes: https://github.com/frappe/crm/issues/1900