### PR TITLE
fix: initialize FCRM Settings currency from site default after setup

### DIFF
--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -87,7 +87,10 @@ website_route_rules = [
 # Setup wizard
 # setup_wizard_requires = "assets/crm/js/setup_wizard.js"
 # setup_wizard_stages = "crm.setup.setup_wizard.setup_wizard.get_setup_stages"
-setup_wizard_complete = "crm.demo.api.create_demo_data"
+setup_wizard_complete = [
+    "crm.install.set_default_currency",
+    "crm.demo.api.create_demo_data",
+]
 # setup_wizard_test = "crm.setup.setup_wizard.test_setup_wizard.run_setup_wizard_test"
 
 # Installation

--- a/crm/install.py
+++ b/crm/install.py
@@ -31,6 +31,7 @@ def after_install(force=False):
 	create_default_manager_dashboard(force)
 	create_assignment_rule_custom_fields()
 	add_assignment_rule_property_setters()
+	set_default_currency()
 	frappe.db.commit()
 
 
@@ -561,3 +562,12 @@ def create_assignment_rule_custom_fields():
 		)
 
 		frappe.clear_cache(doctype="Assignment Rule")
+
+def set_default_currency(args=None):
+    default_currency = frappe.db.get_default("currency")
+    if not default_currency:
+        return
+    settings = frappe.get_single("FCRM Settings")
+    if not settings.currency:
+        settings.currency = default_currency
+        settings.save(ignore_permissions=True)


### PR DESCRIPTION
## Problem
After a fresh install, `FCRM Settings.currency` is not initialized from the currency selected during the setup wizard. It remains empty or defaults to INR regardless of what was chosen.

## Root Cause
The `setup_wizard_complete` hook only called `create_demo_data` , nothing was reading the selected currency from `Global Defaults` and writing it  to `FCRM Settings`.

## Fix
Added `set_default_currency()` to the `setup_wizard_complete` hook. It reads `Global Defaults.default_currency` and sets it on `FCRM Settings.currency`  if not already configured.

## Testing
Fresh install with United States / USD selected in setup wizard → FCRM Settings correctly shows USD after setup completes.

Fixes #1967