### PR TITLE
feat: configurable activity timeline — timestamp format & sort order

### DIFF
--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -15,6 +15,7 @@
   "auto_mark_replied_on_response",
   "auto_reopen_on_new_communication",
   "activity_timeline_section",
+  "crm_timeline_timestamp_format",
   "crm_timeline_sort_order",
   "currency_tab",
   "currency",
@@ -193,6 +194,14 @@
    "fieldname": "activity_timeline_section",
    "fieldtype": "Section Break",
    "label": "Activity Timeline"
+  },
+  {
+   "default": "Relative",
+   "description": "How timestamps are shown in the activity timeline for all users",
+   "fieldname": "crm_timeline_timestamp_format",
+   "fieldtype": "Select",
+   "label": "Timeline Timestamp Format",
+   "options": "Relative\nExact"
   },
   {
    "default": "Oldest First",

--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -14,6 +14,8 @@
   "update_timestamp_on_new_communication",
   "auto_mark_replied_on_response",
   "auto_reopen_on_new_communication",
+  "activity_timeline_section",
+  "crm_timeline_sort_order",
   "currency_tab",
   "currency",
   "exchange_rate_provider_section",
@@ -186,6 +188,19 @@
    "fieldname": "restore_demo_data",
    "fieldtype": "Button",
    "label": "Restore Demo Data"
+  },
+  {
+   "fieldname": "activity_timeline_section",
+   "fieldtype": "Section Break",
+   "label": "Activity Timeline"
+  },
+  {
+   "default": "Oldest First",
+   "description": "Order of activities, emails, comments and calls in the timeline for all users",
+   "fieldname": "crm_timeline_sort_order",
+   "fieldtype": "Select",
+   "label": "Timeline Sort Order",
+   "options": "Oldest First\nNewest First"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -490,6 +490,7 @@ import FilesUploader from '@/components/FilesUploader/FilesUploader.vue'
 import { timeAgo, formatDate, startCase } from '@/utils'
 import { globalStore } from '@/stores/global'
 import { usersStore } from '@/stores/users'
+import { useTimelinePreferences } from '@/composables/useTimelinePreferences'
 import { whatsappEnabled } from '@/composables/whatsapp'
 import { useDocument } from '@/data/document'
 import { useTelemetry } from 'frappe-ui/frappe'
@@ -510,6 +511,7 @@ import { useRoute } from 'vue-router'
 const { $socket } = globalStore()
 const { getUser } = usersStore()
 const { capture } = useTelemetry()
+const { isNewestFirst } = useTimelinePreferences()
 
 const props = defineProps({
   doctype: { type: String, default: 'CRM Lead' },
@@ -641,7 +643,7 @@ const activities = computed(() => {
     )
   } else if (title.value == 'Calls') {
     if (!all_activities.data?.calls) return []
-    return sortByCreation(all_activities.data.calls)
+    return sortByCreation(all_activities.data.calls, isNewestFirst.value)
   } else if (title.value == 'Tasks') {
     if (!all_activities.data?.tasks) return []
     return sortByModified(all_activities.data.tasks)
@@ -672,11 +674,18 @@ const activities = computed(() => {
       })
     }
   })
-  return sortByCreation(_activities)
+  return sortByCreation(_activities, isNewestFirst.value)
 })
 
