### PR TITLE
fix: add forecasting fields to deal quick entry layout

### DIFF
--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
@@ -72,7 +72,8 @@ class FCRMSettings(Document):
 	def setup_forecasting(self):
 		if self.has_value_changed("enable_forecasting"):
 			if not self.enable_forecasting:
-				self.remove_forecasting_section_in_sidepanel()
+				self.remove_forecasting_section("Side Panel")
+				self.remove_forecasting_section("Quick Entry")
 				delete_property_setter(
 					"CRM Deal",
 					"reqd",
@@ -84,7 +85,8 @@ class FCRMSettings(Document):
 					"expected_deal_value",
 				)
 			else:
-				self.add_forecasting_section_in_sidepanel()
+				self.add_forecasting_section("Side Panel")
+				self.add_forecasting_section("Quick Entry")
 				make_property_setter(
 					"CRM Deal",
 					"expected_closure_date",
@@ -110,42 +112,74 @@ class FCRMSettings(Document):
 				"Check",
 			)
 
-	def add_forecasting_section_in_sidepanel(self):
-		doc = frappe.get_doc("CRM Fields Layout", "CRM Deal-Side Panel")
-		layout = doc.layout
-		sections = json.loads(layout)
-		if any(section.get("name") == "forecasted_sales_section" for section in sections):
+	def add_forecasting_section(self, layout_type):
+		layout_name = f"CRM Deal-{layout_type}"
+		if not frappe.db.exists("CRM Fields Layout", layout_name):
 			return
