### PR TITLE
fix: restore Live Demo link broken by demo module rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     </picture>
 </div>
 
-[Live Demo](https://frappecrm-demo.frappe.cloud/api/method/crm.api.live_demo.login) - [Website](https://frappe.io/crm) - [Documentation](https://docs.frappe.io/crm)
+[Live Demo](https://frappecrm-demo.frappe.cloud/api/method/crm.api.demo.login) - [Website](https://frappe.io/crm) - [Documentation](https://docs.frappe.io/crm)
 
 </div>
 

--- a/crm/api/demo.py
+++ b/crm/api/demo.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# Backward-compatible alias for `crm.api.live_demo`.
+#
+# This module was renamed from `crm/api/demo.py` to `crm/api/live_demo.py`. The
+# login endpoint is referenced by public, externally-bookmarkable URLs (the
+# README "Live Demo" link, the live demo site, user bookmarks) as
+# `/api/method/crm.api.demo.login`, so we keep this thin re-export to avoid
+# breaking those URLs regardless of which app version is deployed.
+
+from crm.api.live_demo import login, validate_reset_password, validate_user


### PR DESCRIPTION
## Problem

The **Live Demo** link in the README points to
`https://frappecrm-demo.frappe.cloud/api/method/crm.api.live_demo.login`, and
clicking it returns a `500` Server Error:

```
ModuleNotFoundError: No module named 'crm.api.live_demo'
...
frappe.exceptions.ValidationError: Failed to get method for command
crm.api.live_demo.login with No module named 'crm.api.live_demo'
```

Fixes #2237
Fixes #2247

## Root cause

Commit a7e385d3 (`fix: update live demo link in README and add live demo API
handling`) **renamed** `crm/api/demo.py` → `crm/api/live_demo.py` and updated
the README link from `crm.api.demo.login` → `crm.api.live_demo.login`.

`login` is a `@frappe.whitelist(allow_guest=True)` endpoint that is linked
**publicly** (README, the live demo site, user bookmarks). Renaming it is a
breaking change for any deployment still serving the old module name — which is
exactly the case for the live demo site today.

Verified against the live demo (`frappecrm-demo.frappe.cloud`):

| Endpoint | Result on the live site |
|---|---|
| `crm.api.demo.login` (old name) | `302` → auto-login as the demo user → `/crm` ✅ |
| `crm.api.live_demo.login` (current README) | `500` `ModuleNotFoundError: No module named 'crm.api.live_demo'` ❌ |

So every visitor who clicks "Live Demo" from GitHub hits a server error.

## Fix

- Re-add `crm/api/demo.py` as a thin backward-compatible re-export of
  `crm.api.live_demo` (`login`, `validate_reset_password`, `validate_user`).
  Because `from crm.api.live_demo import login` binds the **same** function
  object, `crm.api.demo.login` keeps its `@frappe.whitelist(allow_guest=True)`
  and guest access — no re-decoration needed.
- Point the README link back to `crm.api.demo.login`.

This makes the demo login URL resolve **regardless of which app version is
deployed** (old or post-rename), so the link won't break again on the next
demo deploy, and existing bookmarks to `.../crm.api.demo.login` keep working.

`crm/api/live_demo.py` stays the canonical module and is still what `hooks.py`
references — this only adds a compatibility shim.

## How to test

1. Visit `https://frappecrm-demo.frappe.cloud/api/method/crm.api.demo.login` —
   it should redirect into the demo (`/crm`), no traceback.
2. After this app version is deployed, both `crm.api.demo.login` and
   `crm.api.live_demo.login` should resolve.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
