### PR TITLE
feat(settings): add Brevo to email setup wizard

### DIFF
--- a/crm/api/settings.py
+++ b/crm/api/settings.py
@@ -81,6 +81,10 @@ email_service_config = {
 		"smtp_server": "smtp.sendgrid.net",
 		"smtp_port": 587,
 	},
+	"Brevo": {
+		"smtp_server": "smtp-relay.brevo.com",
+		"smtp_port": 587,
+	},
 	"SparkPost": {
 		"smtp_server": "smtp.sparkpostmail.com",
 	},

--- a/frontend/src/components/Settings/emailConfig.js
+++ b/frontend/src/components/Settings/emailConfig.js
@@ -3,6 +3,7 @@ import { validateEmail } from '../../utils'
 import LogoGmail from '@/images/gmail.png'
 import LogoOutlook from '@/images/outlook.png'
 import LogoSendgrid from '@/images/sendgrid.png'
+import LogoBrevo from '@/images/brevo.svg'
 import LogoSparkpost from '@/images/sparkpost.webp'
 import LogoYahoo from '@/images/yahoo.png'
 import LogoYandex from '@/images/yandex.png'
@@ -126,6 +127,15 @@ export const services = [
     custom: false,
   },
   {
+    name: 'Brevo',
+    icon: LogoBrevo,
+    info: __(
+      'Brevo uses an SMTP key for authentication (not your account password). Create an SMTP key in Brevo and use it as the password here. Read more',
+    ),
+    link: 'https://help.brevo.com/hc/en-us/articles/209467485-Create-an-SMTP-key',
+    custom: false,
+  },
+  {
     name: 'SparkPost',
     icon: LogoSparkpost,
     info: __(
@@ -167,6 +177,7 @@ export const emailIcon = {
   GMail: LogoGmail,
   Outlook: LogoOutlook,
   Sendgrid: LogoSendgrid,
+  Brevo: LogoBrevo,
   SparkPost: LogoSparkpost,
   Yahoo: LogoYahoo,
   Yandex: LogoYandex,

--- a/frontend/src/images/brevo.svg
+++ b/frontend/src/images/brevo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="Brevo">
+  <rect width="48" height="48" rx="10" fill="#0B996E"/>
+  <path fill="#fff" d="M12 28c0-5 4-9 9-9h11v4H21c-2.8 0-5 2.2-5 5s2.2 5 5 5h11v4H21c-5 0-9-4-9-9zm15-14v4h6c2.2 0 4-1.8 4-4s-1.8-4-4-4h-6z"/>
+</svg>


### PR DESCRIPTION
## Summary
Adds [Brevo](https://www.brevo.com/) (SMTP relay) to the **Setup Email** provider list in CRM Settings, and wires the same SMTP host/port as the Frappe **Email Account** preset.

## Changes
- `emailConfig.js`: new provider tile + `emailIcon` entry
- `settings.py`: `email_service_config['Brevo']` → `smtp-relay.brevo.com`, port **587**
- `frontend/src/images/brevo.svg`: icon (simple brand-colour tile; maintainers may replace with official asset)

## Pairing with framework
Uses **Service** value `Brevo`, matching the **Email Account** option proposed in frappe/frappe (same SMTP defaults).

## User notes
- Brevo expects the **SMTP key** as the password field ([docs](https://help.brevo.com/hc/en-us/articles/209467485-Create-an-SMTP-key)).


Made with [Cursor](https://cursor.com)