### PR TITLE
feat: land on /crm only when CRM is the sole product app, else desk

### DIFF
--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -50,6 +50,22 @@ def complete_setup_for_fc_site(doc, method=None):
 	frappe.db.set_single_value("System Settings", "setup_complete", 1)
 
 
+def set_home_page_on_login(login_manager=None):
+	"""Land users on the CRM app only when it is the sole product app installed.
+
+	Frappe routes System Users to the desk after login (via `get_home_page()`), which
+	doesn't consult the app-screen logic that already knows the default app. So on a
+	CRM-only site we set the request-scoped `home_page` flag — which `get_home_page()`
+	honours first — to send users to `/crm`. On a multi-app site we leave it unset so
+	users fall through to the desk, matching Frappe's `get_default_path()` behaviour.
+	"""
+	from frappe.apps import get_apps
+
+	product_apps = [app for app in get_apps() if app.get("name") != "frappe"]
+	if len(product_apps) == 1 and product_apps[0].get("name") == "crm":
+		frappe.local.flags.home_page = "crm"
+
+
 @frappe.whitelist()
 def get_first_lead():
 	lead = frappe.get_all(

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -61,7 +61,9 @@ doctype_js = {
 # ----------
 
 # application home page (will override Website Settings)
-home_page = "crm"
+# Set dynamically on login (see on_login below): CRM becomes the landing page only
+# when it is the sole product app installed, otherwise users fall through to the desk.
+# home_page = "crm"
 
 # website user home page (by Role)
 # role_home_page = {
@@ -299,6 +301,8 @@ ignore_links_on_delete = ["Failed Lead Sync Log"]
 # auth_hooks = [
 # "crm.auth.validate"
 # ]
+
+on_login = "crm.api.onboarding.set_home_page_on_login"
 
 after_migrate = [
 	"crm.fcrm.doctype.fcrm_settings.fcrm_settings.after_migrate",

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -302,7 +302,7 @@ ignore_links_on_delete = ["Failed Lead Sync Log"]
 # "crm.auth.validate"
 # ]
 
-on_login = "crm.api.onboarding.set_home_page_on_login"
+on_login = ["crm.api.onboarding.set_home_page_on_login"]
 
 after_migrate = [
 	"crm.fcrm.doctype.fcrm_settings.fcrm_settings.after_migrate",


### PR DESCRIPTION
## Context

Follow-up to #2335 (merged & backported). That PR set a global `home_page = "crm"` hook so users land on the CRM app after login. This refines that to avoid hijacking multi-app sites.

## Problem with the global hook

`home_page = "crm"` applies on **every** site where the CRM app is installed and to **all** users. On a multi-app bench (e.g. CRM + ERPNext) it sends every user — and the site root `/` — to `/crm`, even pure ERPNext/desk users, and is fragile if another app also sets the hook.

## Why a hook is needed at all

The framework already has the "sole app → that app" logic in `get_default_path()` and uses it for Website-user login, welcome/reset-password login, OAuth, and the already-logged-in `/login` redirect. But the **ordinary System-User login** uses `get_home_page()` instead (`frappe/auth.py` set_user_info → System User branch), which bottoms out at `frappe/website/utils.py` `"me"` → `"desk"`. So a CRM-only site still drops System Users on the desk at normal login.

## Fix

Replace the unconditional hook with an `on_login` handler that sets the request-scoped `home_page` flag to `"crm"` **only when CRM is the single product app installed** (mirroring `get_default_path`'s logic). `get_home_page()` honours that flag first, short-circuiting the desk fallback. On multi-app sites the flag is left unset, so System Users fall through to the desk exactly as before.

```python
def set_home_page_on_login(login_manager=None):
    from frappe.apps import get_apps
    product_apps = [app for app in get_apps() if app.get("name") != "frappe"]
    if len(product_apps) == 1 and product_apps[0].get("name") == "crm":
        frappe.local.flags.home_page = "crm"
```

## Behaviour

| Site | Landing after login |
|---|---|
| CRM is the only product app | `/crm` |
| CRM + any other app | desk (unchanged) |

## Testing

- Verified in a fresh process: `get_hooks("on_login")` includes the handler; full login chain returns `home_page = "crm"` on a CRM-only site and falls through to the desk when a second app is simulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)