### PR TITLE
perf: speed up session.get_users; unblock CRM frontend at scale

### DIFF
--- a/crm/api/session.py
+++ b/crm/api/session.py
@@ -33,7 +33,7 @@ USER_FIELDS = [
 
 
 @frappe.whitelist()
-def get_users(include_all=False):
+def get_users(include_all: bool = False):
 	"""Return (users, crm_users) for the CRM frontend.
 
 	By default (`include_all=False`) the User query is filtered at SQL level
@@ -135,7 +135,7 @@ def get_users(include_all=False):
 
 
 @frappe.whitelist()
-def get_user_info(users):
+def get_user_info(users: str | list):
 	"""Resolve display info for a batch of User names.
 
 	Used by the frontend to fill in name/avatar info for non-CRM users

--- a/crm/api/session.py
+++ b/crm/api/session.py
@@ -43,26 +43,24 @@ def get_users():
 	if not users:
 		return [], []
 
-	user_names = [u.name for u in users]
 	system_language = frappe.db.get_single_value("System Settings", "language")
 	session_user = frappe.session.user
 
+	# Read every Has Role row for User parents in one indexed scan.
+	# An IN clause with one entry per user inflates the SQL string to MBs on
+	# large sites; the parenttype filter is selective enough on its own.
 	role_rows = frappe.get_all(
 		"Has Role",
-		filters={"parent": ["in", user_names], "parenttype": "User"},
+		filters={"parenttype": "User"},
 		fields=["parent", "role"],
 	)
 	roles_by_user = {}
 	for row in role_rows:
 		roles_by_user.setdefault(row.parent, []).append(row.role)
 
-	telephony_agents = set(
-		frappe.get_all(
-			"CRM Telephony Agent",
-			filters={"user": ["in", user_names]},
-			pluck="user",
-		)
-	)
+	# Telephony agent table is tiny on any real site; a full pluck is cheaper
+	# than serializing a huge IN list and gives identical results.
+	telephony_agents = set(frappe.get_all("CRM Telephony Agent", pluck="user"))
 
 	role_priority = ("System Manager", "Sales Manager", "Sales User", "Guest")
 	crm_users = []
@@ -71,14 +69,20 @@ def get_users():
 		if session_user == user.name:
 			user.session_user = True
 
-		# Mirror frappe.get_roles() which appends implicit "All" and "Guest"
-		user.roles = roles_by_user.get(user.name, []) + ["All", "Guest"]
-
-		user.role = ""
-		for role in role_priority:
-			if role in user.roles:
-				user.role = role
-				break
+		# Administrator has every role implicitly via frappe.get_roles() but
+		# its Has Role child table is not guaranteed to contain System Manager
+		# on every install — special-case it to avoid locking the admin out.
+		if user.name == "Administrator":
+			user.roles = ["System Manager", "All"]
+			user.role = "System Manager"
+		else:
+			# Mirror frappe.get_roles() which appends implicit "All" and "Guest"
+			user.roles = roles_by_user.get(user.name, []) + ["All", "Guest"]
+			user.role = ""
+			for role in role_priority:
+				if role in user.roles:
+					user.role = role
+					break
 
 		user.is_telephony_agent = user.name in telephony_agents
 		user.language = user.language or system_language

--- a/crm/api/session.py
+++ b/crm/api/session.py
@@ -37,37 +37,53 @@ def get_users():
 			"language",
 		],
 		order_by="full_name asc",
-		distinct=True,
 		filters={"enabled": 1},
 	).run(as_dict=1)
 
-	crm_users = []
+	if not users:
+		return [], []
+
+	user_names = [u.name for u in users]
 	system_language = frappe.db.get_single_value("System Settings", "language")
+	session_user = frappe.session.user
+
+	role_rows = frappe.get_all(
+		"Has Role",
+		filters={"parent": ["in", user_names], "parenttype": "User"},
+		fields=["parent", "role"],
+	)
+	roles_by_user = {}
+	for row in role_rows:
+		roles_by_user.setdefault(row.parent, []).append(row.role)
+
+	telephony_agents = set(
+		frappe.get_all(
+			"CRM Telephony Agent",
+			filters={"user": ["in", user_names]},
+			pluck="user",
+		)
+	)
+
+	role_priority = ("System Manager", "Sales Manager", "Sales User", "Guest")
+	crm_users = []
 
 	for user in users:
-		if frappe.session.user == user.name:
+		if session_user == user.name:
 			user.session_user = True
 
-		user.roles = frappe.get_roles(user.name)
+		# Mirror frappe.get_roles() which appends implicit "All" and "Guest"
+		user.roles = roles_by_user.get(user.name, []) + ["All", "Guest"]
 
 		user.role = ""
