### PR TITLE
fix: useBroadcast to open the modal

### DIFF
--- a/frontend/src/components/Layouts/AppSidebar.vue
+++ b/frontend/src/components/Layouts/AppSidebar.vue
@@ -184,6 +184,7 @@ import { usersStore } from '@/stores/users'
 import { sessionStore } from '@/stores/session'
 import { showSettings, activeSettingsPage } from '@/composables/settings'
 import { showChangePasswordModal } from '@/composables/modals'
+import { useBroadcast } from '@/composables/useBroadcast.js'
 import { FeatherIcon, call } from 'frappe-ui'
 import {
   SignupBanner,
@@ -205,6 +206,7 @@ const { getPinnedViews, getPublicViews } = viewsStore()
 const { toggle: toggleNotificationPanel } = notificationsStore()
 const { capture } = useTelemetry()
 const { clearDemoData, isDemoDataCreated } = useDemoData()
+const { send } = useBroadcast()
 
 const isSidebarCollapsed = useStorage('isSidebarCollapsed', false)
 
@@ -366,6 +368,7 @@ const steps = reactive([
     onClick: () => {
       minimize.value = true
       router.push({ name: 'Leads' })
+      send('trigger_lead_create', true)
       capture('onboarding_step_clicked_create_first_lead')
     },
   },

--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -305,6 +305,7 @@ import { globalStore } from '@/stores/global'
 import { usersStore } from '@/stores/users'
 import { statusesStore } from '@/stores/statuses'
 import { callEnabled } from '@/composables/settings'
+import { useBroadcast } from '@/composables/useBroadcast'
 import { formatDate, timeAgo, website, formatTime } from '@/utils'
 import { Avatar, Tooltip, Dropdown } from 'frappe-ui'
 import { useRoute } from 'vue-router'
@@ -315,11 +316,16 @@ const { getFormattedPercent, getFormattedFloat, getFormattedCurrency } =
 const { makeCall } = globalStore()
 const { getUser } = usersStore()
 const { getLeadStatus } = statusesStore()
+const { on } = useBroadcast()
 
 const route = useRoute()
 
 const leadsListView = ref(null)
 const showLeadModal = ref(false)
+
+on('trigger_lead_create', (data) => {
+  showLeadModal.value = Boolean(data)
+})
 
 const defaults = reactive({})
 


### PR DESCRIPTION
In the getting started panel there is button "Create your first lead". When user clicks on it, user is taken to a leads page and no other visual feedback is given as one should get to such action.    

This ensures that the create lead modal is directly opened when user clicks on "Create your first lead"