-		new_section = {
-			"name": "forecasted_sales_section",
-			"label": "Forecasted Sales",
-			"opened": True,
-			"columns": [
-				{
-					"name": "forecasted_sales_column",
-					"fields": ["expected_closure_date", "probability", "expected_deal_value"],
-				}
-			],
+		doc = frappe.get_doc("CRM Fields Layout", layout_name)
+		layout = json.loads(doc.layout) if doc.layout else []
+		# layout is either a plain list of sections or a list of tabs with sections
+		has_tabs = any("sections" in item for item in layout)
+		sections = layout[-1].setdefault("sections", []) if has_tabs else layout
+		all_sections = (
+			[section for tab in layout for section in tab.get("sections", [])] if has_tabs else layout
+		)
+		if any(section.get("name") == "forecasted_sales_section" for section in all_sections):
+			return
+		existing_fields = {
+			field
+			for section in all_sections
+			for column in section.get("columns") or []
+			for field in column.get("fields") or []
 		}
-		# Insert after contacts_section if it's the first section, else insert at the beginning
-		if sections and sections[0].get("name") == "contacts_section":
-			# Insert after the first section
-			sections = [*sections[:1], new_section, *sections[1:]]
+		fields = [
+			field
+			for field in ("expected_deal_value", "expected_closure_date", "probability")
+			if field not in existing_fields
+		]
+		if not fields:
+			return
+
+		if layout_type == "Side Panel":
+			new_section = {
+				"name": "forecasted_sales_section",
+				"label": "Forecasted Sales",
+				"opened": True,
+				"columns": [{"name": "forecasted_sales_column", "fields": fields}],
+			}
+			# Insert after contacts_section if it's the first section, else insert at the beginning
+			if sections and sections[0].get("name") == "contacts_section":
+				sections.insert(1, new_section)
+			else:
+				sections.insert(0, new_section)
 		else:
-			# Insert as the first section
-			sections = [new_section, *sections]
-		doc.layout = json.dumps(sections)
+			# one column per field so they render in a single row
+			new_section = {
+				"name": "forecasted_sales_section",
+				"columns": [{"name": field + "_column", "fields": [field]} for field in fields],
+			}
+			sections.append(new_section)
+
+		doc.layout = json.dumps(layout)
 		doc.save(ignore_permissions=True)
 
-	def remove_forecasting_section_in_sidepanel(self):
-		doc = frappe.get_doc("CRM Fields Layout", "CRM Deal-Side Panel")
-		doc.layout = json.dumps(
-			[
-				section
-				for section in json.loads(doc.layout)
-				if section.get("name") != "forecasted_sales_section"
-			]
-		)
+	def remove_forecasting_section(self, layout_type):
+		layout_name = f"CRM Deal-{layout_type}"
+		if not frappe.db.exists("CRM Fields Layout", layout_name):
+			return
+		doc = frappe.get_doc("CRM Fields Layout", layout_name)
+		layout = json.loads(doc.layout) if doc.layout else []
+		has_tabs = any("sections" in item for item in layout)
+		if has_tabs:
+			for tab in layout:
+				tab["sections"] = [
+					section
+					for section in tab.get("sections", [])
+					if section.get("name") != "forecasted_sales_section"
+				]
+		else:
+			layout = [section for section in layout if section.get("name") != "forecasted_sales_section"]
+		doc.layout = json.dumps(layout)
 		doc.save(ignore_permissions=True)
 
 

--- a/crm/fcrm/doctype/fcrm_settings/test_fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/test_fcrm_settings.py
@@ -1,9 +1,109 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import UnitTestCase
+import json
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+FORECASTING_FIELDS = ["expected_closure_date", "probability", "expected_deal_value"]
 
 
-class TestFCRMSettings(UnitTestCase):
-	pass
+class TestFCRMSettings(IntegrationTestCase):
+	def tearDown(self) -> None:
+		frappe.db.rollback()
+
+	def get_quick_entry_sections(self):
+		layout = json.loads(frappe.db.get_value("CRM Fields Layout", "CRM Deal-Quick Entry", "layout"))
+		if any("sections" in item for item in layout):
+			return [section for tab in layout for section in tab.get("sections", [])]
+		return layout
+
+	def get_quick_entry_fields(self):
+		return [
+			field
+			for section in self.get_quick_entry_sections()
+			for column in section.get("columns") or []
+			for field in column.get("fields") or []
+		]
+
+	def set_forecasting(self, value):
+		settings = frappe.get_single("FCRM Settings")
+		settings.enable_forecasting = value
+		settings.save()
+
+	def test_forecasting_adds_section_to_quick_entry(self):
+		"""Enabling forecasting should append forecasting fields to the deal quick entry layout"""
+		self.set_forecasting(0)
+		self.assertFalse(set(FORECASTING_FIELDS) & set(self.get_quick_entry_fields()))
+
+		self.set_forecasting(1)
+		sections = self.get_quick_entry_sections()
+		self.assertTrue(any(section.get("name") == "forecasted_sales_section" for section in sections))
+		fields = self.get_quick_entry_fields()
+		for field in FORECASTING_FIELDS:
+			self.assertIn(field, fields)
+
+	def test_disabling_forecasting_removes_section_from_quick_entry(self):
+		self.set_forecasting(1)
+		self.set_forecasting(0)
+		sections = self.get_quick_entry_sections()
+		self.assertFalse(any(section.get("name") == "forecasted_sales_section" for section in sections))
+
+	def test_forecasting_skips_fields_already_in_quick_entry(self):
+		"""Fields already placed in the layout by a manager should not be duplicated"""
+		self.set_forecasting(0)
+
+		doc = frappe.get_doc("CRM Fields Layout", "CRM Deal-Quick Entry")
+		layout = json.loads(doc.layout)
+		custom_section = {
+			"name": "custom_section",
+			"columns": [{"name": "custom_column", "fields": ["expected_deal_value"]}],
+		}
+		if any("sections" in item for item in layout):
+			layout[-1]["sections"].append(custom_section)
+		else:
+			layout.append(custom_section)
+		doc.layout = json.dumps(layout)
+		doc.save(ignore_permissions=True)
+
+		self.set_forecasting(1)
+
+		fields = self.get_quick_entry_fields()
+		self.assertEqual(fields.count("expected_deal_value"), 1)
+		self.assertIn("expected_closure_date", fields)
+		self.assertIn("probability", fields)
+
+	def test_forecasting_adds_section_to_sidepanel(self):
+		"""Side panel should get a labeled Forecasted Sales section after the contacts section"""
+		self.set_forecasting(0)
+		self.set_forecasting(1)
+
+		sections = json.loads(frappe.db.get_value("CRM Fields Layout", "CRM Deal-Side Panel", "layout"))
+		section = next((s for s in sections if s.get("name") == "forecasted_sales_section"), None)
+		self.assertIsNotNone(section)
+		self.assertEqual(section.get("label"), "Forecasted Sales")
+		if sections[0].get("name") == "contacts_section":
+			self.assertEqual(sections[1].get("name"), "forecasted_sales_section")
+		else:
+			self.assertEqual(sections[0].get("name"), "forecasted_sales_section")
+
+		self.set_forecasting(0)
+		sections = json.loads(frappe.db.get_value("CRM Fields Layout", "CRM Deal-Side Panel", "layout"))
+		self.assertFalse(any(s.get("name") == "forecasted_sales_section" for s in sections))
+
+	def test_forecasting_adds_section_to_quick_entry_with_tabs_layout(self):
+		"""Layouts saved from the layout editor are wrapped in tabs and should also work"""
+		self.set_forecasting(0)
+
+		doc = frappe.get_doc("CRM Fields Layout", "CRM Deal-Quick Entry")
+		layout = json.loads(doc.layout)
+		if not any("sections" in item for item in layout):
+			doc.layout = json.dumps([{"name": "first_tab", "sections": layout}])
+			doc.save(ignore_permissions=True)
+
+		self.set_forecasting(1)
+
+		fields = self.get_quick_entry_fields()
+		for field in FORECASTING_FIELDS:
+			self.assertIn(field, fields)

--- a/crm/patches.txt
+++ b/crm/patches.txt
@@ -26,3 +26,4 @@ crm.patches.v1_0.add_email_in_default_lead_sources
 crm.patches.v1_0.create_email_account_custom_field
 crm.patches.v1_0.create_default_quick_filters
 crm.patches.v1_0.create_custom_fields_for_product_item_sync
+crm.patches.v1_0.add_forecasting_section_in_quick_entry

--- a/crm/patches/v1_0/add_forecasting_section_in_quick_entry.py
+++ b/crm/patches/v1_0/add_forecasting_section_in_quick_entry.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	if not frappe.db.get_single_value("FCRM Settings", "enable_forecasting"):
+		return
+
+	settings = frappe.get_doc("FCRM Settings")
+	settings.add_forecasting_section("Quick Entry")


### PR DESCRIPTION
- replaces `remove_forecasting_section_in_sidepanel` and `add_forecasting_section_in_sidepanel` with generic `add_forcasting_section` and `remove_forcasting_section` function.
- added test coverage for fcrm settings
- patch to migrate the existing user layouts ( might break quick_entry layout for some by moving it to the bottom )

Fixes HD Ticket #70228