### PR TITLE
fix: data field tab

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -392,6 +392,8 @@
     </div>
     <div v-else-if="title == 'Data'" class="h-full flex flex-col px-3 sm:px-10">
       <DataFields
+        v-model:fieldLayoutTabIndex="fieldLayoutTabIndex"
+        v-model:fieldLayoutTabName="fieldLayoutTabName"
         :doctype="doctype"
         :docname="docname"
         @beforeSave="(data) => emit('beforeSave', data)"
@@ -531,6 +533,8 @@ const doc = computed(() => _document.doc || {})
 const reload_email = ref(false)
 const modalRef = ref(null)
 const showFilesUploader = ref(false)
+const fieldLayoutTabIndex = ref(0)
+const fieldLayoutTabName = ref('')
 
 const title = computed(() => props.tabs?.[tabIndex.value]?.name || 'Activity')
 

--- a/frontend/src/components/Activities/DataFields.vue
+++ b/frontend/src/components/Activities/DataFields.vue
@@ -37,6 +37,8 @@
   <div v-else class="pb-8">
     <FieldLayout
       v-if="tabs.data"
+      v-model:tabIndex="fieldLayoutTabIndex"
+      v-model:tabName="fieldLayoutTabName"
       :tabs="tabs.data"
       :data="document.doc"
       :doctype="doctype"
@@ -64,7 +66,7 @@ import LoadingIndicator from '@/components/Icons/LoadingIndicator.vue'
 import { usersStore } from '@/stores/users'
 import { useDocument } from '@/data/document'
 import { isMobileView } from '@/composables/settings'
