### PR TITLE
fix: resolve AttributeError during customer creation from CRM Deal

### DIFF
--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
@@ -338,10 +338,10 @@ def create_customer_in_erpnext(doc, method):
 				frappe.throw(_("ERPNext is not installed in the current site"))
 
 			if doc.territory and not frappe.db.exists("Territory", doc.territory):
-				customer_data.territory = ""
+				customer_data["territory"] = ""
 
 			if doc.industry and not frappe.db.exists("Industry Type", doc.industry):
-				customer_data.industry = ""
+				customer_data["industry"] = ""
 
 			customer_name = create_customer(customer_data)
 		else:


### PR DESCRIPTION
## Summary

This PR fixes an `AttributeError` that occurs while creating a Customer in ERPNext from a CRM Deal when the selected Territory or Industry does not exist in the connected ERPNext instance.

The issue was caused by using attribute-style assignment on a standard Python dictionary inside the `create_customer_in_erpnext` method.

Closes #2201

---

## Changes Made

Replaced incorrect attribute-style assignments:

```python id="nsj5k0"
customer_data.territory = ""
customer_data.industry = ""
```

with dictionary-style assignments:

```python id="iqvzhv"
customer_data["territory"] = ""
customer_data["industry"] = ""
```

---

## Why This Fix

`customer_data` is initialized as a standard Python dictionary, so attribute assignment raises:

```python id="e8ryj7"
AttributeError: 'dict' object has no attribute 'territory'
```

Using dictionary key assignment aligns with standard Python behavior and matches the existing assignment pattern already used in other parts of the same method.

---

## Impact

* Fixes customer creation flow from CRM → ERPNext
* Prevents crashes when Territory or Industry records are missing
* Maintains consistency in assignment syntax across the method
* No breaking changes

---

## Testing

Tested by:

1. Creating a Deal with non-existing Territory/Industry values
2. Triggering customer creation in ERPNext
3. Verifying customer creation completes successfully without errors

---

## Files Changed

```text id="8y2u6f"
crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
```
