### PR TITLE
fix: TypeError in add_forecasting_section on Python 3.14 (#2357)

### DIFF
--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
@@ -129,7 +129,7 @@ class FCRMSettings(Document):
 		# FIX: fields inside columns are dicts; extract "fieldname" string for set
 		# comparison instead of using dicts as set elements (unhashable on Python 3.14)
 		existing_fields = {
-			field.get("fieldname") if isinstance(field, dict) else field
+			(field.get("fieldname") or field.get("name")) if isinstance(field, dict) else field
 			for section in all_sections
 			for column in section.get("columns") or []
 			for field in column.get("fields") or []

--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
@@ -126,8 +126,10 @@ class FCRMSettings(Document):
 		)
 		if any(section.get("name") == "forecasted_sales_section" for section in all_sections):
 			return
+		# FIX: fields inside columns are dicts; extract "fieldname" string for set
+		# comparison instead of using dicts as set elements (unhashable on Python 3.14)
 		existing_fields = {
-			field
+			field.get("fieldname") if isinstance(field, dict) else field
 			for section in all_sections
 			for column in section.get("columns") or []
 			for field in column.get("fields") or []


### PR DESCRIPTION
## Problem

`add_forecasting_section` in `fcrm_settings.py` performs a set membership check using dict objects as set elements. Dicts are unhashable and cannot be set elements, causing:

`TypeError: cannot use 'dict' as a set element (unhashable type: 'dict')
`
This crashes `bench migrate` on Python 3.14, which prevents the `tabLetter Head` schema from being updated, breaking all PDF printing site-wide with `Field not permitted in query: letter_head_for`.

## Fix

Compare by `fieldname` (a hashable string) instead of by the full dict.

## Impact

This is a **production-blocking** issue for all Frappe Cloud sites running CRM + Frappe 16.24+ on Python 3.14. There is no self-service workaround for Frappe Cloud users (Query Console and System Console both block writes).

Closes #2357