### PR TITLE
fix: use per-site socketio_port instead of common config

### DIFF
--- a/crm/www/crm.py
+++ b/crm/www/crm.py
@@ -52,6 +52,7 @@ def get_boot():
 				"user": frappe.db.get_value("User", frappe.session.user, "time_zone")
 				or get_system_timezone(),
 			},
+			"socketio_port": frappe.conf.socketio_port or 9000,
 		}
 	)
 

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,11 +1,10 @@
 import { io } from 'socket.io-client'
-import { socketio_port } from '../../../../sites/common_site_config.json'
 import { getCachedListResource, getCachedResource } from 'frappe-ui'
 
 export function initSocket() {
   let host = window.location.hostname
   let siteName = window.site_name
-  let port = window.location.port ? `:${socketio_port}` : ''
+  let port = window.location.port ? `:${window.socketio_port}` : ''
   let protocol = port ? 'http' : 'https'
   let url = `${protocol}://${host}${port}/${siteName}`
 


### PR DESCRIPTION
## Problem
In a multi-site bench setup, `socket.js` imports `socketio_port` from `common_site_config.json` at build time. This means all sites use the same socketio port regardless of what is configured in each site's `site_config.json`, causing WebSocket connections to fail on sites with a different `socketio_port`.

## Root Cause
Two issues:
1. `socket.js` imports `socketio_port` from `common_site_config.json`  at build time — this is a static value shared across all sites
2. `crm/www/crm.py` never included `socketio_port` in the boot context, so `window.socketio_port` was always `undefined` in CRM's frontend

## Fix
1. Added `socketio_port` to `get_boot()` in `crm/www/crm.py` so it is  injected per-site at runtime via the boot context
2. Updated `socket.js` to use `window.socketio_port` instead of the build-time JSON import, matching how Frappe Desk handles this in `base.html`

## Testing
Multi-site bench with two sites:

- `opensource.localhost` — `socketio_port: 9000` → connects to **9000** ✅
<img width="868" height="825" alt="opensource.localhost connecting to port 9000" src="https://github.com/user-attachments/assets/ce42ff18-2090-4a82-9a74-55c3dfd7903b" />
*WebSocket successfully connects to port 9000 (matches site config)*

- `crm2.localhost` — `socketio_port: 9001` in `site_config.json` → attempts **9001** first ✅
<img width="876" height="769" alt="crm2.localhost attempting port 9001" src="https://github.com/user-attachments/assets/001798d6-a759-4523-8fe2-fa741abffaa5" />
*CRM correctly reads per-site config and attempts port 9001 first. Connection refused because no socketio server is running on 9001 in this test bench — this confirms the per-site port is being read correctly. It then falls back to the available server on 9000.*

**Before fix:** `crm2.localhost` always connected directly to 9000 (common config), never attempting 9001

**After fix:** `crm2.localhost` correctly reads per-site `socketio_port: 9001` from `site_config.json`

Fixes #1931