### PR TITLE
fix: sort tasks by logical priority order instead of alphabetical

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -382,35 +382,25 @@ def get_data(
 		if group_by_field and group_by_field not in rows:
 			rows.append(group_by_field)
 
-
 		# After frappe.get_list returns data, sort by priority
-		PRIORITY_ORDER = {"High": 0, "Medium": 1, "Low": 2}
+		priority_map = {"High": 0, "Medium": 1, "Low": 2}
 
-		if order_by and "priority" in order_by:
-			direction = "desc" if "desc" in order_by else "asc"
-			reverse = direction == "desc"
-			data = sorted(
-				frappe.get_list(
-					doctype,
-					fields=rows,
-					filters=filters,
-					order_by="modified desc",
-					page_length=page_length,
-				) or [],
-				key=lambda x: PRIORITY_ORDER.get(x.get("priority"), 99),
-				reverse=reverse,
+		is_priority_sort = order_by and "priority" in order_by
+		reverse = "desc" in order_by if is_priority_sort else False
+
+		data = (
+			frappe.get_list(
+				doctype,
+				fields=rows,
+				filters=filters,
+				order_by=order_by if not is_priority_sort else "modified desc",
+				page_length=page_length,
 			)
-		else:
-			data = (
-				frappe.get_list(
-					doctype,
-					fields=rows,
-					filters=filters,
-					order_by=order_by,
-					page_length=page_length,
-				)
-				or []
-			)
+			or []
+		)
+
+		if is_priority_sort:
+			data.sort(key=lambda x: priority_map.get(x.get("priority"), 99), reverse=reverse)
 		data = parse_list_data(data, doctype)
 
 	if view_type == "kanban":

--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -382,16 +382,35 @@ def get_data(
 		if group_by_field and group_by_field not in rows:
 			rows.append(group_by_field)
 
-		data = (
-			frappe.get_list(
-				doctype,
-				fields=rows,
-				filters=filters,
-				order_by=order_by,
-				page_length=page_length,
+
+		# After frappe.get_list returns data, sort by priority
+		PRIORITY_ORDER = {"High": 0, "Medium": 1, "Low": 2}
+
+		if order_by and "priority" in order_by:
+			direction = "desc" if "desc" in order_by else "asc"
+			reverse = direction == "desc"
+			data = sorted(
+				frappe.get_list(
+					doctype,
+					fields=rows,
+					filters=filters,
+					order_by="modified desc",
+					page_length=page_length,
+				) or [],
+				key=lambda x: PRIORITY_ORDER.get(x.get("priority"), 99),
+				reverse=reverse,
 			)
-			or []
-		)
+		else:
+			data = (
+				frappe.get_list(
+					doctype,
+					fields=rows,
+					filters=filters,
+					order_by=order_by,
+					page_length=page_length,
+				)
+				or []
+			)
 		data = parse_list_data(data, doctype)
 
 	if view_type == "kanban":


### PR DESCRIPTION
## Problem
When sorting tasks by Priority, the order was High → Low → Medium (alphabetical) instead of the expected High → Medium → Low or Low → Medium → High.

## Root Cause
`frappe.get_list` sorts the `priority` field alphabetically by default.  Frappe's query builder does not allow raw SQL expressions like `FIELD()` in `order_by`, so the sort cannot be overridden at the database level.

## Fix
When `order_by` contains `priority`, fetch data normally and re-sort in Python using a logical priority order map `{High: 0, Medium: 1, Low: 2}`.

## Testing
Tasks sorted by Priority asc: Low → Medium → High ✅
<img width="1292" height="410" alt="Screenshot 2026-04-09 at 06 56 37" src="https://github.com/user-attachments/assets/73c714e2-8408-4d26-9d9f-03a3ffc6998f" />



Tasks sorted by Priority desc: High → Medium → Low ✅
<img width="1296" height="439" alt="Screenshot 2026-04-09 at 06 55 50" src="https://github.com/user-attachments/assets/bb5f1277-8036-45e4-9698-207583232885" />

Fixes #1882