### PR TITLE
fix: full name has null as last name if not present

### DIFF
--- a/frontend/src/components/Settings/Profile/ProfileSettings.vue
+++ b/frontend/src/components/Settings/Profile/ProfileSettings.vue
@@ -160,7 +160,8 @@ const profileTooltipText = computed(() => {
 
 const fullNameRef = useTemplateRef('fullNameRef')
 const fullName = computed({
-  get: () => [user.doc.first_name, user.doc.last_name].filter(Boolean).join(" "),
+  get: () =>
+    [user.doc.first_name, user.doc.last_name].filter(Boolean).join(' '),
   set: (val) => {
     const [firstName, ...lastName] = val.split(' ')
     user.doc.first_name = firstName


### PR DESCRIPTION
<img width="532" height="248" alt="CleanShot 2026-03-31 at 21 44 10@2x" src="https://github.com/user-attachments/assets/d1940afd-a0a8-4b64-a8ba-877f6b13935c" />


Fixed from a [Doppio Box](https://boxes.buildwithhussain.com/).