### PR TITLE
fix: bind modal fields to the document by authoritative name

### DIFF
--- a/frontend/src/components/FieldLayout/Field.vue
+++ b/frontend/src/components/FieldLayout/Field.vue
@@ -340,6 +340,7 @@ const props = defineProps({
 
 const data = inject('data')
 const doctype = inject('doctype')
+const docname = inject('docname', null)
 const preview = inject('preview')
 const isGridRow = inject('isGridRow')
 
@@ -388,13 +389,18 @@ if (standaloneContext) {
     computed(() => standaloneContext?.fieldPropertyOverrides || {}),
   )
 } else if (!isGridRow) {
+  // Bind to the document by its authoritative name (injected from FieldLayout),
+  // falling back to data.name. Using data.name alone breaks the first edit of a
+  // freshly-loaded doc: name is still empty, so changes write to the wrong
+  // (new-document) cache slot and the first save serializes the pristine doc.
+  const resolvedName = docname != null ? docname.value : data.value.name
   const {
     triggerOnChange: trigger,
     triggerButton: triggerBtn,
     triggerOnRowAdd,
     triggerOnRowRemove,
     document: doc,
-  } = useDocument(doctype, data.value.name)
+  } = useDocument(doctype, resolvedName)
   triggerOnChange = trigger
   triggerButton = triggerBtn
   formDocument.value = doc

--- a/frontend/src/components/FieldLayout/FieldLayout.vue
+++ b/frontend/src/components/FieldLayout/FieldLayout.vue
@@ -36,6 +36,7 @@ const props = defineProps({
   tabs: { type: Array, default: () => [] },
   data: { type: Object, default: () => ({}) },
   doctype: { type: String, default: 'CRM Lead' },
+  docname: { type: String, default: '' },
   isGridRow: { type: Boolean, default: false },
   preview: { type: Boolean, default: false },
   context: { type: Object, default: null },
@@ -43,13 +44,18 @@ const props = defineProps({
 
 const tabIndex = ref(0)
 
+// The authoritative document name. Prefer the explicit docname prop (known
+// synchronously by the parent modal) over data.name, which is empty while the
+// document is still loading and would bind field changes to the wrong cache.
+const resolvedDocname = computed(() => props.docname || props.data?.name || '')
+
 // Get fieldPropertyOverrides for tab/section overrides
 let overrides = {}
 if (props.context) {
   // Standalone mode: use externally managed context, skip useDocument
   overrides = computed(() => props.context?.fieldPropertyOverrides || {})
 } else if (!props.isGridRow) {
-  const { document: doc } = useDocument(props.doctype, props.data?.name)
+  const { document: doc } = useDocument(props.doctype, resolvedDocname.value)
   overrides = computed(() => doc?.fieldPropertyOverrides || {})
 } else {
   overrides = computed(() => ({}))
@@ -87,6 +93,7 @@ provide(
 )
 provide('hasTabs', hasTabs)
 provide('doctype', props.doctype)
+provide('docname', resolvedDocname)
 provide('preview', props.preview)
 provide('isGridRow', props.isGridRow)
 provide('fieldLayoutContext', props.context)

--- a/frontend/src/components/Modals/DoctypeModal.vue
+++ b/frontend/src/components/Modals/DoctypeModal.vue
@@ -40,6 +40,7 @@
             :tabs="layout.data"
             :data="doc"
             :doctype="doctype"
+            :docname="docname"
           />
           <ErrorMessage v-if="error" class="mt-4" :message="__(error)" />
         </div>


### PR DESCRIPTION
The first edit of a freshly-created/loaded doc persisted no fields: the very first save serialized the pristine document and was a no-op.

Field.vue derived its change handler via useDocument(doctype, data.name), reading the name at setup time. On first open the document GET has not resolved yet, so data.name is empty and the field binds triggerOnChange to the new-document ("") cache slot, while the modal's document.save reads the real cache slot. Edits and save therefore target different objects, so the first set_value ships the unchanged doc; subsequent opens work because the doc is warm in cache and data.name is populated.

Thread the authoritative docname (known synchronously by the modal) from DoctypeModal -> FieldLayout -> Field, so fields bind to the same cache slot the modal saves from, from the first render. Falls back to data.name when no docname is provided, so other FieldLayout callers are unaffected.