### PR TITLE
fix: get fieldname from doctype meta in filters

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -76,21 +76,13 @@ def get_filterable_fields(doctype: str):
 	if hasattr(c, "get_non_filterable_fields"):
 		restricted_fields = c.get_non_filterable_fields()
 
-	res = []
+	fields = []
 
-	# append DocFields
-	DocField = frappe.qb.DocType("DocField")
-	doc_fields = get_doctype_fields_meta(DocField, doctype, allowed_fieldtypes, restricted_fields)
-	res.extend(doc_fields)
-
-	# append Custom Fields
-	CustomField = frappe.qb.DocType("Custom Field")
-	custom_fields = get_doctype_fields_meta(CustomField, doctype, allowed_fieldtypes, restricted_fields)
-	res.extend(custom_fields)
+	meta = frappe.get_meta(doctype).as_dict()
 
 	# append standard fields (getting error when using frappe.model.std_fields)
 	standard_fields = [
-		{"fieldname": "name", "fieldtype": "Link", "label": "ID", "options": doctype},
+		{"fieldname": "name", "fieldtype": "Link", "label": "Name", "options": doctype},
 		{"fieldname": "owner", "fieldtype": "Link", "label": "Created By", "options": "User"},
 		{
 			"fieldname": "modified_by",
@@ -105,22 +97,15 @@ def get_filterable_fields(doctype: str):
 		{"fieldname": "creation", "fieldtype": "Datetime", "label": "Created On"},
 		{"fieldname": "modified", "fieldtype": "Datetime", "label": "Last Updated On"},
 	]
-	for field in standard_fields:
+
+	for field in standard_fields + meta.get("fields", []):
 		if field.get("fieldname") not in restricted_fields and field.get("fieldtype") in allowed_fieldtypes:
 			field["name"] = field.get("fieldname")
-			res.append(field)
-
-	meta = frappe.get_meta(doctype).fields
-	meta_fields = {f.fieldname: f for f in meta}
-	for field in res:
-		fieldname = field.get("fieldname")
-		if fieldname in meta_fields:
-			field["label"] = _(meta_fields[fieldname].label)
-		else:
 			field["label"] = _(field.get("label"))
-		field["value"] = field.get("fieldname")
+			field["value"] = field.get("fieldname")
+			fields.append(field)
 
-	return res
+	return fields
 
 
 @frappe.whitelist()
@@ -172,25 +157,6 @@ def get_group_by_fields(doctype: str):
 		fields.append(field)
 
 	return fields
-
-
-def get_doctype_fields_meta(DocField, doctype, allowed_fieldtypes, restricted_fields):
-	parent = "parent" if DocField._table_name == "tabDocField" else "dt"
-	return (
-		frappe.qb.from_(DocField)
-		.select(
-			DocField.fieldname,
-			DocField.fieldtype,
-			DocField.label,
-			DocField.name,
-			DocField.options,
-		)
-		.where(DocField[parent] == doctype)
-		.where(DocField.hidden == False)  # noqa: E712
-		.where(Criterion.any([DocField.fieldtype == i for i in allowed_fieldtypes]))
-		.where(Criterion.all([DocField.fieldname != i for i in restricted_fields]))
-		.run(as_dict=True)
-	)
 
 
 @frappe.whitelist()

--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -110,8 +110,14 @@ def get_filterable_fields(doctype: str):
 			field["name"] = field.get("fieldname")
 			res.append(field)
 
+	meta = frappe.get_meta(doctype).fields
+	meta_fields = {f.fieldname: f for f in meta}
 	for field in res:
-		field["label"] = _(field.get("label"))
+		fieldname = field.get("fieldname")
+		if fieldname in meta_fields:
+			field["label"] = _(meta_fields[fieldname].label)
+		else:
+			field["label"] = _(field.get("label"))
 		field["value"] = field.get("fieldname")
 
 	return res


### PR DESCRIPTION
`get_filterable_fields` queries the DocField table directly which only has original field labels. Labels customized in Customize Form are stored in Property Setters and were not being applied. This uses `frappe.get_meta()` to get the correct labels. 
Renamed field: 
<img width="600" height="400" alt="custom_field" src="https://github.com/user-attachments/assets/a1a21036-946d-4953-af74-5b0bfc149682" />
Before:
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/a0f38a32-3636-44ec-a97f-db559526daeb" />
After: 
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/5d04583a-7843-4d8f-b2d6-696fca9b4567" />

