### PR TITLE
fix(onboarding): trigger FC setup-complete from on_login instead of after_insert

### DIFF
--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -50,6 +50,22 @@ def complete_setup_for_fc_site(doc, method=None):
 	frappe.db.set_single_value("System Settings", "setup_complete", 1)
 
 
+def set_home_page_on_login(login_manager=None):
+	"""Land users on the CRM app only when it is the sole product app installed.
+
+	Frappe routes System Users to the desk after login (via `get_home_page()`), which
+	doesn't consult the app-screen logic that already knows the default app. So on a
+	CRM-only site we set the request-scoped `home_page` flag — which `get_home_page()`
+	honours first — to send users to `/crm`. On a multi-app site we leave it unset so
+	users fall through to the desk, matching Frappe's `get_default_path()` behaviour.
+	"""
+	from frappe.apps import get_apps
+
+	product_apps = [app for app in get_apps() if app.get("name") != "frappe"]
+	if len(product_apps) == 1 and product_apps[0].get("name") == "crm":
+		frappe.local.flags.home_page = "crm"
+
+
 @frappe.whitelist()
 def get_first_lead():
 	lead = frappe.get_all(

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -20,6 +20,10 @@ def complete_setup_for_fc_site(login_manager=None):
 	# importing anything or hitting the DB.
 	if frappe.is_setup_complete():
 		return
+	# Site has opted out of the setup wizard entirely (site_config), so there is
+	# nothing to auto-complete.
+	if frappe.conf.skip_setup_wizard:
+		return
 
 	user = frappe.session.user
 	if user in ("Administrator", "Guest"):

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -1,5 +1,3 @@
-import logging
-
 import frappe
 
 
@@ -17,44 +15,13 @@ def complete_setup_for_fc_site(login_manager=None):
 	fresh provisions and re-provisions. The `is_setup_complete()` guard makes it
 	idempotent and cheap on subsequent logins.
 	"""
-	# Dedicated log file (logs/fc_onboarding.log) so the auto-complete decision path
-	# can be traced on test deployments without sifting through the main web log.
-	# Force INFO: frappe's default level is ERROR on non-dev benches (see
-	# frappe/utils/logger.py default_log_level), which would silently drop every
-	# line below and leave the file empty.
-	logger = frappe.logger("fc_onboarding", allow_site=True, file_count=5)
-	logger.setLevel(logging.INFO)
-
-	# Snapshot the full decision state up front, so the log shows why we proceed or
-	# bail regardless of which guard fires first.
-	setup_complete = frappe.is_setup_complete()
-	system_settings_setup_complete = frappe.db.get_single_value("System Settings", "setup_complete")
-	non_admin_system_user_exists = bool(
-		frappe.db.exists(
-			"User",
-			{"user_type": "System User", "name": ("not in", ("Administrator", "Guest"))},
-		)
-	)
-	skip_setup_wizard = bool(frappe.conf.skip_setup_wizard)
-	logger.info(
-		"complete_setup_for_fc_site: invoked | "
-		f"session.user={frappe.session.user} | "
-		f"is_setup_complete()={setup_complete} | "
-		f"System Settings.setup_complete={system_settings_setup_complete} | "
-		f"non_admin_system_user_exists={non_admin_system_user_exists} | "
-		f"skip_setup_wizard={skip_setup_wizard}"
-	)
-
-	# Act only while setup is pending, and only for a real System User. These cheap
-	# guards run first so the common case (setup already complete) returns before
-	# importing anything or hitting the DB.
-	if setup_complete:
-		logger.info("complete_setup_for_fc_site: bail — setup already complete")
+	# Act only while setup is pending. These cheap guards run first so the common
+	# case (setup already complete) returns before importing anything.
+	if frappe.is_setup_complete():
 		return
 	# Site has opted out of the setup wizard entirely (site_config), so there is
 	# nothing to auto-complete.
-	if skip_setup_wizard:
-		logger.info("complete_setup_for_fc_site: bail — skip_setup_wizard set in site_config")
+	if frappe.conf.skip_setup_wizard:
 		return
 
 	# Only auto-complete once Frappe Cloud has prefilled the account — which it
@@ -65,8 +32,10 @@ def complete_setup_for_fc_site(login_manager=None):
 	# while setup is pending, Press's "Setup Site" action logs in as Administrator
 	# (POST /api/method/login), so gating on the session user would skip exactly the
 	# login that lands on the wizard.
-	if not non_admin_system_user_exists:
-		logger.info("complete_setup_for_fc_site: bail — no prefilled non-admin System User yet")
+	if not frappe.db.exists(
+		"User",
+		{"user_type": "System User", "name": ("not in", ("Administrator", "Guest"))},
+	):
 		return
 
 	# Imported lazily and guarded: on installs without the frappe_providers integration
@@ -76,13 +45,9 @@ def complete_setup_for_fc_site(login_manager=None):
 	try:
 		from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 	except ImportError:
-		logger.info("complete_setup_for_fc_site: bail — frappe_providers integration absent (not an FC site)")
 		return
 
 	if not is_fc_site():
-		logger.info(
-			"complete_setup_for_fc_site: bail — is_fc_site() is False (no System Manager role / no fc_communication_secret)"
-		)
 		return
 
 	from frappe.desk.page.setup_wizard.setup_wizard import enable_setup_wizard_complete
@@ -99,23 +64,22 @@ def complete_setup_for_fc_site(login_manager=None):
 	enable_setup_wizard_complete("frappe")
 	enable_setup_wizard_complete("crm")
 	frappe.db.set_single_value("System Settings", "setup_complete", 1)
-	logger.info("complete_setup_for_fc_site: marked setup complete (frappe + crm + System Settings)")
 
 
-def set_home_page_on_login(login_manager=None):
-	"""Land users on the CRM app only when it is the sole product app installed.
+# def set_home_page_on_login(login_manager=None):
+# 	"""Land users on the CRM app only when it is the sole product app installed.
 
-	Frappe routes System Users to the desk after login (via `get_home_page()`), which
-	doesn't consult the app-screen logic that already knows the default app. So on a
-	CRM-only site we set the request-scoped `home_page` flag — which `get_home_page()`
-	honours first — to send users to `/crm`. On a multi-app site we leave it unset so
-	users fall through to the desk, matching Frappe's `get_default_path()` behaviour.
-	"""
-	from frappe.apps import get_apps
+# 	Frappe routes System Users to the desk after login (via `get_home_page()`), which
+# 	doesn't consult the app-screen logic that already knows the default app. So on a
+# 	CRM-only site we set the request-scoped `home_page` flag — which `get_home_page()`
+# 	honours first — to send users to `/crm`. On a multi-app site we leave it unset so
+# 	users fall through to the desk, matching Frappe's `get_default_path()` behaviour.
+# 	"""
+# 	from frappe.apps import get_apps
 
-	product_apps = [app for app in get_apps() if app.get("name") != "frappe"]
-	if len(product_apps) == 1 and product_apps[0].get("name") == "crm":
-		frappe.local.flags.home_page = "crm"
+# 	product_apps = [app for app in get_apps() if app.get("name") != "frappe"]
+# 	if len(product_apps) == 1 and product_apps[0].get("name") == "crm":
+# 		frappe.local.flags.home_page = "crm"
 
 
 @frappe.whitelist()

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -1,31 +1,36 @@
 import frappe
 
 
-def complete_setup_for_fc_site(doc, method=None):
+def complete_setup_for_fc_site(login_manager=None):
 	"""Auto-complete the setup wizard on Frappe Cloud provisioned sites.
 
 	When Press provisions a CRM trial site it prefills System Settings and creates
 	the real System User via `initialize_system_settings_and_user`, but leaves
 	`setup_complete` as 0 — which forces the user through the redundant desk setup
 	wizard at `/app`. The data that wizard collects has already been gathered during
-	Frappe Cloud signup, so we mark setup complete the moment that user is inserted.
+	Frappe Cloud signup, so we mark setup complete on first authenticated login.
 
-	This fires from `User.after_insert` (see `doc_events` in hooks.py). The prefill's
-	`create_or_update_user()` is the last step it runs, so by the time this handler
-	executes both System Settings and the user already exist.
+	Runs from the `on_login` hook (see hooks.py): every user who reaches `/crm` must
+	authenticate, so this is guaranteed to fire before they hit the wizard, on both
+	fresh provisions and re-provisions. The `is_setup_complete()` guard makes it
+	idempotent and cheap on subsequent logins.
 	"""
-	# Only act during the provisioning window, for the prefilled System User. These
-	# cheap guards run first so the common case (setup already complete) returns before
-	# importing anything.
+	# Act only while setup is pending, and only for a real System User. These cheap
+	# guards run first so the common case (setup already complete) returns before
+	# importing anything or hitting the DB.
 	if frappe.is_setup_complete():
 		return
-	if doc.user_type != "System User" or doc.name == "Administrator":
+
+	user = frappe.session.user
+	if user in ("Administrator", "Guest"):
+		return
+	if frappe.db.get_value("User", user, "user_type") != "System User":
 		return
 
 	# Imported lazily and guarded: on installs without the frappe_providers integration
 	# (older versions / community forks) the module is absent, which also means the site
 	# can't be a Frappe Cloud site — so bail out without letting the ImportError bubble
-	# up and abort the in-progress user-insert transaction.
+	# up and abort the login request.
 	try:
 		from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 	except ImportError:
@@ -37,7 +42,7 @@ def complete_setup_for_fc_site(doc, method=None):
 	from frappe.desk.page.setup_wizard.setup_wizard import enable_setup_wizard_complete
 
 	# Run CRM's `setup_wizard_complete` hook(s) (demo data). Enqueued so the seeding
-	# work doesn't slow down or risk failing Press's prefill request — the flags below
+	# work doesn't slow down or risk failing the login request — the flags below
 	# flip synchronously so `setup_complete` is true immediately.
 	for hook in frappe.get_hooks("setup_wizard_complete"):
 		frappe.enqueue(hook, enqueue_after_commit=True)

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 
 
 def complete_setup_for_fc_site(doc, method=None):
@@ -15,11 +14,19 @@ def complete_setup_for_fc_site(doc, method=None):
 	`create_or_update_user()` is the last step it runs, so by the time this handler
 	executes both System Settings and the user already exist.
 	"""
-	# Only act during the provisioning window, on FC sites, for the prefilled System User.
+	# Only act during the provisioning window, for the prefilled System User. These
+	# cheap guards run first so the common case (setup already complete) returns before
+	# importing anything.
 	if frappe.is_setup_complete():
 		return
 	if doc.user_type != "System User" or doc.name == "Administrator":
 		return
+
+	# Imported lazily so this module stays importable on Frappe installs that don't
+	# ship the frappe_providers integration (older versions / community forks) — keeping
+	# the unrelated whitelisted endpoints below working there.
+	from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
+
 	if not is_fc_site():
 		return
 
@@ -29,7 +36,7 @@ def complete_setup_for_fc_site(doc, method=None):
 	# work doesn't slow down or risk failing Press's prefill request — the flags below
 	# flip synchronously so `setup_complete` is true immediately.
 	for hook in frappe.get_hooks("setup_wizard_complete"):
-		frappe.enqueue(hook, args={}, enqueue_after_commit=True)
+		frappe.enqueue(hook, enqueue_after_commit=True)
 
 	# Flip the completion flags. Marking "frappe" is enough for frappe.is_setup_complete()
 	# (it only checks installed-app rows, so erpnext is irrelevant on a CRM-only site);

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -25,10 +25,18 @@ def complete_setup_for_fc_site(login_manager=None):
 	if frappe.conf.skip_setup_wizard:
 		return
 
-	user = frappe.session.user
-	if user in ("Administrator", "Guest"):
-		return
-	if frappe.db.get_value("User", user, "user_type") != "System User":
+	# Only auto-complete once Frappe Cloud has prefilled the account — which it
+	# signals by creating a real (non-Administrator) System User on the site. Until
+	# then there is no gathered data to stand in for the wizard, so let it run.
+	#
+	# We check that such a user *exists*, not that the *logged-in* user is one:
+	# while setup is pending, Press's "Setup Site" action logs in as Administrator
+	# (POST /api/method/login), so gating on the session user would skip exactly the
+	# login that lands on the wizard.
+	if not frappe.db.exists(
+		"User",
+		{"user_type": "System User", "name": ("not in", ("Administrator", "Guest"))},
+	):
 		return
 
 	# Imported lazily and guarded: on installs without the frappe_providers integration

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -1,4 +1,42 @@
 import frappe
+from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
+
+
+def complete_setup_for_fc_site(doc, method=None):
+	"""Auto-complete the setup wizard on Frappe Cloud provisioned sites.
+
+	When Press provisions a CRM trial site it prefills System Settings and creates
+	the real System User via `initialize_system_settings_and_user`, but leaves
+	`setup_complete` as 0 — which forces the user through the redundant desk setup
+	wizard at `/app`. The data that wizard collects has already been gathered during
+	Frappe Cloud signup, so we mark setup complete the moment that user is inserted.
+
+	This fires from `User.after_insert` (see `doc_events` in hooks.py). The prefill's
+	`create_or_update_user()` is the last step it runs, so by the time this handler
+	executes both System Settings and the user already exist.
+	"""
+	# Only act during the provisioning window, on FC sites, for the prefilled System User.
+	if frappe.is_setup_complete():
+		return
+	if doc.user_type != "System User" or doc.name == "Administrator":
+		return
+	if not is_fc_site():
+		return
+
+	from frappe.desk.page.setup_wizard.setup_wizard import enable_setup_wizard_complete
+
+	# Run CRM's `setup_wizard_complete` hook(s) (demo data). Enqueued so the seeding
+	# work doesn't slow down or risk failing Press's prefill request — the flags below
+	# flip synchronously so `setup_complete` is true immediately.
+	for hook in frappe.get_hooks("setup_wizard_complete"):
+		frappe.enqueue(hook, args={}, enqueue_after_commit=True)
+
+	# Flip the completion flags. Marking "frappe" is enough for frappe.is_setup_complete()
+	# (it only checks installed-app rows, so erpnext is irrelevant on a CRM-only site);
+	# "crm" is marked too so the wizard doesn't re-prompt for CRM's stage.
+	enable_setup_wizard_complete("frappe")
+	enable_setup_wizard_complete("crm")
+	frappe.db.set_single_value("System Settings", "setup_complete", 1)
 
 
 @frappe.whitelist()

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -22,10 +22,14 @@ def complete_setup_for_fc_site(doc, method=None):
 	if doc.user_type != "System User" or doc.name == "Administrator":
 		return
 
-	# Imported lazily so this module stays importable on Frappe installs that don't
-	# ship the frappe_providers integration (older versions / community forks) — keeping
-	# the unrelated whitelisted endpoints below working there.
-	from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
+	# Imported lazily and guarded: on installs without the frappe_providers integration
+	# (older versions / community forks) the module is absent, which also means the site
+	# can't be a Frappe Cloud site — so bail out without letting the ImportError bubble
+	# up and abort the in-progress user-insert transaction.
+	try:
+		from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
+	except ImportError:
+		return
 
 	if not is_fc_site():
 		return

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -66,22 +66,6 @@ def complete_setup_for_fc_site(login_manager=None):
 	frappe.db.set_single_value("System Settings", "setup_complete", 1)
 
 
-# def set_home_page_on_login(login_manager=None):
-# 	"""Land users on the CRM app only when it is the sole product app installed.
-
-# 	Frappe routes System Users to the desk after login (via `get_home_page()`), which
-# 	doesn't consult the app-screen logic that already knows the default app. So on a
-# 	CRM-only site we set the request-scoped `home_page` flag — which `get_home_page()`
-# 	honours first — to send users to `/crm`. On a multi-app site we leave it unset so
-# 	users fall through to the desk, matching Frappe's `get_default_path()` behaviour.
-# 	"""
-# 	from frappe.apps import get_apps
-
-# 	product_apps = [app for app in get_apps() if app.get("name") != "frappe"]
-# 	if len(product_apps) == 1 and product_apps[0].get("name") == "crm":
-# 		frappe.local.flags.home_page = "crm"
-
-
 @frappe.whitelist()
 def get_first_lead():
 	lead = frappe.get_all(

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -15,14 +15,21 @@ def complete_setup_for_fc_site(login_manager=None):
 	fresh provisions and re-provisions. The `is_setup_complete()` guard makes it
 	idempotent and cheap on subsequent logins.
 	"""
+	# Dedicated log file (logs/fc_onboarding.log) so the auto-complete decision path
+	# can be traced on test deployments without sifting through the main web log.
+	logger = frappe.logger("fc_onboarding", allow_site=True, file_count=5)
+	logger.info(f"complete_setup_for_fc_site: invoked (session.user={frappe.session.user})")
+
 	# Act only while setup is pending, and only for a real System User. These cheap
 	# guards run first so the common case (setup already complete) returns before
 	# importing anything or hitting the DB.
 	if frappe.is_setup_complete():
+		logger.info("complete_setup_for_fc_site: bail — setup already complete")
 		return
 	# Site has opted out of the setup wizard entirely (site_config), so there is
 	# nothing to auto-complete.
 	if frappe.conf.skip_setup_wizard:
+		logger.info("complete_setup_for_fc_site: bail — skip_setup_wizard set in site_config")
 		return
 
 	# Only auto-complete once Frappe Cloud has prefilled the account — which it
@@ -37,6 +44,7 @@ def complete_setup_for_fc_site(login_manager=None):
 		"User",
 		{"user_type": "System User", "name": ("not in", ("Administrator", "Guest"))},
 	):
+		logger.info("complete_setup_for_fc_site: bail — no prefilled non-admin System User yet")
 		return
 
 	# Imported lazily and guarded: on installs without the frappe_providers integration
@@ -46,9 +54,13 @@ def complete_setup_for_fc_site(login_manager=None):
 	try:
 		from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 	except ImportError:
+		logger.info("complete_setup_for_fc_site: bail — frappe_providers integration absent (not an FC site)")
 		return
 
 	if not is_fc_site():
+		logger.info(
+			"complete_setup_for_fc_site: bail — is_fc_site() is False (no System Manager role / no fc_communication_secret)"
+		)
 		return
 
 	from frappe.desk.page.setup_wizard.setup_wizard import enable_setup_wizard_complete
@@ -65,6 +77,7 @@ def complete_setup_for_fc_site(login_manager=None):
 	enable_setup_wizard_complete("frappe")
 	enable_setup_wizard_complete("crm")
 	frappe.db.set_single_value("System Settings", "setup_complete", 1)
+	logger.info("complete_setup_for_fc_site: marked setup complete (frappe + crm + System Settings)")
 
 
 def set_home_page_on_login(login_manager=None):

--- a/crm/api/onboarding.py
+++ b/crm/api/onboarding.py
@@ -1,3 +1,5 @@
+import logging
+
 import frappe
 
 
@@ -17,18 +19,41 @@ def complete_setup_for_fc_site(login_manager=None):
 	"""
 	# Dedicated log file (logs/fc_onboarding.log) so the auto-complete decision path
 	# can be traced on test deployments without sifting through the main web log.
+	# Force INFO: frappe's default level is ERROR on non-dev benches (see
+	# frappe/utils/logger.py default_log_level), which would silently drop every
+	# line below and leave the file empty.
 	logger = frappe.logger("fc_onboarding", allow_site=True, file_count=5)
-	logger.info(f"complete_setup_for_fc_site: invoked (session.user={frappe.session.user})")
+	logger.setLevel(logging.INFO)
+
+	# Snapshot the full decision state up front, so the log shows why we proceed or
+	# bail regardless of which guard fires first.
+	setup_complete = frappe.is_setup_complete()
+	system_settings_setup_complete = frappe.db.get_single_value("System Settings", "setup_complete")
+	non_admin_system_user_exists = bool(
+		frappe.db.exists(
+			"User",
+			{"user_type": "System User", "name": ("not in", ("Administrator", "Guest"))},
+		)
+	)
+	skip_setup_wizard = bool(frappe.conf.skip_setup_wizard)
+	logger.info(
+		"complete_setup_for_fc_site: invoked | "
+		f"session.user={frappe.session.user} | "
+		f"is_setup_complete()={setup_complete} | "
+		f"System Settings.setup_complete={system_settings_setup_complete} | "
+		f"non_admin_system_user_exists={non_admin_system_user_exists} | "
+		f"skip_setup_wizard={skip_setup_wizard}"
+	)
 
 	# Act only while setup is pending, and only for a real System User. These cheap
 	# guards run first so the common case (setup already complete) returns before
 	# importing anything or hitting the DB.
-	if frappe.is_setup_complete():
+	if setup_complete:
 		logger.info("complete_setup_for_fc_site: bail — setup already complete")
 		return
 	# Site has opted out of the setup wizard entirely (site_config), so there is
 	# nothing to auto-complete.
-	if frappe.conf.skip_setup_wizard:
+	if skip_setup_wizard:
 		logger.info("complete_setup_for_fc_site: bail — skip_setup_wizard set in site_config")
 		return
 
@@ -40,10 +65,7 @@ def complete_setup_for_fc_site(login_manager=None):
 	# while setup is pending, Press's "Setup Site" action logs in as Administrator
 	# (POST /api/method/login), so gating on the session user would skip exactly the
 	# login that lands on the wizard.
-	if not frappe.db.exists(
-		"User",
-		{"user_type": "System User", "name": ("not in", ("Administrator", "Guest"))},
-	):
+	if not non_admin_system_user_exists:
 		logger.info("complete_setup_for_fc_site: bail — no prefilled non-admin System User yet")
 		return
 

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -61,7 +61,9 @@ doctype_js = {
 # ----------
 
 # application home page (will override Website Settings)
-home_page = "crm"
+# Set dynamically on login (see on_login below): CRM becomes the landing page only
+# when it is the sole product app installed, otherwise users fall through to the desk.
+# home_page = "crm"
 
 # website user home page (by Role)
 # role_home_page = {
@@ -299,6 +301,8 @@ ignore_links_on_delete = ["Failed Lead Sync Log"]
 # auth_hooks = [
 # "crm.auth.validate"
 # ]
+
+on_login = "crm.api.onboarding.set_home_page_on_login"
 
 after_migrate = [
 	"crm.fcrm.doctype.fcrm_settings.fcrm_settings.after_migrate",

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -204,6 +204,7 @@ doc_events = {
 		"on_trash": ["crm.integrations.erpnext.doc_share.on_trash"],
 	},
 	"User": {
+		"after_insert": ["crm.api.onboarding.complete_setup_for_fc_site"],
 		"before_validate": ["crm.api.live_demo.validate_user"],
 		"validate_reset_password": ["crm.api.live_demo.validate_reset_password"],
 	},

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -61,7 +61,7 @@ doctype_js = {
 # ----------
 
 # application home page (will override Website Settings)
-# home_page = "login"
+home_page = "crm"
 
 # website user home page (by Role)
 # role_home_page = {

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -61,9 +61,7 @@ doctype_js = {
 # ----------
 
 # application home page (will override Website Settings)
-# Set dynamically on login (see on_login below): CRM becomes the landing page only
-# when it is the sole product app installed, otherwise users fall through to the desk.
-# home_page = "crm"
+# home_page = "login"
 
 # website user home page (by Role)
 # role_home_page = {
@@ -301,10 +299,7 @@ ignore_links_on_delete = ["Failed Lead Sync Log"]
 # "crm.auth.validate"
 # ]
 
-on_login = [
-	"crm.api.onboarding.set_home_page_on_login",
-	"crm.api.onboarding.complete_setup_for_fc_site",
-]
+on_login = "crm.api.onboarding.complete_setup_for_fc_site"
 
 after_migrate = [
 	"crm.fcrm.doctype.fcrm_settings.fcrm_settings.after_migrate",

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -206,7 +206,6 @@ doc_events = {
 		"on_trash": ["crm.integrations.erpnext.doc_share.on_trash"],
 	},
 	"User": {
-		"after_insert": ["crm.api.onboarding.complete_setup_for_fc_site"],
 		"before_validate": ["crm.api.live_demo.validate_user"],
 		"validate_reset_password": ["crm.api.live_demo.validate_reset_password"],
 	},
@@ -302,7 +301,10 @@ ignore_links_on_delete = ["Failed Lead Sync Log"]
 # "crm.auth.validate"
 # ]
 
-on_login = "crm.api.onboarding.set_home_page_on_login"
+on_login = [
+	"crm.api.onboarding.set_home_page_on_login",
+	"crm.api.onboarding.complete_setup_for_fc_site",
+]
 
 after_migrate = [
 	"crm.fcrm.doctype.fcrm_settings.fcrm_settings.after_migrate",


### PR DESCRIPTION
## Problem

When Frappe Cloud provisions a CRM trial/product site, Press prefills `System Settings` and creates the real System User (via `initialize_system_settings_and_user`) using data already collected at signup — but it leaves `setup_complete` as `0`. As a result the user is still forced through the redundant desk setup wizard at `/app` to re-enter information FC already has.

## Solution

Add an `on_login` handler, `complete_setup_for_fc_site`, that marks setup complete on the first authenticated login to an FC-provisioned CRM site, so the wizard is skipped.

`on_login` is used (instead of the original `User.after_insert`) because Press's prefill calls `create_or_update_user()`, which only *inserts* a User when one doesn't already exist — on re-provision / Administrator-only flows it takes a raw SQL `UPDATE` path that fires no document events, making `after_insert` unreliable. Every user who reaches `/crm` must authenticate, so `on_login` is guaranteed to fire before the wizard.

### Behaviour / guards

The handler runs through cheap guards first and only acts when all hold:

- `frappe.is_setup_complete()` is false — otherwise return (keeps it idempotent and cheap on every later login)
- `frappe.conf.skip_setup_wizard` is not set — respect sites that opted out of the wizard
- a **prefilled non-admin System User exists** on the site — FC's signal that account data was gathered (mirrors Press's `additional_system_user_created` and Frappe's `has_non_admin_user`). We check that such a user *exists*, not that the *logged-in* user is one, because Press's "Setup Site" action logs in as **Administrator** while setup is pending — gating on the session user would skip exactly the login that lands on the wizard.
- `is_fc_site()` is true — imported lazily and wrapped in `try/except ImportError` so `crm.api.onboarding` stays importable (and its other endpoints keep working) on installs without the `frappe_providers` integration; a missing integration also means it can't be an FC site.

When all guards pass it:

1. enqueues the `setup_wizard_complete` hook(s) (demo data seeding) so the login request isn't slowed or risked,
2. flips `Installed Application.is_setup_complete` for `frappe` and `crm`, and
3. mirrors `System Settings.setup_complete = 1` (the value Press polls to recognise completion and switch future logins to the team user).

On a vanilla / non-prefilled site (only Administrator, no team System User) the handler correctly bails and lets the setup wizard run as normal.

## Compatibility

Verified all referenced framework symbols (`is_setup_complete`, `enable_setup_wizard_complete`, `is_fc_site`, `Installed Application.is_setup_complete`/`has_setup_wizard`) exist with the same semantics on both **version-15** and **develop**.

> Note: an earlier `set_home_page_on_login` handler (land on `/crm` when CRM is the sole product app) was dropped, because v15's `get_apps()` pulls in desk/workspace context (`get_workspace_sidebar_items`, `frappe.local.module_app`) that isn't available in the `on_login` trigger and broke login on v15.

## Changes

- `crm/api/onboarding.py` — `complete_setup_for_fc_site` handler
- `crm/hooks.py` — register it on `on_login`