-function sortByCreation(list) {
-  return list.sort((a, b) => new Date(a.creation) - new Date(b.creation))
+function sortByCreation(list, newestFirst = false) {
+  // Direction comes from the comparator operand order (like sortByModified),
+  // not .reverse(). A consistent comparator keeps .sort() idempotent, so
+  // sorting the reactive array in place doesn't re-trigger this computed.
+  return list.sort((a, b) =>
+    newestFirst
+      ? new Date(b.creation) - new Date(a.creation)
+      : new Date(a.creation) - new Date(b.creation),
+  )
 }
 function sortByModified(list) {
   return list.sort((b, a) => new Date(a.modified) - new Date(b.modified))
@@ -829,7 +838,7 @@ function scroll(hash) {
     let el
     if (!hash) {
       let e = document.getElementsByClassName('activity')
-      el = e[e.length - 1]
+      el = isNewestFirst.value ? e[0] : e[e.length - 1]
     } else {
       el = document.getElementById(hash)
     }

--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -226,11 +226,7 @@
                 />
               </div>
               <div class="ml-auto whitespace-nowrap">
-                <Tooltip :text="formatDate(activity.creation)">
-                  <div class="text-sm text-ink-gray-5">
-                    {{ __(timeAgo(activity.creation)) }}
-                  </div>
-                </Tooltip>
+                <TimelineTimestamp :date="activity.creation" />
               </div>
             </div>
           </div>
@@ -311,11 +307,7 @@
               </div>
 
               <div class="ml-auto whitespace-nowrap">
-                <Tooltip :text="formatDate(activity.creation)">
-                  <div class="text-sm text-ink-gray-5">
-                    {{ __(timeAgo(activity.creation)) }}
-                  </div>
-                </Tooltip>
+                <TimelineTimestamp :date="activity.creation" />
               </div>
             </div>
             <div
@@ -378,11 +370,7 @@
                 </div>
 
                 <div class="ml-auto whitespace-nowrap">
-                  <Tooltip :text="formatDate(a.creation)">
-                    <div class="text-sm text-ink-gray-5">
-                      {{ __(timeAgo(a.creation)) }}
-                    </div>
-                  </Tooltip>
+                  <TimelineTimestamp :date="a.creation" />
                 </div>
               </div>
             </div>
@@ -487,14 +475,15 @@ import CommunicationArea from '@/components/CommunicationArea.vue'
 import WhatsappTemplateSelectorModal from '@/components/Modals/WhatsappTemplateSelectorModal.vue'
 import AllModals from '@/components/Activities/AllModals.vue'
 import FilesUploader from '@/components/FilesUploader/FilesUploader.vue'
-import { timeAgo, formatDate, startCase } from '@/utils'
+import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
+import { startCase } from '@/utils'
 import { globalStore } from '@/stores/global'
 import { usersStore } from '@/stores/users'
 import { useTimelinePreferences } from '@/composables/useTimelinePreferences'
 import { whatsappEnabled } from '@/composables/whatsapp'
 import { useDocument } from '@/data/document'
 import { useTelemetry } from 'frappe-ui/frappe'
-import { Button, Tooltip, createResource, toast } from 'frappe-ui'
+import { Button, createResource, toast } from 'frappe-ui'
 import { useElementVisibility } from '@vueuse/core'
 import {
   ref,

--- a/frontend/src/components/Activities/AttachmentArea.vue
+++ b/frontend/src/components/Activities/AttachmentArea.vue
@@ -32,11 +32,7 @@
           </div>
         </div>
         <div class="flex flex-col items-end gap-2 flex-shrink-0">
-          <Tooltip :text="formatDate(attachment.creation)">
-            <div class="text-sm text-ink-gray-5">
-              {{ __(timeAgo(attachment.creation)) }}
-            </div>
-          </Tooltip>
+          <TimelineTimestamp :date="attachment.creation" />
           <div class="flex gap-1">
             <Button
               :tooltip="
@@ -78,8 +74,9 @@ import FileAudioIcon from '@/components/Icons/FileAudioIcon.vue'
 import FileTextIcon from '@/components/Icons/FileTextIcon.vue'
 import FileVideoIcon from '@/components/Icons/FileVideoIcon.vue'
 import { globalStore } from '@/stores/global'
-import { call, Tooltip } from 'frappe-ui'
-import { formatDate, timeAgo, convertSize, isImage } from '@/utils'
+import { call } from 'frappe-ui'
+import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
+import { convertSize, isImage } from '@/utils'
 
 defineProps({
   attachments: { type: Array, default: () => [] },

--- a/frontend/src/components/Activities/CallArea.vue
+++ b/frontend/src/components/Activities/CallArea.vue
@@ -17,11 +17,7 @@
         }}</span>
       </div>
       <div class="ml-auto whitespace-nowrap">
-        <Tooltip :text="formatDate(call.creation)">
-          <div class="text-sm text-ink-gray-5">
-            {{ __(timeAgo(call.creation)) }}
-          </div>
-        </Tooltip>
+        <TimelineTimestamp :date="call.creation" />
       </div>
     </div>
     <div
@@ -105,9 +101,10 @@ import DurationIcon from '@/components/Icons/DurationIcon.vue'
 import MultipleAvatar from '@/components/MultipleAvatar.vue'
 import AudioPlayer from '@/components/Activities/AudioPlayer.vue'
 import CallLogDetailModal from '@/components/Modals/CallLogDetailModal.vue'
+import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
 import { statusLabelMap, statusColorMap } from '@/utils/callLog.js'
-import { formatDate, timeAgo } from '@/utils'
-import { Avatar, Badge, Tooltip, createResource } from 'frappe-ui'
+import { formatDate } from '@/utils'
+import { Avatar, Badge, createResource } from 'frappe-ui'
 import { reactive, ref } from 'vue'
 
 const props = defineProps({

--- a/frontend/src/components/Activities/CommentArea.vue
+++ b/frontend/src/components/Activities/CommentArea.vue
@@ -12,11 +12,7 @@
         </span>
       </div>
       <div class="ml-auto flex items-center gap-1 whitespace-nowrap">
-        <Tooltip :text="formatDate(activity.creation)">
-          <div class="text-sm text-ink-gray-5">
-            {{ __(timeAgo(activity.creation)) }}
-          </div>
-        </Tooltip>
+        <TimelineTimestamp :date="activity.creation" />
         <Dropdown
           v-if="isOwner && !editing"
           :options="menuOptions"
@@ -68,8 +64,9 @@
 <script setup>
 import UserAvatar from '@/components/UserAvatar.vue'
 import AttachmentItem from '@/components/AttachmentItem.vue'
-import { Tooltip, Dropdown, Button, TextEditor, call, toast } from 'frappe-ui'
-import { timeAgo, formatDate, sanitizeHTML, ConfirmDelete } from '@/utils'
+import { Dropdown, Button, TextEditor, call, toast } from 'frappe-ui'
+import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
+import { sanitizeHTML, ConfirmDelete } from '@/utils'
 import { sessionStore } from '@/stores/session'
 import { computed, ref } from 'vue'
 

--- a/frontend/src/components/Activities/EmailArea.vue
+++ b/frontend/src/components/Activities/EmailArea.vue
@@ -24,11 +24,7 @@
           variant="subtle"
           :theme="status.color"
         />
-        <Tooltip :text="formatDate(activity.communication_date)">
-          <div class="text-sm text-ink-gray-5">
-            {{ __(timeAgo(activity.communication_date)) }}
-          </div>
-        </Tooltip>
+        <TimelineTimestamp :date="activity.communication_date" />
         <div class="flex gap-0.5">
           <Button
             :tooltip="__('Reply')"
@@ -81,8 +77,8 @@ import ReplyIcon from '@/components/Icons/ReplyIcon.vue'
 import ReplyAllIcon from '@/components/Icons/ReplyAllIcon.vue'
 import AttachmentItem from '@/components/AttachmentItem.vue'
 import EmailContent from '@/components/Activities/EmailContent.vue'
-import { Badge, Tooltip } from 'frappe-ui'
-import { timeAgo, formatDate } from '@/utils'
+import { Badge } from 'frappe-ui'
+import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
 import { reactive, computed } from 'vue'
 
 const props = defineProps({

--- a/frontend/src/components/Activities/EventArea.vue
+++ b/frontend/src/components/Activities/EventArea.vue
@@ -31,11 +31,7 @@
             <span>{{ 'has created an event' }}</span>
           </div>
           <div class="ml-auto whitespace-nowrap">
-            <Tooltip :text="formatDate(event.creation)">
-              <div class="text-sm text-ink-gray-5">
-                {{ __(timeAgo(event.creation)) }}
-              </div>
-            </Tooltip>
+            <TimelineTimestamp :date="event.creation" />
           </div>
         </div>
         <div
@@ -87,8 +83,8 @@ import EmptyState from '@/components/ListViews/EmptyState.vue'
 import CalendarIcon from '@/components/Icons/CalendarIcon.vue'
 import MultipleAvatar from '@/components/MultipleAvatar.vue'
 import { useEvent, showEventModal, activeEvent } from '@/composables/event'
-import { formatDate, timeAgo } from '@/utils'
-import { Tooltip, Avatar } from 'frappe-ui'
+import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
+import { Avatar } from 'frappe-ui'
 
 const props = defineProps({
   doctype: { type: String, default: '' },

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -42,18 +42,17 @@
           {{ getUser(note.owner).full_name }}
         </div>
       </div>
-      <Tooltip :text="formatDate(note.modified)">
-        <div class="truncate text-sm text-ink-gray-7">
-          {{ __(timeAgo(note.modified)) }}
-        </div>
-      </Tooltip>
+      <TimelineTimestamp
+        :date="note.modified"
+        class-name="truncate text-sm text-ink-gray-7"
+      />
     </div>
   </div>
 </template>
 <script setup>
 import UserAvatar from '@/components/UserAvatar.vue'
-import { timeAgo, formatDate } from '@/utils'
-import { Tooltip, Dropdown, TextEditor, call, toast } from 'frappe-ui'
+import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
+import { Dropdown, TextEditor, call, toast } from 'frappe-ui'
 import { usersStore } from '@/stores/users'
 
 defineProps({

--- a/frontend/src/components/Activities/TimelineTimestamp.vue
+++ b/frontend/src/components/Activities/TimelineTimestamp.vue
@@ -1,0 +1,31 @@
+<template>
+  <Tooltip :text="tooltipText">
+    <div :class="className">{{ displayText }}</div>
+  </Tooltip>
+</template>
+
+<script setup>
+import { Tooltip } from 'frappe-ui'
+import { timeAgo, formatDate } from '@/utils'
+import { useTimelinePreferences } from '@/composables/useTimelinePreferences'
+import { computed } from 'vue'
+
+const props = defineProps({
+  date: { type: [String, Object], default: '' },
+  // Format used for the exact timestamp (falls back to the default in formatDate)
+  format: { type: String, default: '' },
+  className: { type: String, default: 'text-sm text-ink-gray-5' },
+})
+
+const { showExactTimestamp } = useTimelinePreferences()
+
+const relative = computed(() => __(timeAgo(props.date)))
+const exact = computed(() => formatDate(props.date, props.format || undefined))
+
+const displayText = computed(() =>
+  showExactTimestamp.value ? exact.value : relative.value,
+)
+const tooltipText = computed(() =>
+  showExactTimestamp.value ? relative.value : exact.value,
+)
+</script>

--- a/frontend/src/components/Settings/GeneralSettings.vue
+++ b/frontend/src/components/Settings/GeneralSettings.vue
@@ -79,6 +79,31 @@
       <div class="flex gap-4 items-center justify-between py-3 px-2">
         <div class="flex flex-col">
           <div class="text-p-base font-medium text-ink-gray-7 truncate">
+            {{ __('Timeline timestamp format') }}
+          </div>
+          <div class="text-p-sm text-ink-gray-5">
+            {{
+              __(
+                'Show timestamps in the activity timeline as relative time (5 mins ago) or an exact date & time',
+              )
+            }}
+          </div>
+        </div>
+        <div>
+          <FormControl
+            v-model="settings.doc.crm_timeline_timestamp_format"
+            type="select"
+            class="w-40"
+            :options="timestampFormatOptions"
+            :placeholder="__('Relative')"
+            @update:modelValue="save()"
+          />
+        </div>
+      </div>
+      <div class="h-px border-t mx-2 border-outline-gray-modals" />
+      <div class="flex gap-4 items-center justify-between py-3 px-2">
+        <div class="flex flex-col">
+          <div class="text-p-base font-medium text-ink-gray-7 truncate">
             {{ __('Timeline sort order') }}
           </div>
           <div class="text-p-sm text-ink-gray-5">
@@ -110,6 +135,10 @@ import { FormControl, Switch, toast } from 'frappe-ui'
 
 const { _settings: settings } = getSettings()
 
+const timestampFormatOptions = [
+  { label: __('Relative (5 mins ago)'), value: 'Relative' },
+  { label: __('Exact (Jun 9, 2026 14:02)'), value: 'Exact' },
+]
 const sortOrderOptions = [
   { label: __('Oldest First'), value: 'Oldest First' },
   { label: __('Newest First'), value: 'Newest First' },

--- a/frontend/src/components/Settings/GeneralSettings.vue
+++ b/frontend/src/components/Settings/GeneralSettings.vue
@@ -75,15 +75,45 @@
           />
         </div>
       </div>
+      <div class="h-px border-t mx-2 border-outline-gray-modals" />
+      <div class="flex gap-4 items-center justify-between py-3 px-2">
+        <div class="flex flex-col">
+          <div class="text-p-base font-medium text-ink-gray-7 truncate">
+            {{ __('Timeline sort order') }}
+          </div>
+          <div class="text-p-sm text-ink-gray-5">
+            {{
+              __(
+                'Order of activities, emails, comments and calls in the timeline',
+              )
+            }}
+          </div>
+        </div>
+        <div>
+          <FormControl
+            v-model="settings.doc.crm_timeline_sort_order"
+            type="select"
+            class="w-40"
+            :options="sortOrderOptions"
+            :placeholder="__('Oldest First')"
+            @update:modelValue="save()"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
 import { getSettings } from '@/stores/settings'
-import { Switch, toast } from 'frappe-ui'
+import { FormControl, Switch, toast } from 'frappe-ui'
 
 const { _settings: settings } = getSettings()
+
+const sortOrderOptions = [
+  { label: __('Oldest First'), value: 'Oldest First' },
+  { label: __('Newest First'), value: 'Newest First' },
+]
 
 function toggle(settingKey) {
   settings.save.submit(null, {
@@ -94,6 +124,12 @@ function toggle(settingKey) {
           : __('Setting disabled successfully'),
       )
     },
+  })
+}
+
+function save() {
+  settings.save.submit(null, {
+    onSuccess: () => toast.success(__('Setting updated successfully')),
   })
 }
 </script>

--- a/frontend/src/components/Settings/GeneralSettings.vue
+++ b/frontend/src/components/Settings/GeneralSettings.vue
@@ -136,8 +136,8 @@ import { FormControl, Switch, toast } from 'frappe-ui'
 const { _settings: settings } = getSettings()
 
 const timestampFormatOptions = [
-  { label: __('Relative (5 mins ago)'), value: 'Relative' },
-  { label: __('Exact (Jun 9, 2026 14:02)'), value: 'Exact' },
+  { label: __('Relative'), value: 'Relative' },
+  { label: __('Exact'), value: 'Exact' },
 ]
 const sortOrderOptions = [
   { label: __('Oldest First'), value: 'Oldest First' },

--- a/frontend/src/composables/useTimelinePreferences.js
+++ b/frontend/src/composables/useTimelinePreferences.js
@@ -1,0 +1,41 @@
+import { computed } from 'vue'
+import { getSettings } from '@/stores/settings'
+import { formatDate, timeAgo } from '@/utils'
+
+export function useTimelinePreferences() {
+  const { _settings } = getSettings()
+
+  const timestampFormat = computed(
+    () => _settings.doc?.crm_timeline_timestamp_format || 'Relative',
+  )
+  const sortOrder = computed(
+    () => _settings.doc?.crm_timeline_sort_order || 'Oldest First',
+  )
+
+  const showExactTimestamp = computed(() => timestampFormat.value === 'Exact')
+  const isNewestFirst = computed(() => sortOrder.value === 'Newest First')
+
+  return {
+    timestampFormat,
+    sortOrder,
+    showExactTimestamp,
+    isNewestFirst,
+  }
+}
+
+// Builds a { label, timeAgo } cell for list/table views, honoring the global
+// FCRM Settings timestamp format. `timeAgo` is the displayed value and `label`
+// is the tooltip; when "Exact" is set the two are swapped so the date shows.
+// Kept here (not in utils/index.js) so the settings store is not pulled into
+// the eager import graph and fetched before frappe-ui is configured.
+export function timestampCell(date) {
+  if (!date) return { label: '', timeAgo: '' }
+  const exact = formatDate(date)
+  const relative = __(timeAgo(date))
+  const showExact =
+    getSettings()._settings.doc?.crm_timeline_timestamp_format === 'Exact'
+  return {
+    label: showExact ? relative : exact,
+    timeAgo: showExact ? exact : relative,
+  }
+}

--- a/frontend/src/pages/Contact.vue
+++ b/frontend/src/pages/Contact.vue
@@ -180,12 +180,8 @@ import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
 import CustomActions from '@/components/CustomActions.vue'
-import {
-  formatDate,
-  timeAgo,
-  validateIsImageFile,
-  setupCustomizations,
-} from '@/utils'
+import { validateIsImageFile, setupCustomizations } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
 import { getSettings } from '@/stores/settings'
@@ -510,10 +506,7 @@ function getDealRowObject(deal) {
       label: deal.deal_owner && getUser(deal.deal_owner).full_name,
       ...(deal.deal_owner && getUser(deal.deal_owner)),
     },
-    modified: {
-      label: formatDate(deal.modified),
-      timeAgo: __(timeAgo(deal.modified)),
-    },
+    modified: timestampCell(deal.modified),
   }
 }
 

--- a/frontend/src/pages/Contacts.vue
+++ b/frontend/src/pages/Contacts.vue
@@ -70,7 +70,8 @@ import EmptyState from '@/components/ListViews/EmptyState.vue'
 import ViewControls from '@/components/ViewControls.vue'
 import { getMeta } from '@/stores/meta'
 import { organizationsStore } from '@/stores/organizations.js'
-import { formatDate, timeAgo } from '@/utils'
+import { formatDate } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { ref, computed } from 'vue'
 
 const { getFormattedPercent, getFormattedFloat, getFormattedCurrency } =
@@ -135,10 +136,7 @@ const rows = computed(() => {
           logo: getOrganization(contact.company_name)?.organization_logo,
         }
       } else if (['modified', 'creation'].includes(row)) {
-        _rows[row] = {
-          label: formatDate(contact[row]),
-          timeAgo: __(timeAgo(contact[row])),
-        }
+        _rows[row] = timestampCell(contact[row])
       }
     })
     return _rows

--- a/frontend/src/pages/Deals.vue
+++ b/frontend/src/pages/Deals.vue
@@ -266,6 +266,7 @@ import { organizationsStore } from '@/stores/organizations'
 import { statusesStore } from '@/stores/statuses'
 import { callEnabled } from '@/composables/telephony'
 import { formatDate, timeAgo, website, formatTime } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 import { Tooltip, Avatar, Dropdown } from 'frappe-ui'
 import { useRoute } from 'vue-router'
@@ -459,10 +460,7 @@ function parseRows(rows, columns = []) {
           label: getUser(user).full_name,
         }))
       } else if (['modified', 'creation'].includes(row)) {
-        _rows[row] = {
-          label: formatDate(deal[row]),
-          timeAgo: __(timeAgo(deal[row])),
-        }
+        _rows[row] = timestampCell(deal[row])
       } else if (
         ['first_response_time', 'first_responded_on', 'response_by'].includes(
           row,

--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -292,6 +292,7 @@ import { statusesStore } from '@/stores/statuses'
 import { callEnabled } from '@/composables/telephony'
 import { useBroadcast } from '@/composables/useBroadcast'
 import { formatDate, timeAgo, website, formatTime } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 import { Avatar, Tooltip, Dropdown } from 'frappe-ui'
 import { useRoute } from 'vue-router'
@@ -493,10 +494,7 @@ function parseRows(rows, columns = []) {
           label: getUser(user).full_name,
         }))
       } else if (['modified', 'creation'].includes(row)) {
-        _rows[row] = {
-          label: formatDate(lead[row]),
-          timeAgo: __(timeAgo(lead[row])),
-        }
+        _rows[row] = timestampCell(lead[row])
       } else if (
         ['first_response_time', 'first_responded_on', 'response_by'].includes(
           row,

--- a/frontend/src/pages/MobileContact.vue
+++ b/frontend/src/pages/MobileContact.vue
@@ -167,7 +167,8 @@ import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
 import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
-import { formatDate, timeAgo, validateIsImageFile } from '@/utils'
+import { validateIsImageFile } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
 import { getSettings } from '@/stores/settings'
@@ -503,10 +504,7 @@ function getDealRowObject(deal) {
       label: deal.deal_owner && getUser(deal.deal_owner).full_name,
       ...(deal.deal_owner && getUser(deal.deal_owner)),
     },
-    modified: {
-      label: formatDate(deal.modified),
-      timeAgo: __(timeAgo(deal.modified)),
-    },
+    modified: timestampCell(deal.modified),
   }
 }
 

--- a/frontend/src/pages/MobileOrganization.vue
+++ b/frontend/src/pages/MobileOrganization.vue
@@ -168,11 +168,10 @@ import { usersStore } from '@/stores/users'
 import { statusesStore } from '@/stores/statuses'
 import { getView } from '@/utils/view'
 import {
-  formatDate,
-  timeAgo,
   validateIsImageFile,
   openWebsite as openExternalWebsite,
 } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import {
   Breadcrumbs,
   Avatar,
@@ -431,10 +430,7 @@ function getDealRowObject(deal) {
       label: deal.deal_owner && getUser(deal.deal_owner).full_name,
       ...(deal.deal_owner && getUser(deal.deal_owner)),
     },
-    modified: {
-      label: formatDate(deal.modified),
-      timeAgo: __(timeAgo(deal.modified)),
-    },
+    modified: timestampCell(deal.modified),
   }
 }
 
@@ -452,10 +448,7 @@ function getContactRowObject(contact) {
       label: contact.company_name,
       logo: organization.doc?.organization_logo,
     },
-    modified: {
-      label: formatDate(contact.modified),
-      timeAgo: __(timeAgo(contact.modified)),
-    },
+    modified: timestampCell(contact.modified),
   }
 }
 

--- a/frontend/src/pages/Organization.vue
+++ b/frontend/src/pages/Organization.vue
@@ -199,12 +199,11 @@ import { usersStore } from '@/stores/users'
 import { statusesStore } from '@/stores/statuses'
 import { getView } from '@/utils/view'
 import {
-  formatDate,
-  timeAgo,
   validateIsImageFile,
   setupCustomizations,
   openWebsite as openExternalWebsite,
 } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import {
   Breadcrumbs,
   Avatar,
@@ -461,10 +460,7 @@ function getDealRowObject(deal) {
       label: deal.deal_owner && getUser(deal.deal_owner).full_name,
       ...(deal.deal_owner && getUser(deal.deal_owner)),
     },
-    modified: {
-      label: formatDate(deal.modified),
-      timeAgo: __(timeAgo(deal.modified)),
-    },
+    modified: timestampCell(deal.modified),
   }
 }
 
@@ -482,10 +478,7 @@ function getContactRowObject(contact) {
       label: contact.company_name,
       logo: organization.doc?.organization_logo,
     },
-    modified: {
-      label: formatDate(contact.modified),
-      timeAgo: __(timeAgo(contact.modified)),
-    },
+    modified: timestampCell(contact.modified),
   }
 }
 