+		for role in role_priority:
+			if role in user.roles:
+				user.role = role
+				break
 
-		if "System Manager" in user.roles:
-			user.role = "System Manager"
-		elif "Sales Manager" in user.roles:
-			user.role = "Sales Manager"
-		elif "Sales User" in user.roles:
-			user.role = "Sales User"
-		elif "Guest" in user.roles:
-			user.role = "Guest"
-
-		if frappe.session.user == user.name:
-			user.session_user = True
-
-		user.is_telephony_agent = frappe.db.exists("CRM Telephony Agent", {"user": user.name})
+		user.is_telephony_agent = user.name in telephony_agents
 		user.language = user.language or system_language
 
-		if user.role in ("System Manager", "Sales Manager", "Sales User"):
+		if user.role in CRM_ALLOWED_ROLES:
 			crm_users.append(user)
 
 	if not session_roles["is_system_manager"]:

--- a/crm/api/session.py
+++ b/crm/api/session.py
@@ -19,25 +19,62 @@ def get_session_role_flags():
 	}
 
 
+USER_FIELDS = [
+	"name",
+	"email",
+	"enabled",
+	"user_image",
+	"first_name",
+	"last_name",
+	"full_name",
+	"user_type",
+	"language",
+]
+
+
 @frappe.whitelist()
-def get_users():
+def get_users(include_all=False):
+	"""Return (users, crm_users) for the CRM frontend.
+
+	By default (`include_all=False`) the User query is filtered at SQL level
+	to just users with CRM roles — typically a handful of rows. This unblocks
+	the UI on initial load even on sites with hundreds of thousands of users.
+
+	When `include_all=True` and the session has System Manager, the full
+	enabled user list is returned. The frontend uses this path for a
+	non-blocking background fetch that populates name/avatar info for
+	non-CRM users referenced in CRM activity. Non-System-Manager sessions
+	cannot escalate by passing this param.
+	"""
 	session_roles = get_session_role_flags()
+
+	# Param arrives as a string from the HTTP layer; coerce.
+	if isinstance(include_all, str):
+		include_all = include_all.lower() in ("1", "true", "yes")
+	if not session_roles["is_system_manager"]:
+		include_all = False
+
+	# Always need the CRM user name set — used both as the filter for the
+	# fast path and as the membership check on the full path.
+	crm_user_names = set(
+		frappe.get_all(
+			"Has Role",
+			filters={"parenttype": "User", "role": ["in", CRM_ALLOWED_ROLES]},
+			pluck="parent",
+			distinct=True,
+		)
+	)
+	crm_user_names.add("Administrator")
+
+	user_filters = {"enabled": 1}
+	if not include_all:
+		user_filters["name"] = ["in", list(crm_user_names)]
 
 	users = frappe.qb.get_query(
 		"User",
-		fields=[
-			"name",
-			"email",
-			"enabled",
-			"user_image",
-			"first_name",
-			"last_name",
-			"full_name",
-			"user_type",
-			"language",
-		],
+		fields=USER_FIELDS,
 		order_by="full_name asc",
-		filters={"enabled": 1},
+		filters=user_filters,
 	).run(as_dict=1)
 
 	if not users:
@@ -46,20 +83,20 @@ def get_users():
 	system_language = frappe.db.get_single_value("System Settings", "language")
 	session_user = frappe.session.user
 
-	# Read every Has Role row for User parents in one indexed scan.
-	# An IN clause with one entry per user inflates the SQL string to MBs on
-	# large sites; the parenttype filter is selective enough on its own.
-	role_rows = frappe.get_all(
-		"Has Role",
-		filters={"parenttype": "User"},
-		fields=["parent", "role"],
-	)
+	# Has Role lookup — restrict by parent on the fast path (tiny IN list);
+	# unfiltered scan on the full path because the IN list would otherwise
+	# carry every enabled user name (see commit dropping IN-list filters).
+	if include_all:
+		role_filters = {"parenttype": "User"}
+	else:
+		role_filters = {"parenttype": "User", "parent": ["in", list(crm_user_names)]}
+	role_rows = frappe.get_all("Has Role", filters=role_filters, fields=["parent", "role"])
 	roles_by_user = {}
 	for row in role_rows:
 		roles_by_user.setdefault(row.parent, []).append(row.role)
 
