### PR TITLE
fix: clear lead/deal owner when current owner is unassigned

### DIFF
--- a/crm/api/todo.py
+++ b/crm/api/todo.py
@@ -26,6 +26,18 @@ def on_update(doc, method):
 		and doc.allocated_to
 	):
 		notify_assigned_user(doc, is_cancelled=True)
+		clear_owner_on_unassign(doc)
+
+
+def clear_owner_on_unassign(doc):
+	# Owner concept only exists for Lead/Deal, not Task.
+	if doc.reference_type not in ["CRM Lead", "CRM Deal"]:
+		return
+	fieldname = "lead_owner" if doc.reference_type == "CRM Lead" else "deal_owner"
+	owner = frappe.db.get_value(doc.reference_type, doc.reference_name, fieldname)
+	# Only clear when the user being unassigned is the current owner.
+	if owner and owner == doc.allocated_to:
+		frappe.db.set_value(doc.reference_type, doc.reference_name, fieldname, None, update_modified=False)
 
 
 def notify_assigned_user(doc, is_cancelled=False):

--- a/crm/fcrm/doctype/crm_deal/test_crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/test_crm_deal.py
@@ -2,6 +2,8 @@
 # See license.txt
 
 import frappe
+from frappe.desk.form.assign_to import add as assign_add
+from frappe.desk.form.assign_to import remove as assign_remove
 from frappe.tests import IntegrationTestCase
 
 from crm.fcrm.doctype.crm_deal.crm_deal import (
@@ -150,6 +152,52 @@ class TestCRMDeal(IntegrationTestCase):
 		deal.assign_agent("Administrator")
 		assignees_after = deal.get_assigned_users()
 		self.assertEqual(len(assignees_after), initial_count)
+
+	def test_owner_cleared_on_unassign(self):
+		"""Unassigning the current owner clears deal_owner"""
+		deal = create_test_deal(organization="Owner Clear Org", deal_owner="crm.user1@example.com")
+		self.assertEqual(deal.deal_owner, "crm.user1@example.com")
+
+		assign_remove("CRM Deal", deal.name, "crm.user1@example.com")
+
+		self.assertIsNone(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"))
+
+	def test_reassignment_moves_owner(self):
+		"""After the owner is unassigned, assigning a new user makes them the owner"""
+		deal = create_test_deal(organization="Reassign Org", deal_owner="crm.user1@example.com")
+
+		# Frappe assignment rules unassign before assign in one cycle; mirror that order
+		assign_remove("CRM Deal", deal.name, "crm.user1@example.com")
+		self.assertIsNone(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"))
+
+		assign_add({"assign_to": ["crm.user2@example.com"], "doctype": "CRM Deal", "name": deal.name})
+
+		self.assertEqual(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"), "crm.user2@example.com")
+
+	def test_non_owner_removal_leaves_owner(self):
+		"""Removing a non-owner assignee does not touch the owner"""
+		deal = create_test_deal(organization="Non Owner Org", deal_owner="crm.user1@example.com")
+		assign_add({"assign_to": ["crm.user2@example.com"], "doctype": "CRM Deal", "name": deal.name})
+
+		assign_remove("CRM Deal", deal.name, "crm.user2@example.com")
+
+		self.assertEqual(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"), "crm.user1@example.com")
+
+	def test_task_unassign_does_not_touch_owner(self):
+		"""Cancelling a CRM Task assignment is a no-op for owner fields"""
+		deal = create_test_deal(organization="Task Org")
+		task = frappe.get_doc(
+			{
+				"doctype": "CRM Task",
+				"title": "Owner sync task",
+				"reference_doctype": "CRM Deal",
+				"reference_docname": deal.name,
+			}
+		).insert()
+
+		assign_add({"assign_to": ["crm.user1@example.com"], "doctype": "CRM Task", "name": task.name})
+		# Should not raise
+		assign_remove("CRM Task", task.name, "crm.user1@example.com")
 
 	def test_add_contact_api(self):
 		"""Test add_contact API function"""

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.desk.form.assign_to import remove as assign_remove
 from frappe.tests import IntegrationTestCase
 
 from crm.fcrm.doctype.crm_lead.crm_lead import convert_to_deal
@@ -529,6 +530,15 @@ class TestCRMLead(IntegrationTestCase):
 		deal_assignees = deal.get_assigned_users()
 		self.assertIn("Administrator", deal_assignees)
 		self.assertIn("crm.user1@example.com", deal_assignees)
+
+	def test_owner_cleared_on_unassign(self):
+		"""Unassigning the current owner clears lead_owner"""
+		lead = create_lead(first_name="Owner", lead_owner="crm.user1@example.com")
+		self.assertEqual(lead.lead_owner, "crm.user1@example.com")
+
+		assign_remove("CRM Lead", lead.name, "crm.user1@example.com")
+
+		self.assertIsNone(frappe.db.get_value("CRM Lead", lead.name, "lead_owner"))
 
 
 def create_lead(**kwargs):


### PR DESCRIPTION
The ToDo after_insert hook sets lead_owner/deal_owner from the assignee only when the owner is empty. On unassign, the owner was never cleared, so a stale "ghost owner" remained and blocked any later reassignment (including Assignment Rule routing) from updating the owner.

Clear the owner in the ToDo on_update Cancelled branch when the unassigned user is the current owner, mirroring after_insert. This covers every unassign path (rule, single UI removal, bulk, clear) since all cancel the ToDo. Uses db.set_value to avoid re-triggering the controller.