### PR TITLE
fix: add validation when linking notes and tasks to call logs

### DIFF
--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -61,6 +61,9 @@ def set_default_calling_medium(medium: str):
 @frappe.whitelist()
 def add_note_to_call_log(call_sid: str, note: dict):
 	"""Add/Update note to call log based on call sid."""
+	if not frappe.has_permission("CRM Call Log", "write", call_sid):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
 	_note = None
 	if not note.get("name"):
 		_note = frappe.get_doc(
@@ -83,6 +86,9 @@ def add_note_to_call_log(call_sid: str, note: dict):
 @frappe.whitelist()
 def add_task_to_call_log(call_sid: str, task: dict):
 	"""Add/Update task to call log based on call sid."""
+	if not frappe.has_permission("CRM Call Log", "write", call_sid):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
 	_task = None
 	if not task.get("name"):
 		_task = frappe.get_doc(


### PR DESCRIPTION
### Summary

`add_note_to_call_log` and `add_task_to_call_log` linked and saved the target call log without validating that the caller can write to it. This adds a `frappe.has_permission` check on the referenced call log before the note/task is linked, consistent with the existing pattern in `create_lead_from_call_log`.

### Changes

- Validate write access to the `CRM Call Log` before linking a note or task to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)