### PR TITLE
fix: unable to view email content

### DIFF
--- a/frontend/src/components/Activities/EmailContent.vue
+++ b/frontend/src/components/Activities/EmailContent.vue
@@ -13,7 +13,10 @@ const props = defineProps({
   content: { type: String, required: true },
 })
 
-const files = import.meta.glob('/src/index.css', { eager: true, query: '?inline' });
+const files = import.meta.glob('/src/index.css', {
+  eager: true,
+  query: '?inline',
+})
 const css = files['/src/index.css'].default
 
 const iframeRef = ref(null)

--- a/frontend/src/components/Activities/EmailContent.vue
+++ b/frontend/src/components/Activities/EmailContent.vue
@@ -13,7 +13,7 @@ const props = defineProps({
   content: { type: String, required: true },
 })
 
-const files = import.meta.globEager('/src/index.css', { query: '?inline' })
+const files = import.meta.glob('/src/index.css', { eager: true, query: '?inline' });
 const css = files['/src/index.css'].default
 
 const iframeRef = ref(null)


### PR DESCRIPTION
in vite 5 `import.meta.globEager` is deprecated, use  `import.meta.glob('*', { eager: true })` instead [ref](https://vite.dev/guide/features#glob-import)