--- a/frontend/src/pages/Organizations.vue
+++ b/frontend/src/pages/Organizations.vue
@@ -66,7 +66,8 @@ import OrganizationModal from '@/components/Modals/OrganizationModal.vue'
 import OrganizationsListView from '@/components/ListViews/OrganizationsListView.vue'
 import ViewControls from '@/components/ViewControls.vue'
 import { getMeta } from '@/stores/meta'
-import { formatDate, timeAgo, website } from '@/utils'
+import { formatDate, website } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { ref, computed } from 'vue'
 import EmptyState from '../components/ListViews/EmptyState.vue'
 
@@ -131,10 +132,7 @@ const rows = computed(() => {
       } else if (row === 'website') {
         _rows[row] = website(organization.website)
       } else if (['modified', 'creation'].includes(row)) {
-        _rows[row] = {
-          label: formatDate(organization[row]),
-          timeAgo: __(timeAgo(organization[row])),
-        }
+        _rows[row] = timestampCell(organization[row])
       }
     })
     return _rows

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -198,7 +198,8 @@ import KanbanView from '@/components/Kanban/KanbanView.vue'
 import { useDoctypeModal } from '@/composables/doctypeModal'
 import { getMeta } from '@/stores/meta'
 import { usersStore } from '@/stores/users'
