### PR TITLE
fix: use FrappeTestCase for FCRM Settings tests

### DIFF
--- a/crm/fcrm/doctype/fcrm_settings/test_fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/test_fcrm_settings.py
@@ -4,12 +4,12 @@
 import json
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 
 FORECASTING_FIELDS = ["expected_closure_date", "probability", "expected_deal_value"]
 
 
-class TestFCRMSettings(IntegrationTestCase):
+class TestFCRMSettings(FrappeTestCase):
 	def tearDown(self) -> None:
 		frappe.db.rollback()
 


### PR DESCRIPTION
IntegrationTestCase is unavailable in the Frappe version this backport branch targets. Align with the rest of the app's tests.