### PR TITLE
fix: WhatsApp webhook silently fails when incoming message is from unknown number

### DIFF
--- a/crm/api/whatsapp.py
+++ b/crm/api/whatsapp.py
@@ -37,10 +37,13 @@ def validate_access(reference_doctype=None, reference_name=None, permtype="read"
 def validate(doc, method):
 	phone_number = doc.get("from") if doc.type == "Incoming" else doc.get("to")
 	if phone_number:
-		name, doctype = get_contact_lead_or_deal_from_number(phone_number)
-		if doctype and name is not None:
-			doc.reference_doctype = doctype
-			doc.reference_name = name
+		try:
+			name, doctype = get_contact_lead_or_deal_from_number(phone_number)
+			if doctype and name is not None:
+				doc.reference_doctype = doctype
+				doc.reference_name = name
+		except Exception:
+			frappe.log_error("CRM WhatsApp: failed to resolve contact from number")
 
 
 def on_update(doc, method):
@@ -57,6 +60,8 @@ def on_update(doc, method):
 
 def notify_agent(doc):
 	if doc.type == "Incoming":
+		if not doc.reference_doctype or not doc.reference_name:
+			return
 		doctype = doc.reference_doctype
 		if doctype and doctype.startswith("CRM "):
 			doctype = doctype[4:].lower()

--- a/crm/tests/test_whatsapp.py
+++ b/crm/tests/test_whatsapp.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from crm.api.whatsapp import notify_agent, validate
+
+
+class TestWhatsAppHooks(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	# --- validate() ---
+
+	def test_validate_sets_reference_when_contact_found(self):
+		"""validate() links the doc when a matching Contact/Lead is found"""
+		doc = MagicMock()
+		doc.type = "Incoming"
+		doc.get.return_value = "+15551234567"
+
+		with patch(
+			"crm.api.whatsapp.get_contact_lead_or_deal_from_number",
+			return_value=("LEAD-0001", "CRM Lead"),
+		):
+			validate(doc, None)
+
+		self.assertEqual(doc.reference_doctype, "CRM Lead")
+		self.assertEqual(doc.reference_name, "LEAD-0001")
+
+	def test_validate_skips_reference_when_no_contact_found(self):
+		"""validate() leaves reference fields untouched when number is unknown"""
+		doc = MagicMock()
+		doc.type = "Incoming"
+		doc.get.return_value = "+15559999999"
+		doc.reference_doctype = None
+		doc.reference_name = None
+
+		with patch(
+			"crm.api.whatsapp.get_contact_lead_or_deal_from_number",
+			return_value=(None, None),
+		):
+			validate(doc, None)
+
+		self.assertIsNone(doc.reference_doctype)
+		self.assertIsNone(doc.reference_name)
+
+	def test_validate_logs_error_on_exception(self):
+		"""validate() catches lookup exceptions and logs them instead of raising"""
+		doc = MagicMock()
+		doc.type = "Incoming"
+		doc.get.return_value = "invalid-number"
+
+		with (
+			patch(
+				"crm.api.whatsapp.get_contact_lead_or_deal_from_number",
+				side_effect=Exception("parse error"),
+			),
+			patch("frappe.log_error") as mock_log,
+		):
+			validate(doc, None)  # must not raise
+
+		mock_log.assert_called_once()
+
+	# --- notify_agent() ---
+
+	def test_notify_agent_returns_early_when_no_reference(self):
+		"""notify_agent() skips notification when reference_doctype and reference_name are absent"""
+		doc = MagicMock()
+		doc.type = "Incoming"
+		doc.reference_doctype = None
+		doc.reference_name = None
+
+		with patch("crm.api.whatsapp.get_assigned_users") as mock_users:
+			notify_agent(doc)  # must not raise
+
+		mock_users.assert_not_called()
+
+	def test_notify_agent_returns_early_when_reference_doctype_missing(self):
+		"""notify_agent() skips notification when only reference_doctype is absent"""
+		doc = MagicMock()
+		doc.type = "Incoming"
+		doc.reference_doctype = ""
+		doc.reference_name = "LEAD-0001"
+
+		with patch("crm.api.whatsapp.get_assigned_users") as mock_users:
+			notify_agent(doc)
+
+		mock_users.assert_not_called()


### PR DESCRIPTION
## Description

When a WhatsApp message is received from a phone number that has no matching Contact, CRM Lead, or CRM Deal, the CRM app's doc_events hooks on WhatsApp Message cause the entire webhook transaction to fail silently — no message is saved at all.

## Root Cause

Two issues in `crm/api/whatsapp.py`:

### 1. `validate()` has no error handling

If `get_contact_lead_or_deal_from_number()` raises (e.g. due to phone number parsing failures via the `phonenumbers` library), the exception propagates out of the hook and rolls back the entire WhatsApp Message insert transaction.

### 2. `notify_agent()` crashes with None reference values

When `validate()` succeeds but finds no matching document (returns `None, None`), `reference_doctype` and `reference_name` remain unset. `notify_agent()` then proceeds to call `get_assigned_users(None, None)` and render `None` into the notification text, causing another exception inside the same transaction — silently rolling back the message save.

## Fix

- Wrap the `get_contact_lead_or_deal_from_number()` call in `validate()` with try/except, logging the error instead of raising  
- Add an early-return guard at the top of `notify_agent()` when `reference_doctype` or `reference_name` is absent  

After this fix, incoming messages from unknown numbers are saved successfully with empty reference fields and can be linked to a Contact/Lead manually afterwards.

## Testing

Added `crm/tests/test_whatsapp.py` covering:

- `validate()` sets reference fields when a contact is found  
- `validate()` leaves reference fields untouched when no contact is found  
- `validate()` logs the error and does not raise when lookup throws  
- `notify_agent()` returns early (no notification attempted) when reference fields are absent  