### PR TITLE
Fix: Remove All button allows to re-attach files

### DIFF
--- a/frontend/src/components/FilesUploader/FilesUploaderArea.vue
+++ b/frontend/src/components/FilesUploader/FilesUploaderArea.vue
@@ -198,6 +198,7 @@ function browseFiles() {
 
 function onFileInput() {
   addFiles(fileInput.value.files)
+  fileInput.value.value = ''
 }
 
 const video = ref(null)


### PR DESCRIPTION
## Summary:

- After removing files using the "Remove All" option, users were unable to re-attach the same file(s) without refreshing the page. 
- This was because the file input element retained its value even after files were removed, preventing the change event from firing when the same file was selected again.

> Fixes: https://github.com/frappe/crm/issues/2017

### How to Test
1. Go to Leads/Deals page → Attachment Tab
2. Click Upload Attachment
3. Select a file (don't attach)
4. Click "Remove All" button
5. Try to select the same file again
6. Verify the file now appears in the attachment list
