### PR TITLE
fix: link deal addresses to customer on auto-creation

### DIFF
--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
@@ -537,9 +537,51 @@ def create_customer_from_deal(doc, erpnext_crm_settings):
 
 	if customer_name:
 		frappe.db.set_value("CRM Deal", doc.name, "erpnext_customer", customer_name)
+		link_deal_addresses_to_customer(doc.name, customer_name, erpnext_crm_settings)
 		frappe.publish_realtime("crm_customer_created")
 
 	return customer_name
+
+
+def link_deal_addresses_to_customer(deal_name, customer_name, erpnext_crm_settings):
+	"""Link all addresses associated with the CRM Deal to the newly created Customer.
+
+	When a Customer is auto-created from a CRM Deal, addresses that were added
+	to the deal (via Dynamic Links) only reference the CRM Deal. This function
+	adds a Dynamic Link to the new Customer on each address so that the addresses
+	are usable in ERPNext transactions (Sales Orders, Invoices, etc.).
+
+	For remote ERPNext sites, the organization address is already handled via the
+	create_address API call in create_customer_from_deal.
+	"""
+	if erpnext_crm_settings.is_erpnext_in_different_site:
+		return
+
+	address_names = frappe.get_all(
+		"Dynamic Link",
+		filters={"link_doctype": "CRM Deal", "link_name": deal_name, "parenttype": "Address"},
+		pluck="parent",
+		distinct=True,
+	)
+
+	for address_name in address_names:
+		try:
+			address_doc = frappe.get_doc("Address", address_name)
+			already_linked = any(
+				link.link_doctype == "Customer" and link.link_name == customer_name
+				for link in address_doc.links
+			)
+			if not already_linked:
+				address_doc.append("links", {
+					"link_doctype": "Customer",
+					"link_name": customer_name,
+				})
+				address_doc.save(ignore_permissions=True)
+		except Exception:
+			frappe.log_error(
+				frappe.get_traceback(),
+				f"Error linking address {address_name} to customer {customer_name}",
+			)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Problem

When a CRM Deal moves to "Won" and a Customer is auto-created (via `ERPNext CRM Settings > Create Customer on Status Change`), addresses linked to the deal are **not re-linked** to the new Customer.

This causes ERPNext to throw:
> **"Billing Address does not belong to {Customer}"**

when creating Sales Orders or Invoices against the auto-created Customer.

### Root Cause

In `create_customer_from_deal()`, only the organization's address (via `get_organization_address()`) is passed to ERPNext's `create_customer` API. Addresses linked directly to the CRM Deal via **Dynamic Links** are completely ignored.

After customer creation, those deal-linked addresses still only have:
```
link_doctype: "CRM Deal", link_name: "CRM-DEAL-xxxx"
```

They're missing:
```
link_doctype: "Customer", link_name: "<new_customer>"
```

### Steps to Reproduce

1. Create a CRM Deal with an address (via FCRM Data tab)
2. Move the deal to **Won** → Customer is auto-created
3. Go to ERPNext → Create **Sales Order** for that Customer
4. Select the billing address → **Error: address does not belong to Customer**

## Solution

Added `link_deal_addresses_to_customer()` which runs immediately after customer creation in `create_customer_from_deal()`. It:

1. Queries all addresses linked to the CRM Deal via Dynamic Links
2. For each address, checks if a Customer link already exists (idempotent)
3. Appends a `Customer` Dynamic Link entry if missing
4. Wraps each address update in try/except to avoid breaking the main flow

### Scope

- **Same-site deployments**: Fully handled (addresses are on the same DB)
- **Remote ERPNext sites**: Skipped (organization address is already handled via the `create_address` API call; deal-level addresses on remote sites would require ERPNext API changes)

## Change Summary

| File | Change |
|------|--------|
| `erpnext_crm_settings.py` | Added `link_deal_addresses_to_customer()` function |
| `erpnext_crm_settings.py` | Called it from `create_customer_from_deal()` after customer creation |

Closes #2292