### PR TITLE
feat(ci): Run tests against stable framework branches

### DIFF
--- a/.github/actions/setup-server-env/action.yml
+++ b/.github/actions/setup-server-env/action.yml
@@ -17,6 +17,10 @@ inputs:
         description: When "true", fetch and install erpnext alongside crm
         required: false
         default: "false"
+    frappe-branch:
+        description: Frappe (and erpnext) branch to install and test against
+        required: false
+        default: "develop"
 runs:
     using: composite
     steps:
@@ -87,4 +91,5 @@ runs:
           env:
               TYPE: ${{ inputs.type }}
               INSTALL_ERPNEXT: ${{ inputs.install-erpnext }}
+              FRAPPE_BRANCH: ${{ inputs.frappe-branch }}
           run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -8,8 +8,11 @@ sudo apt update
 sudo apt remove mysql-server mysql-client
 sudo apt install libcups2-dev redis-server mariadb-client libmariadb-dev
 
+# Frappe (and erpnext) branch to test against; set by CI matrix, defaults to develop.
+FRAPPE_BRANCH="${FRAPPE_BRANCH:-develop}"
+
 pip install frappe-bench
-git clone "https://github.com/frappe/frappe" --branch "develop" --depth 1 
+git clone "https://github.com/frappe/frappe" --branch "${FRAPPE_BRANCH}" --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mkdir ~/frappe-bench/sites/test_site
@@ -44,7 +47,7 @@ bench get-app crm "${GITHUB_WORKSPACE}"
 
 # Only pull erpnext when the integration is under test, to keep other runs fast.
 if [ "${INSTALL_ERPNEXT}" = "true" ]; then
-    bench get-app erpnext --branch develop
+    bench get-app erpnext --branch "${FRAPPE_BRANCH}"
 fi
 
 bench setup requirements --dev

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -21,12 +21,32 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    setup:
+        name: Resolve frappe matrix
+        runs-on: ubuntu-latest
+        outputs:
+            frappe-branches: ${{ steps.resolve.outputs.branches }}
+        steps:
+            - name: Resolve frappe branches from target branch
+              id: resolve
+              run: |
+                  BASE="${{ github.base_ref || github.ref_name }}"
+                  # develop tracks frappe develop; the stable lane ships frappe 15 and 16.
+                  if [ "$BASE" = "develop" ]; then
+                      echo 'branches=["develop"]' >> "$GITHUB_OUTPUT"
+                  else
+                      echo 'branches=["version-15","version-16"]' >> "$GITHUB_OUTPUT"
+                  fi
+
     test:
-        name: Tests
+        name: Tests (frappe ${{ matrix.frappe-branch }})
+        needs: setup
         runs-on: ubuntu-latest
         timeout-minutes: 60
         strategy:
             fail-fast: false
+            matrix:
+                frappe-branch: ${{ fromJson(needs.setup.outputs.frappe-branches) }}
 
         services:
             mysql:
@@ -57,6 +77,7 @@ jobs:
                   node-version: "24"
                   type: "server"
                   install-erpnext: ${{ steps.changes.outputs.erpnext }}
+                  frappe-branch: ${{ matrix.frappe-branch }}
 
             - name: Run server tests
               uses: ./.github/actions/run-server-tests
@@ -72,7 +93,7 @@ jobs:
               if: github.base_ref == 'develop' || github.ref_name == 'develop'
               uses: ./.github/actions/upload-coverage
               with:
-                  artifact-name: coverage-${{ matrix.container }}
+                  artifact-name: coverage-${{ matrix.frappe-branch }}
                   coverage-path: /home/runner/frappe-bench/sites/coverage.xml
 
     coverage:


### PR DESCRIPTION
Server tests previously always ran against frappe `develop`, even for PRs into the stable branches that ship on frappe v15/v16 so version specific breakage wasn't caught before release.

This adds a frappe-version matrix keyed off the target branch:
  - `develop` → frappe `develop` (unchanged)
  - `main-hotfix` / `main` → frappe `version-15` and `version-16`

`install.sh` now honors a `FRAPPE_BRANCH` env var (frappe + erpnext) through the `setup-server-env` action from the workflow matrix.