### PR TITLE
fix: don't use `create_custom_fields_for_frappe_crm` API from ERPNext

### DIFF
--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
@@ -83,11 +83,7 @@ class ERPNextCRMSettings(Document):
 
 	def create_custom_fields(self):
 		if not self.is_erpnext_in_different_site:
-			try:
-				from erpnext.crm.frappe_crm_api import create_custom_fields_for_frappe_crm
-
-				create_custom_fields_for_frappe_crm()
-			except ImportError:
+			if not _is_erpnext_installed():
 				frappe.throw(_("ERPNext is not installed in the current site"))
 		else:
 			self.create_custom_fields_in_remote_site()
@@ -135,6 +131,16 @@ class ERPNextCRMSettings(Document):
 					"insert_after": "party_name",
 				}
 			]
+		if frappe.db.exists("DocType", "Customer"):
+			custom_fields["Customer"] = [
+				{
+					"fieldname": "crm_deal",
+					"fieldtype": "Data",
+					"label": "Frappe CRM Deal",
+					"read_only": 1,
+					"insert_after": "prospect_name",
+				}
+			]
 		_create_custom_fields(custom_fields, ignore_validate=True)
 
 	def create_custom_fields_in_remote_site(self):
@@ -142,9 +148,18 @@ class ERPNextCRMSettings(Document):
 		try:
 			client.post_api("erpnext.crm.frappe_crm_api.create_custom_fields_for_frappe_crm")
 		except Exception:
-			_log_and_throw(
-				"Error while creating custom field in ERPNext, check error log for more details",
-				f"Error while creating custom field in the remote erpnext site: {self.erpnext_site_url}",
+			frappe.log_error(
+				frappe.get_traceback(),
+				f"Could not create custom fields on remote ERPNext site: {self.erpnext_site_url}",
+			)
+			frappe.msgprint(
+				_(
+					"Could not create the Frappe CRM custom fields on {0} automatically. "
+					"If it is running the latest ERPNext, enable <b>Frappe CRM Data Synchronization</b> "
+					"in its CRM Settings, Otherwise check the Error Log."
+				).format(self.erpnext_site_url),
+				title=_("ERPNext custom fields not created"),
+				indicator="orange",
 			)
 
 	def grant_item_access_to_sales_roles(self):
@@ -530,7 +545,7 @@ def create_customer_from_deal(doc, erpnext_crm_settings):
 				"Error while creating customer in ERPNext, check error log for more details",
 				f"Error while creating customer in ERPNext for CRM Deal: {doc.name}",
 			)
-	except frappe.ValidationError:
+	except (frappe.ValidationError, frappe.PermissionError):
 		raise
 	except Exception:
 		_log_and_throw("Error while creating customer in ERPNext, check error log for more details")

--- a/crm/patches/v1_0/create_custom_fields_for_product_item_sync.py
+++ b/crm/patches/v1_0/create_custom_fields_for_product_item_sync.py
@@ -30,11 +30,6 @@ def execute():
 		]
 	create_custom_fields(custom_fields, ignore_validate=True)
 
-	if frappe.db.get_single_value("ERPNext CRM Settings", "is_erpnext_in_different_site"):
-		return
-
-	try:
-		from erpnext.crm.frappe_crm_api import create_custom_fields_for_frappe_crm
-	except ImportError:
-		return
-	create_custom_fields_for_frappe_crm()
+	# Latest ERPNext removed the create_custom_fields_for_frappe_crm API and creates its own
+	# fields automatically so we no longer call into ERPNext here.
+	frappe.get_single("ERPNext CRM Settings").create_custom_fields_in_frappe_crm()


### PR DESCRIPTION
  **Changes:**
  - Stop depending on the removed API. CRM now creates the crm_deal custom fields on Quotation and Customer itself (including the previously ERPNext-owned Customer.crm_deal), so enabling the integration no longer crashes on the latest ERPNext.
  - Best-effort remote field creation. The remote create_custom_fields_for_frappe_crm call is still attempted for older ERPNext but on failure it shows a non-blocking, actionable warning instead of hard-failing or silently logging.
  - Surface ERPNext's real errors. Sync-gate failures (PermissionError/ValidationError) now pass through with ERPNext's own message ("enable Frappe CRM Data Synchronization / add this user to Allowed Users") instead of a generic one.
  - Patch updated to create the CRM-side fields via the settings method rather than the removed ERPNext API.

ref https://github.com/frappe/erpnext/pull/56268

