### PR TITLE
fix: resolve @me filters in export all records flow

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -367,7 +367,7 @@ const props = defineProps({
 const { brand } = getSettings()
 const { $dialog, $socket } = globalStore()
 const { reload: reloadView, getDefaultView, getView } = viewsStore()
-const { isManager } = usersStore()
+const { isManager, getUser } = usersStore()
 const { organizations } = organizationsStore()
 
 const list = defineModel({ type: Object, default: () => ({}) })
@@ -592,11 +592,32 @@ function updateSelections(selections) {
 
 async function exportRows() {
   let fields = JSON.stringify(list.value.data.columns.map((f) => f.key))
-
-  let filters = JSON.stringify({
+  const userId = getUser()?.name
+  let filters = {
     ...props.filters,
     ...list.value.params.filters,
-  })
+  }
+
+  // Only resolve @me placeholders when we know the current user; otherwise
+  // leave filters untouched rather than emitting undefined / "%undefined%".
+  if (userId) {
+    Object.keys(filters).forEach((key) => {
+      const value = filters[key]
+
+      // Handle direct filter format: { owner: "@me" }
+      if (value === '@me') {
+        filters[key] = userId
+        return
+      }
+      if (!Array.isArray(value)) return
+      // Handle all operator-based filter format: { owner: ["=", "@me"], _assign: ["LIKE", "%@me%"] }
+      filters[key] = value.map((entry) =>
+        entry === '@me' ? userId : entry === '%@me%' ? `%${userId}%` : entry,
+      )
+    })
+  }
+
+  filters = JSON.stringify(filters)
 
   let order_by = list.value.params.order_by
   let page_length = list.value.params.page_length


### PR DESCRIPTION
## Summary

Fixes #2227 by resolving `@me` filters before exporting records in the CRM Portal **Export Records** flow.

Previously, exports returned blank data when using **Export All Records** with filters containing the special `@me` value because the export request serialized filters directly without converting `@me` into the current logged-in user.

This issue affected filters such as:

* `{ owner: "@me" }`
* `{ owner: ["=", "@me"] }`

The list view itself worked correctly because `@me` was resolved during normal data loading, but the **Export All Records** flow skipped this transformation.

---

## Root Cause

The **Export Records** flow sent `@me` directly to the backend instead of resolving it to the current logged-in user.

Because of this, the backend could not match records correctly and returned empty export results.


---

## What Changed

* Added `@me` resolution logic before export filter serialization
* Replaces `@me` with the current logged-in user ID using `getUser().name`
* Supports:

  * Direct filter format
  * Operator-based filter format

Examples:

```js id="s6v78q"
{ owner: "@me" }
```

becomes:

```js id="0j5u8q"
{ owner: "user@example.com" }
```

and:

```js id="26l9mr"
{ owner: ["=", "@me"] }
```

becomes:

```js id="evn0ha"
{ owner: ["=", "user@example.com"] }
```

---

## Additional Context

Exporting **selected records** was already working correctly because that flow exports explicit selected document IDs instead of relying on filters.

The issue mostly affected the **Export All Records** flow, where data retrieval depends entirely on serialized filters.
