### PR TITLE
fix: allow creating customer from deal without organization

### DIFF
--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
@@ -305,14 +305,22 @@ def create_customer_in_erpnext(doc, method):
 	):
 		return
 
-	if not doc.organization:
-		frappe.throw(_("Organization is required to create a customer"))
-
 	contacts = get_contacts(doc)
 	address = get_organization_address(doc.organization)
+
+	if doc.organization:
+		customer_title = doc.organization
+		customer_type = "Company"
+	else:
+		primary_contact = next((c for c in contacts if c.get("is_primary")), None)
+		customer_title = (primary_contact or {}).get("full_name") or doc.lead_name
+		if not customer_title:
+			frappe.throw(_("Organization or a primary Contact is required to create a customer"))
+		customer_type = "Individual"
+
 	customer_data = {
-		"customer_name": doc.organization,
-		"customer_type": "Company",
+		"customer_name": customer_title,
+		"customer_type": customer_type,
 		"territory": doc.territory,
 		"default_currency": doc.currency,
 		"industry": doc.industry,


### PR DESCRIPTION
for B2C use cases, orginization should not be mandatory. fall back to the primary contact's `full_name` then `lead_name`