-	# Telephony agent table is tiny on any real site; a full pluck is cheaper
-	# than serializing a huge IN list and gives identical results.
+	# Telephony agent table is tiny on any real site; full pluck is cheaper
+	# than serializing an IN list and gives identical results.
 	telephony_agents = set(frappe.get_all("CRM Telephony Agent", pluck="user"))
 
 	role_priority = ("System Manager", "Sales Manager", "Sales User", "Guest")
@@ -77,7 +114,7 @@ def get_users():
 			user.role = "System Manager"
 		else:
 			# Mirror frappe.get_roles() which appends implicit "All" and "Guest"
-			user.roles = roles_by_user.get(user.name, []) + ["All", "Guest"]
+			user.roles = [*roles_by_user.get(user.name, []), "All", "Guest"]
 			user.role = ""
 			for role in role_priority:
 				if role in user.roles:
@@ -90,10 +127,34 @@ def get_users():
 		if user.role in CRM_ALLOWED_ROLES:
 			crm_users.append(user)
 
-	if not session_roles["is_system_manager"]:
-		users = crm_users
+	if not include_all:
+		# Fast path — both positions are the CRM users.
+		return crm_users, crm_users
 
 	return users, crm_users
+
+
+@frappe.whitelist()
+def get_user_info(users):
+	"""Resolve display info for a batch of User names.
+
+	Used by the frontend to fill in name/avatar info for non-CRM users
+	referenced in CRM activity (comment authors, doc owners, etc.) when
+	the background full-list fetch has not yet landed. Gated behind a
+	CRM role; capped at 200 names per call to limit enumeration cost.
+	"""
+	get_session_role_flags()
+
+	if isinstance(users, str):
+		users = frappe.parse_json(users)
+	if not users:
+		return []
+
+	return frappe.get_all(
+		"User",
+		filters={"name": ["in", list(users)[:200]]},
+		fields=["name", "email", "full_name", "user_image", "user_type"],
+	)
 
 
 @frappe.whitelist()

--- a/frontend/src/components/Controls/EmailMultiSelect.vue
+++ b/frontend/src/components/Controls/EmailMultiSelect.vue
@@ -157,8 +157,10 @@ const query = ref('')
 const showOptions = ref(false)
 const tempSelection = ref(null)
 
-// Users data
-const { users } = usersStore()
+// Users data — use the store's `allUsers` computed so we get the full
+// list once the background fetch lands, falling back to the smaller
+// crm-users-only payload during initial load.
+const { users, allUsers } = usersStore()
 
 // Contacts resource (only if needed)
 const filterOptions = ref(null)
