### PR TITLE
fix: use _add instead of add for agent assignment

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.desk.form.assign_to import add as assign
+from frappe.desk.form.assign_to import _add as assign
 from frappe.model.document import Document
 
 from crm.api.exchange_rate import get_exchange_rate

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -5,7 +5,7 @@ import json
 
 import frappe
 from frappe import _
-from frappe.desk.form.assign_to import add as assign
+from frappe.desk.form.assign_to import _add as assign
 from frappe.model.document import Document
 from frappe.utils import has_gravatar, validate_email_address
 

--- a/crm/integrations/erpnext/test_utils.py
+++ b/crm/integrations/erpnext/test_utils.py
@@ -13,14 +13,12 @@ class TestSyncHookWiring(FrappeTestCase):
 			self.assertNotIn(doctype, override_doctype_class)
 
 	def test_doc_event_handlers_are_importable(self):
-		from frappe.utils import get_attr
-
 		from crm.hooks import doc_events
 
 		for doctype in SYNC_DOCTYPES:
 			for handlers in doc_events[doctype].values():
 				for path in handlers:
-					self.assertTrue(callable(get_attr(path)), path)
+					self.assertTrue(callable(frappe.get_attr(path)), path)
 
 
 class TestFindTargetFor(FrappeTestCase):


### PR DESCRIPTION
Updates the auto-assignment logic in CRM Lead and CRM Deal to use the internal _add method from frappe.desk.form.assign_to.

The current code passes ignore_permissions=True to the public add method, which results in a TypeError: add() got an unexpected keyword argument 'ignore_permissions' during background assignments (such as demo data generation). Using the internal _add method safely accepts this parameter and resolves the crash.