### PR TITLE
fix: action buttons missing on doctype modal in prod build

### DIFF
--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -14,6 +14,7 @@ const assigneesCache = {}
 const permissionsCache = {}
 
 export function useDocument(doctype, docname, resourceOverrides = {}) {
+  if (typeof docname === 'number') docname = String(docname)
   const { setupScript, scripts } = getScript(doctype)
   const meta = getMeta(doctype)
   const { trackOldFile, processPendingDeletions } = useAttachments(

--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -174,7 +174,7 @@ export function useDocument(doctype, docname, resourceOverrides = {}) {
 
     const organizedControllers = {}
     for (const controller of controllersArray) {
-      const controllerKey = controller.constructor.name // e.g., "CRMLead", "CRMProducts"
+      const controllerKey = controller._className || controller.constructor.name
       if (!organizedControllers[controllerKey]) {
         organizedControllers[controllerKey] = []
       }

--- a/frontend/src/data/script.js
+++ b/frontend/src/data/script.js
@@ -133,6 +133,7 @@ export function getScript(doctype, view = 'Form') {
         parentInstance,
         isChildDoctype,
       )
+      instance._className = className
 
       controllers.push(instance)
     }
@@ -237,7 +238,9 @@ export function getScript(doctype, view = 'Form') {
           dt = field?.options?.replace(/\s+/g, '')
 
           if (!idx && dt) {
-            idx = this.find((r) => r.constructor.name === dt)?.currentRowIdx
+            idx = this.find(
+              (r) => (r._className || r.constructor.name) === dt,
+            )?.currentRowIdx
           }
         }
 
@@ -264,7 +267,7 @@ export function getScript(doctype, view = 'Form') {
         if (this instanceof Array && dt) {
           return createDocProxy(
             row,
-            this.find((r) => r.constructor.name === dt),
+            this.find((r) => (r._className || r.constructor.name) === dt),
           )
         }
 


### PR DESCRIPTION
### Problem:
CRM Task's "Open Lead" button is rendered by document.actions, which is set inside CRMTask.onRender(). For onRender to run, the controller has to be looked up from a cache:

  document.js:
  organizedControllers[controller.constructor.name] = [controller]

  then: 
  controllers[doctype.replace(/\s+/g, '')]   // "CRMTask"

  In dev, class CRMTask keeps its name, so constructor.name === "CRMTask" and the lookup works fine.

  In prod, Vite minifies the class to class n. The export alias (export { n as CRMTask }) preserves only the module's export key, not the class's .name. So the cache stored as "n" which misses on lookup.

  **Fix**:  preserve the export name on the instance and use it as the key.