@@ -206,7 +208,7 @@ function reload(val) {
 const options = computed(() => {
   const mode = effectiveMode.value
   if (mode === 'users') {
-    let list = users?.data?.allUsers || []
+    let list = allUsers.value || []
     list = list.map((u) => ({
       label: u.full_name || u.name || u.email,
       value: u.email,

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -50,7 +50,11 @@ export const usersStore = defineStore('crm-users', () => {
     auto: false,
     transform([allUsers]) {
       for (let user of allUsers) {
-        if (!usersByName[user.name]) {
+        // upgrade partial get_user_info so always full record is used
+        const existing = usersByName[user.name]
+        if (existing) {
+          Object.assign(existing, user)
+        } else {
           usersByName[user.name] = user
         }
       }

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -10,6 +10,10 @@ export const usersStore = defineStore('crm-users', () => {
   let usersByName = reactive({})
   const router = useRouter()
 
+  // Fast initial fetch — returns only the ~few CRM users so the UI is
+  // interactive immediately. Non-CRM user profile data is filled in
+  // afterwards by the background `usersFull` fetch (and by `get_user_info`
+  // for the race window before that lands).
   const users = createResource({
     url: 'crm.api.session.get_users',
     cache: 'crm-users',
@@ -29,7 +33,75 @@ export const usersStore = defineStore('crm-users', () => {
         router.push('/login')
       }
     },
+    onSuccess() {
+      scheduleBackgroundFetch()
+    },
   })
+
+  // Background full-list fetch fired on browser idle. Only System Manager
+  // sessions receive a larger payload here; for others the server returns
+  // the same crm-users-only list. Populates usersByName so existing
+  // getUser(email) call sites keep working for non-CRM emails (comment
+  // authors, doc owners, email recipient typeahead, etc.).
+  const usersFull = createResource({
+    url: 'crm.api.session.get_users',
+    params: { include_all: 1 },
+    cache: 'crm-users-full',
+    auto: false,
+    transform([allUsers]) {
+      for (let user of allUsers) {
+        if (!usersByName[user.name]) {
+          usersByName[user.name] = user
+        }
+      }
+      return { allUsers }
+    },
+  })
+
+  let backgroundFetchScheduled = false
+  function scheduleBackgroundFetch() {
+    if (backgroundFetchScheduled) return
+    backgroundFetchScheduled = true
+    const fire = () => usersFull.fetch()
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(fire, { timeout: 5000 })
+    } else {
+      setTimeout(fire, 2000)
+    }
+  }
+
+  // Coalesced on-demand resolver. Used when getUser(email) is called for
+  // an email that the fast fetch did not cover and the background full
+  // fetch has not yet landed.
+  const pendingResolves = new Set()
+  let flushScheduled = false
+
+  function queueResolve(email) {
+    pendingResolves.add(email)
+    if (flushScheduled) return
+    flushScheduled = true
+    queueMicrotask(flush)
+  }
+
+  async function flush() {
+    flushScheduled = false
+    if (!pendingResolves.size) return
+    const batch = [...pendingResolves]
+    pendingResolves.clear()
+    try {
+      const r = createResource({
+        url: 'crm.api.session.get_user_info',
+        params: { users: batch },
+        auto: false,
+      })
+      const records = await r.fetch()
+      for (const u of records || []) {
+        usersByName[u.name] = { ...usersByName[u.name], ...u }
+      }
+    } catch (e) {
+      // best-effort — the synthesized stub remains on failure
+    }
+  }
 
   function getUser(email) {
     if (!email || email === 'sessionUser') {
@@ -44,6 +116,11 @@ export const usersStore = defineStore('crm-users', () => {
         last_name: '',
         user_image: null,
         role: null,
+      }
+      // Try to upgrade the stub via a batched fetch unless the full list
+      // has already arrived.
+      if (!usersFull.data) {
+        queueResolve(email)
       }
     }
     return usersByName[email]
@@ -84,8 +161,9 @@ export const usersStore = defineStore('crm-users', () => {
 
   return {
     users,
-    allUsers: computed(() => users.data.allUsers),
-    crmUsers: computed(() => users.data.crmUsers),
+    usersFull,
+    allUsers: computed(() => usersFull.data?.allUsers || users.data?.allUsers),
+    crmUsers: computed(() => users.data?.crmUsers),
     getUser,
     isAdmin,
     isManager,

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -66,7 +66,7 @@ export const usersStore = defineStore('crm-users', () => {
   }
 
   function isTelephonyAgent(email) {
-    return getUser(email).is_telphony_agent
+    return getUser(email).is_telephony_agent
   }
 
   function getUserRole(email) {


### PR DESCRIPTION
Closes #2186 (also fixes the user-visible failure mode reported in #1558).

## Summary

Speeds up `crm.api.session.get_users` from ~11 s to ~64 ms on large sites and unblocks the CRM frontend on initial load.

Three independently reviewable commits, each with measurable impact and no scope creep:

1. **`perf(session): batch N+1 lookups in get_users`** — replace per-user `frappe.get_roles()` and `db.exists("CRM Telephony Agent")` with two batched queries. Also fixes a `is_telphony_agent` → `is_telephony_agent` typo on the frontend that silently broke `isTelephonyAgent()` for every user.
2. **`perf(session): drop 173k-IN-list filters; safety-net Administrator`** — drop the per-call IN lists from the batched queries (they were serializing ~5 MB of SQL text on large sites for no benefit) and add an explicit `Administrator → System Manager` classification since the Has Role child table is not guaranteed to contain it on every install.
3. **`feat(session): split UI-blocking vs background user fetch`** — `get_users()` now returns only users with a CRM role by default (filtered at SQL level). A new optional `include_all=True` param (honored only for System Manager — silent downgrade otherwise) returns the full enabled user list. The frontend uses the fast call to unblock the UI immediately, then fires the full-list call on `requestIdleCallback`. A new `get_user_info(users)` endpoint resolves individual user records on demand for the race window between first paint and the background fetch landing.

Commits 1 and 2 have **no API contract change** — maintainers who want only the perf win can stop there. Commit 3 changes the default return shape of `get_users()` (documented below).

## Why

Root cause and reproduction documented in detail at #2186; same symptom previously reported at #1558. On a site with ~173 k enabled `User` records (real customer scenario, where bulk-imported contacts/employees landed as User rows on a shared Frappe/ERPNext/HRMS site), the CRM frontend either hangs on a white screen for ~11 s or, worse, redirects to "Not Permitted" because the `get_users` response never arrives in time.

Root cause is a tight per-user loop in `crm/api/session.py`:

```python
for user in users:                                  # 173k iterations
    user.roles = frappe.get_roles(user.name)        # ← 1 DB hit per user
    ...
    user.is_telephony_agent = frappe.db.exists(     # ← 1 DB hit per user
        "CRM Telephony Agent", {"user": user.name}
    )
```

Each iteration also runs role-priority logic, builds Python dicts, and so on. Even with `frappe.get_roles` cached in redis after the first hit, the function:

- Issues ~173 k SQL calls
- Returns a ~54 MiB JSON payload to System Manager sessions (the per-row `roles` array via `frappe.get_roles()` blows up the payload further on Administrator)
- Takes ~11 s of wall-clock time
- Blocks the entire CRM frontend on initial load

## Benchmark progression

Same site, same data (173,539 enabled users, 33 CRM users), median of 3 warm runs:

| Stage | Admin wall-clock | Sales Mgr wall-clock | SQL calls | Admin payload |
|---|---:|---:|---:|---:|
| Baseline | 10,760 ms | 10,884 ms | 173,540 | 53.6 MiB |
| After commit 1 (batch N+1) | 2,185 ms | 2,407 ms | 3 | 52.3 MiB |
| After commit 2 (drop IN lists) | 764 ms | 773 ms | 3 | 52.3 MiB |
| **After commit 3 (fast path, default)** | **64 ms** | **66 ms** | **4** | **59 KB** |
| After commit 3 (`include_all=1`, background) | 789 ms | n/a (downgraded) | 4 | 52.3 MiB |
| `get_user_info(2 names)` | 0.2 ms | 0.2 ms | 1 | 297 B |

**Net effect on user-visible behavior:** CRM frontend is interactive in ~64 ms instead of ~11 s — **~168× faster** — and the background fetch costs the *same* server time as commit 2 but doesn't block the UI.

## API contract

| Endpoint | Before | After |
|---|---|---|
| `crm.api.session.get_users()` (no args) | `(all_enabled_users, crm_users)` for System Manager; `(crm_users, crm_users)` otherwise | `(crm_users, crm_users)` for everyone |
| `crm.api.session.get_users(include_all=True)` | n/a | `(all_enabled_users, crm_users)` for System Manager; `(crm_users, crm_users)` otherwise (silent downgrade — no escalation) |
| `crm.api.session.get_user_info(users)` | n/a | New whitelisted endpoint, gated by CRM-role membership, capped at 200 names per call |

The breaking surface is small: the only known internal consumer of the full `allUsers` list is `EmailMultiSelect.vue`, updated in the same commit to read from the store-level computed (which transparently picks up the background fetch).

External callers of `crm.api.session.get_users` that need the full list should now pass `include_all=1` explicitly.

## Why the System-Manager carve-out was the wrong default

Pre-PR, `get_users()` returned the full enabled-user table to System Manager sessions but only `crm_users` to everyone else. This carve-out's intent was to populate the frontend's `usersByName` cache for arbitrary-email profile lookups (comment authors, doc owners, email recipient typeahead, etc.).

In practice that cache is only needed for the small subset of users that are *referenced* in CRM activity — usually a few dozen. Shipping the entire user table up front to populate a cache that may never be fully used isn't a great trade at any scale, and at 173 k users it becomes a denial-of-service vector against System Managers themselves.

The new design: send the small, blocking part synchronously; send the large, optional part asynchronously after first paint; fall back to point lookups for the race window. Costs the same total work for huge sites and is dramatically cheaper for typical sites where most users in the table never get referenced.

## Notes for reviewers

- The Administrator special-case in commit 2 (always classified as System Manager regardless of Has Role contents) is intentional — it mirrors Frappe's existing `frappe.get_roles("Administrator")` behavior which returns every role implicitly. Without this, sites where Administrator's Has Role child table doesn't explicitly contain "System Manager" would lock the admin out of CRM. This same correctness issue exists today in the pre-PR code for any code path that doesn't go through `frappe.get_roles()`, so it's worth catching here.
- The IN-list drop in commit 2 fetches a few extra rows from `Has Role` for users not in our in-memory set (e.g. role assignments for disabled users). These sit harmlessly in a dict that nobody looks up. The memory cost is a few KB.
- The frontend `getUser()` change preserves backwards compatibility — it still returns synchronously, the cached object is reactive, and stub records get upgraded in place when records resolve. No consumer needs to await anything.
- `get_user_info` is capped at 200 names per call to bound enumeration cost. The coalesced microtask-batched flush from the frontend stays well under that on any realistic page.
- Commit boundaries are intentionally split so that maintainers can stop at commit 1 (pure perf, no contract change), commit 2 (more perf, still no contract change), or take the full commit 3 (perf + UX + new endpoint + contract change). Each is independently mergeable.

