### PR TITLE
fix: unable to disable email template

### DIFF
--- a/frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue
+++ b/frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue
@@ -102,7 +102,9 @@
               <Switch
                 v-model="template.enabled"
                 size="sm"
-                @update:model-value="toggleEmailTemplate(template)"
+                @update:model-value="
+                  (val) => toggleEmailTemplate(template, val)
+                "
                 @click.stop
               />
               <Dropdown
@@ -185,16 +187,16 @@ const templatesList = computed(() => {
   return list
 })
 
-function toggleEmailTemplate(template) {
+function toggleEmailTemplate(template, enabledVal) {
   templates.setValue.submit(
     {
       name: template.name,
-      enabled: template.enabled ? 1 : 0,
+      enabled: enabledVal ? 1 : 0,
     },
     {
       onSuccess: () => {
         toast.success(
-          template.enabled
+          enabledVal
             ? __('Template enabled successfully')
             : __('Template disabled successfully'),
         )
@@ -203,7 +205,7 @@ function toggleEmailTemplate(template) {
       onError: (error) => {
         toast.error(error.messages[0] || __('Failed to update template'))
         // Revert the change if there was an error
-        template.enabled = !template.enabled
+        template.enabled = !enabledVal
       },
     },
   )


### PR DESCRIPTION
issue:

https://github.com/user-attachments/assets/722e0809-3548-4d90-8bc7-37a8b3abca2a


Toggling an Email Template's Enabled switch worked correctly in dev but not in the production build. Disabling an enabled template showed the "enabled successfully" toast and the switch snapped back to on. My hunch is that when `setValue` resolves, the server response back onto the same object which changes `template.enabled` from a boolean to an integer. And by the time `onSuccess` runs, template.enabled no longer shows what the user just clicked, just whatever the server sent back

fix: explicitly pass the toggled value in the `toggleEmailTemplate` method