### PR TITLE
fix: allow system manager to be removable

### DIFF
--- a/crm/api/user.py
+++ b/crm/api/user.py
@@ -140,7 +140,6 @@ def remove_crm_roles_from_user(user: str):
 		remove_roles(user_doc, "System Manager")
 		update_module_in_user(user_doc, "FCRM")
 
-
 	user_doc.save(ignore_permissions=True)
 	frappe.msgprint(_("User {0} has been removed from CRM roles.").format(user))
 

--- a/crm/api/user.py
+++ b/crm/api/user.py
@@ -136,6 +136,10 @@ def remove_crm_roles_from_user(user: str):
 		remove_roles(user_doc, "Sales User")
 	if "Sales Manager" in roles:
 		remove_roles(user_doc, "Sales Manager")
+	if "System Manager" in roles and current_user_is_system_manager:
+		remove_roles(user_doc, "System Manager")
+		update_module_in_user(user_doc, "FCRM")
+
 
 	user_doc.save(ignore_permissions=True)
 	frappe.msgprint(_("User {0} has been removed from CRM roles.").format(user))


### PR DESCRIPTION
Only removable if the current user is a system manager