-import { ref, watch, getCurrentInstance } from 'vue'
+import { ref, watch, getCurrentInstance, computed } from 'vue'
 
 const props = defineProps({
   doctype: { type: String, required: true },
@@ -72,6 +74,14 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['beforeSave', 'afterSave'])
+const fieldLayoutTabIndex = defineModel('fieldLayoutTabIndex', {
+  type: Number,
+  default: 0,
+})
+const fieldLayoutTabName = defineModel('fieldLayoutTabName', {
+  type: String,
+  default: '',
+})
 
 const { isManager } = usersStore()
 
@@ -81,6 +91,28 @@ const attrs = instance?.vnode?.props ?? {}
 const showDataFieldsModal = ref(false)
 
 const { document } = useDocument(props.doctype, props.docname)
+const fieldLayoutTabStorageKey = computed(
+  () => `fieldLayoutTab:${props.doctype}:${props.docname}`,
+)
+
+watch(
+  fieldLayoutTabStorageKey,
+  (key) => {
+    const tabName = sessionStorage.getItem(key)
+    if (tabName && fieldLayoutTabName.value !== tabName) {
+      fieldLayoutTabName.value = tabName
+    }
+  },
+  { immediate: true },
+)
+
+watch(fieldLayoutTabName, (tabName) => {
+  if (tabName) {
+    sessionStorage.setItem(fieldLayoutTabStorageKey.value, tabName)
+  } else {
+    sessionStorage.removeItem(fieldLayoutTabStorageKey.value)
+  }
+})
 
 const tabs = createResource({
   url: 'crm.fcrm.doctype.crm_fields_layout.crm_fields_layout.get_fields_layout',

--- a/frontend/src/components/FieldLayout/FieldLayout.vue
+++ b/frontend/src/components/FieldLayout/FieldLayout.vue
@@ -7,7 +7,7 @@
     }"
   >
     <Tabs
-      v-model="tabIndex"
+      v-model="selectedTabIndex"
       as="div"
       :tabs="processedTabs"
       :class="[
@@ -30,7 +30,7 @@
 import Section from '@/components/FieldLayout/Section.vue'
 import { useDocument } from '@/data/document'
 import { Tabs } from 'frappe-ui'
-import { ref, computed, provide } from 'vue'
+import { computed, provide, watch } from 'vue'
 
 const props = defineProps({
   tabs: { type: Array, default: () => [] },
@@ -42,7 +42,8 @@ const props = defineProps({
   context: { type: Object, default: null },
 })
 
-const tabIndex = ref(0)
+const tabIndex = defineModel('tabIndex', { type: Number, default: 0 })
+const tabName = defineModel('tabName', { type: String, default: '' })
 
 // The authoritative document name. Prefer the explicit docname prop (known
 // synchronously by the parent modal) over data.name, which is empty while the
@@ -86,6 +87,42 @@ const hasTabs = computed(() => {
     (processedTabs.value.length == 1 && processedTabs.value[0].label)
   )
 })
+
+const selectedTabIndex = computed({
+  get() {
+    if (tabName.value) {
+      const namedTabIndex = processedTabs.value.findIndex(
+        (tab) => tab.name === tabName.value,
+      )
+      if (namedTabIndex !== -1) return namedTabIndex
+    }
+    return tabIndex.value
+  },
+  set(value) {
+    tabIndex.value = value
+    tabName.value = processedTabs.value[value]?.name || ''
+  },
+})
+
+watch(
+  processedTabs,
+  (tabs) => {
+    if (!tabs.length) {
+      tabIndex.value = 0
+      tabName.value = ''
+      return
+    }
+    if (tabName.value && tabs.some((tab) => tab.name === tabName.value)) {
+      tabIndex.value = tabs.findIndex((tab) => tab.name === tabName.value)
+      return
+    }
+    if (tabIndex.value >= tabs.length) {
+      tabIndex.value = tabs.length - 1
+    }
+    tabName.value = tabs[tabIndex.value]?.name || ''
+  },
+  { immediate: true },
+)
 
 provide(
   'data',

--- a/frontend/tests/unit/fieldLayoutTabState.test.js
+++ b/frontend/tests/unit/fieldLayoutTabState.test.js
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref } from 'vue'
+
+vi.mock('frappe-ui', async () => {
+  const { defineComponent, h } = await import('vue')
+
+  return {
+    Tabs: defineComponent({
+      props: {
+        modelValue: { type: Number, default: 0 },
+        tabs: { type: Array, default: () => [] },
+      },
+      emits: ['update:modelValue'],
+      setup(props, { emit, slots }) {
+        return () =>
+          h('div', [
+            h(
+              'div',
+              { role: 'tablist' },
+              props.tabs.map((tab, index) =>
+                h(
+                  'button',
+                  {
+                    role: 'tab',
+                    'aria-selected': props.modelValue === index,
+                    onClick: () => emit('update:modelValue', index),
+                  },
+                  tab.label,
+                ),
+              ),
+            ),
+            h(
+              'div',
+              { role: 'tabpanel' },
+              slots['tab-panel']?.({ tab: props.tabs[props.modelValue] }),
+            ),
+          ])
+      },
+    }),
+  }
+})
+
+vi.mock('@/data/document', () => ({
+  useDocument: () => ({
+    document: {
+      fieldPropertyOverrides: {},
+    },
+  }),
+}))
+
+vi.mock('@/components/FieldLayout/Section.vue', () => ({
+  default: defineComponent({
+    props: {
+      section: { type: Object, required: true },
+    },
+    setup(props) {
+      return () => h('section', props.section.label)
+    },
+  }),
+}))
+
+describe('FieldLayout tab state', () => {
+  it('keeps the selected data field tab when the layout remounts', async () => {
+    const { default: FieldLayout } = await import(
+      '@/components/FieldLayout/FieldLayout.vue'
+    )
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const Parent = defineComponent({
+      setup() {
+        const showLayout = ref(true)
+        const fieldLayoutTabIndex = ref(0)
+        const tabs = [
+          {
+            name: 'details_tab',
+            label: 'Details',
+            sections: [{ name: 'details_section', label: 'Details' }],
+          },
+          {
+            name: 'data_tab',
+            label: 'Data',
+            sections: [{ name: 'data_section', label: 'Data' }],
+          },
+        ]
+
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-testid': 'remount',
+                onClick: async () => {
+                  showLayout.value = false
+                  await nextTick()
+                  showLayout.value = true
+                },
+              },
+              'Remount',
+            ),
+            showLayout.value &&
+              h(FieldLayout, {
+                tabs,
+                data: {},
+                doctype: 'CRM Deal',
+                isGridRow: true,
+                tabIndex: fieldLayoutTabIndex.value,
+                'onUpdate:tabIndex': (value) => {
+                  fieldLayoutTabIndex.value = value
+                },
+              }),
+          ])
+      },
+    })
+
+    const app = createApp(Parent)
+    app.mount(root)
+
+    root.querySelectorAll('[role="tab"]')[1].click()
+    await nextTick()
+    expect(root.querySelector('[aria-selected="true"]').textContent).toBe(
+      'Data',
+    )
+
+    root.querySelector('[data-testid="remount"]').click()
+    await nextTick()
+    await nextTick()
+
+    expect(root.querySelector('[aria-selected="true"]').textContent).toBe(
+      'Data',
+    )
+
+    app.unmount()
+    root.remove()
+  })
+
+  it('keeps the selected data field tab when DataFields remounts', async () => {
+    const { default: FieldLayout } = await import(
+      '@/components/FieldLayout/FieldLayout.vue'
+    )
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const DataFieldsStub = defineComponent({
+      props: {
+        fieldLayoutTabIndex: { type: Number, default: 0 },
+      },
+      emits: ['update:fieldLayoutTabIndex'],
+      setup(props, { emit }) {
+        const tabs = [
+          {
+            name: 'details_tab',
+            label: 'Details',
+            sections: [{ name: 'details_section', label: 'Details' }],
+          },
+          {
+            name: 'data_tab',
+            label: 'Data',
+            sections: [{ name: 'data_section', label: 'Data' }],
+          },
+        ]
+
+        return () =>
+          h(FieldLayout, {
+            tabs,
+            data: {},
+            doctype: 'CRM Deal',
+            isGridRow: true,
+            tabIndex: props.fieldLayoutTabIndex,
+            'onUpdate:tabIndex': (value) => {
+              emit('update:fieldLayoutTabIndex', value)
+            },
+          })
+      },
+    })
+
+    const Parent = defineComponent({
+      setup() {
+        const showDataFields = ref(true)
+        const fieldLayoutTabIndex = ref(0)
+
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-testid': 'remount-data-fields',
+                onClick: async () => {
+                  showDataFields.value = false
+                  await nextTick()
+                  showDataFields.value = true
+                },
+              },
+              'Remount DataFields',
+            ),
+            showDataFields.value &&
+              h(DataFieldsStub, {
+                fieldLayoutTabIndex: fieldLayoutTabIndex.value,
+                'onUpdate:fieldLayoutTabIndex': (value) => {
+                  fieldLayoutTabIndex.value = value
+                },
+              }),
+          ])
+      },
+    })
+
+    const app = createApp(Parent)
+    app.mount(root)
+
+    root.querySelectorAll('[role="tab"]')[1].click()
+    await nextTick()
+    expect(root.querySelector('[aria-selected="true"]').textContent).toBe(
+      'Data',
+    )
+
+    root.querySelector('[data-testid="remount-data-fields"]').click()
+    await nextTick()
+    await nextTick()
+
+    expect(root.querySelector('[aria-selected="true"]').textContent).toBe(
+      'Data',
+    )
+
+    app.unmount()
+    root.remove()
+  })
+
+  it('keeps the selected tab by name when labels are duplicated and tabs reload', async () => {
+    const { default: FieldLayout } = await import(
+      '@/components/FieldLayout/FieldLayout.vue'
+    )
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const Parent = defineComponent({
+      setup() {
+        const fieldLayoutTabIndex = ref(0)
+        const fieldLayoutTabName = ref('')
+        const tabs = ref([
+          {
+            name: 'tab_a',
+            label: 'New Tab',
+            sections: [{ name: 'section_a', label: 'First' }],
+          },
+          {
+            name: 'tab_b',
+            label: 'New Tab',
+            sections: [{ name: 'section_b', label: 'Second' }],
+          },
+        ])
+
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-testid': 'reload-tabs',
+                onClick: () => {
+                  tabs.value = [
+                    {
+                      name: 'tab_a',
+                      label: 'New Tab',
+                      sections: [{ name: 'section_a_new', label: 'First' }],
+                    },
+                    {
+                      name: 'tab_b',
+                      label: 'New Tab',
+                      sections: [{ name: 'section_b_new', label: 'Second' }],
+                    },
+                  ]
+                },
+              },
+              'Reload Tabs',
+            ),
+            h(FieldLayout, {
+              tabs: tabs.value,
+              data: {},
+              doctype: 'CRM Deal',
+              isGridRow: true,
+              tabIndex: fieldLayoutTabIndex.value,
+              tabName: fieldLayoutTabName.value,
+              'onUpdate:tabIndex': (value) => {
+                fieldLayoutTabIndex.value = value
+              },
+              'onUpdate:tabName': (value) => {
+                fieldLayoutTabName.value = value
+              },
+            }),
+          ])
+      },
+    })
+
+    const app = createApp(Parent)
+    app.mount(root)
+
+    root.querySelectorAll('[role="tab"]')[1].click()
+    await nextTick()
+    expect(root.querySelector('[role="tabpanel"]').textContent).toBe('Second')
+
+    root.querySelector('[data-testid="reload-tabs"]').click()
+    await nextTick()
+
+    expect(root.querySelector('[role="tabpanel"]').textContent).toBe('Second')
+
+    app.unmount()
+    root.remove()
+  })
+
+  it('restores the selected tab name from session storage after page remount', async () => {
+    const { default: FieldLayout } = await import(
+      '@/components/FieldLayout/FieldLayout.vue'
+    )
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    sessionStorage.clear()
+
+    const DataFieldsStub = defineComponent({
+      setup() {
+        const doctype = 'CRM Deal'
+        const docname = 'DEAL-001'
+        const fieldLayoutTabIndex = ref(0)
+        const fieldLayoutTabName = ref('')
+        const storageKey = `fieldLayoutTab:${doctype}:${docname}`
+        const tabs = [
+          {
+            name: 'tab_a',
+            label: 'New Tab',
+            sections: [{ name: 'section_a', label: 'First' }],
+          },
+          {
+            name: 'tab_b',
+            label: 'New Tab',
+            sections: [{ name: 'section_b', label: 'Second' }],
+          },
+        ]
+
+        const storedFieldLayoutTabName = sessionStorage.getItem(storageKey)
+        if (storedFieldLayoutTabName) {
+          fieldLayoutTabName.value = storedFieldLayoutTabName
+        }
+
+        return () =>
+          h(FieldLayout, {
+            tabs,
+            data: {},
+            doctype,
+            isGridRow: true,
+            tabIndex: fieldLayoutTabIndex.value,
+            tabName: fieldLayoutTabName.value,
+            'onUpdate:tabIndex': (value) => {
+              fieldLayoutTabIndex.value = value
+            },
+            'onUpdate:tabName': (value) => {
+              fieldLayoutTabName.value = value
+              sessionStorage.setItem(storageKey, value)
+            },
+          })
+      },
+    })
+
+    const Parent = defineComponent({
+      setup() {
+        const showPage = ref(true)
+
+        return () =>
+          h('div', [
+            h(
+              'button',
+              {
+                'data-testid': 'remount-page',
+                onClick: async () => {
+                  showPage.value = false
+                  await nextTick()
+                  showPage.value = true
+                },
+              },
+              'Remount Page',
+            ),
+            showPage.value && h(DataFieldsStub),
+          ])
+      },
+    })
+
+    const app = createApp(Parent)
+    app.mount(root)
+
+    root.querySelectorAll('[role="tab"]')[1].click()
+    await nextTick()
+    expect(root.querySelector('[role="tabpanel"]').textContent).toBe('Second')
+
+    root.querySelector('[data-testid="remount-page"]').click()
+    await nextTick()
+    await nextTick()
+
+    expect(root.querySelector('[role="tabpanel"]').textContent).toBe('Second')
+
+    app.unmount()
+    root.remove()
+    sessionStorage.clear()
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
 import path from 'path'
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
## Describe the bug

  When a user edits and saves a field under a non-default Data Fields tab, the form layout is re-
  rendered and the selected tab is reset to the first tab, such as Deal Details. This makes the
  user lose their current context after saving.

  ## Root cause

  `FieldLayout` kept the selected tab in local component state initialized to `0`. When the Data
  Fields layout was remounted or reloaded after save, that local state was recreated and the first
  tab became selected again.

  ## Changes

  - Lifted the Data Fields tab state to `Activities.vue` so it survives `DataFields` remounts.
  - Added `v-model:tabIndex` and `v-model:tabName` support to `FieldLayout`.
  - Restored the selected tab by stable tab `name`, which also works when tab labels are
  duplicated.
  - Persisted the selected Data Fields tab in `sessionStorage` per `doctype` and `docname`, so the
  tab can be restored after page remounts.
  - Added unit tests for tab persistence across layout remounts, DataFields remounts, tab reloads,
  and session storage restore.

  ## Expected behaviour after fix

  After editing and saving a field under another Data Fields tab, the user stays on the same tab
  instead of being redirected back to the first tab.

  ## Test plan

  - Added unit coverage in `frontend/tests/unit/fieldLayoutTabState.test.js`.
  - Run:

  ```bash
  cd frontend
  yarn test:run
```
closes #2270