-import { formatDate, timeAgo } from '@/utils'
+import { formatDate } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 import { Tooltip, Avatar, TextEditor, Dropdown, call } from 'frappe-ui'
 import { computed, ref } from 'vue'
@@ -303,10 +304,7 @@ function parseRows(rows, columns = []) {
       }
 
       if (['modified', 'creation'].includes(row)) {
-        _rows[row] = {
-          label: formatDate(task[row]),
-          timeAgo: __(timeAgo(task[row])),
-        }
+        _rows[row] = timestampCell(task[row])
       } else if (row == 'assigned_to') {
         _rows[row] = {
           label: task.assigned_to && getUser(task.assigned_to).full_name,

--- a/frontend/src/utils/callLog.js
+++ b/frontend/src/utils/callLog.js
@@ -1,4 +1,5 @@
-import { formatDate, timeAgo } from '@/utils'
+import { formatDate } from '@/utils'
+import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getMeta } from '@/stores/meta'
 
 const { getFormattedPercent, getFormattedFloat, getFormattedCurrency } =
@@ -33,10 +34,7 @@ export function getCallLogDetail(row, log, columns = []) {
       color: statusColorMap[log.status],
     }
   } else if (['modified', 'creation'].includes(row)) {
-    return {
-      label: formatDate(log[row]),
-      timeAgo: __(timeAgo(log[row])),
-    }
+    return timestampCell(log[row])
   }
 
   let fieldType = columns?.find((col) => (col.key || col.value) == row)?.type


### PR DESCRIPTION
## Summary
Adds two global (FCRM Settings) preferences for the activity timeline, set in
General Settings and applied for all users:
- Timestamp format: Relative (5 mins ago) or Exact date & time
- Sort order: Oldest First or Newest First (Activity / Comments / Emails / Calls)

The timestamp format also applies to the list views (Leads, Deals, Contacts,
Organizations, Tasks, Call Logs) and related deal/contact lists.

## Commits (setting → feature)
1. add timeline sort order setting
2. apply newest/oldest sort order in the activity timeline
3. add timeline timestamp format setting
4. show relative/exact timestamps in the activity timeline
5. apply timestamp format to list views

Issue https://github.com/frappe/crm/issues/2271