### PR TITLE
fix: use light theme by default

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,8 +20,10 @@ import { computed, defineAsyncComponent, provide } from 'vue'
 const session = sessionStore()
 provide('session', session)
 
-const { initializeTheme } = useTheme()
-initializeTheme()
+const { setTheme } = useTheme()
+if (!localStorage.getItem('theme')) {
+  setTheme('light')
+}
 
 const MobileLayout = defineAsyncComponent(
   () => import('./components/Layouts/MobileLayout.vue'),


### PR DESCRIPTION
use light theme by default instead of system theme when no theme is found in localstorage