### PR TITLE
Refactor duplicate lead creation flow to use a single dialog

### DIFF
--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -482,6 +482,56 @@ class CRMLead(Document):
 			"kanban_fields": '["organization", "email", "mobile_no", "_assign", "modified"]',
 		}
 
+@frappe.whitelist()
+def find_duplicate_leads(
+	email: str | None = None,
+	mobile_no: str | None = None,
+	current_lead: str | None = None,
+):
+	"""
+	Return existing CRM Leads matching the given email and/or mobile number.
+	Used before creating a Lead to warn the user about existing Leads.
+	"""
+
+	email = email.strip() if email else None
+	mobile_no = mobile_no.strip() if mobile_no else None
+
+	if not email and not mobile_no:
+		return []
+
+	duplicates = {}
+
+	fields = [
+		"name",
+		"lead_name",
+		"email",
+		"mobile_no",
+		"status",
+		"organization",
+	]
+
+	if email:
+		filters = {"email": email}
+		if current_lead:
+			filters["name"] = ["!=", current_lead]
+
+		for lead in frappe.get_all("CRM Lead", filters=filters, fields=fields):
+			lead["matched_on"] = ["Email"]
+			duplicates[lead["name"]] = lead
+
+	if mobile_no:
+		filters = {"mobile_no": mobile_no}
+		if current_lead:
+			filters["name"] = ["!=", current_lead]
+
+		for lead in frappe.get_all("CRM Lead", filters=filters, fields=fields):
+			if lead["name"] in duplicates:
+				duplicates[lead["name"]]["matched_on"].append("Mobile Number")
+			else:
+				lead["matched_on"] = ["Mobile Number"]
+				duplicates[lead["name"]] = lead
+
+	return list(duplicates.values())
 
 @frappe.whitelist()
 def convert_to_deal(

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -516,6 +516,9 @@ def find_duplicate_leads(
 			filters["name"] = ["!=", current_lead]
 
 		for lead in frappe.get_all("CRM Lead", filters=filters, fields=fields):
+			if not frappe.has_permission("CRM Lead", "read", lead["name"]):
+				continue
+
 			lead["matched_on"] = ["Email"]
 			duplicates[lead["name"]] = lead
 
@@ -525,12 +528,15 @@ def find_duplicate_leads(
 			filters["name"] = ["!=", current_lead]
 
 		for lead in frappe.get_all("CRM Lead", filters=filters, fields=fields):
+			if not frappe.has_permission("CRM Lead", "read", lead["name"]):
+				continue
+
 			if lead["name"] in duplicates:
 				duplicates[lead["name"]]["matched_on"].append("Mobile Number")
 			else:
 				lead["matched_on"] = ["Mobile Number"]
 				duplicates[lead["name"]] = lead
-
+				
 	return list(duplicates.values())
 
 @frappe.whitelist()

--- a/frontend/src/components/Modals/LeadModal.vue
+++ b/frontend/src/components/Modals/LeadModal.vue
@@ -325,16 +325,28 @@ function insertLead() {
 }
 
 async function createNewLead() {
+  if (isLeadCreating.value) return
+
+  isLeadCreating.value = true
+
   if (lead.doc.website && !lead.doc.website.startsWith('http')) {
     lead.doc.website = 'https://' + lead.doc.website
   }
 
-  await triggerOnBeforeCreate?.()
+  let existingLeads
 
-  const existingLeads = await checkDuplicateLead.submit({
-    email: lead.doc.email,
-    mobile_no: lead.doc.mobile_no,
-  })
+  try {
+    await triggerOnBeforeCreate?.()
+    
+    existingLeads = await checkDuplicateLead.submit({
+      email: lead.doc.email,
+      mobile_no: lead.doc.mobile_no,
+    })
+  } catch (err) {
+    isLeadCreating.value = false
+    error.value = err.message || __('Failed to check for duplicate leads')
+    return
+  }
 
   if (!existingLeads || existingLeads.length === 0) {
     insertLead()
@@ -343,6 +355,7 @@ async function createNewLead() {
 
   duplicateLeads.value = existingLeads
   showDuplicateDialog.value = true
+  isLeadCreating.value = false
 }
 
 function continueAnyway() {

--- a/frontend/src/components/Modals/LeadModal.vue
+++ b/frontend/src/components/Modals/LeadModal.vue
@@ -359,6 +359,9 @@ async function createNewLead() {
 }
 
 function continueAnyway() {
+  if (isLeadCreating.value) return
+
+  isLeadCreating.value = true
   showDuplicateDialog.value = false
   insertLead()
 }

--- a/frontend/src/components/Modals/LeadModal.vue
+++ b/frontend/src/components/Modals/LeadModal.vue
@@ -1,47 +1,177 @@
 <template>
-  <Dialog v-model:open="show" :size="'3xl'">
-    <template #body>
-      <div class="bg-surface-elevation-2 px-4 pb-6 pt-5 sm:px-6">
-        <div class="mb-5 flex items-center justify-between">
-          <div>
-            <h3 class="text-3xl-semibold leading-6 text-ink-gray-9">
-              {{ __('Create Lead') }}
-            </h3>
-          </div>
-          <div class="flex items-center gap-1">
-            <Button
-              v-if="isManager() && !isMobileView"
-              variant="ghost"
-              class="w-7"
-              :tooltip="__('Edit Fields Layout')"
-              :icon="EditIcon"
-              @click="openQuickEntryModal"
-            />
-            <Button
-              variant="ghost"
-              class="w-7"
-              icon="lucide-x"
-              @click="show = false"
-            />
-          </div>
-        </div>
+<Dialog v-model:open="show" :size="'3xl'">
+  <template #body>
+    <div class="bg-surface-elevation-2 px-4 pb-6 pt-5 sm:px-6">
+      <!-- Header -->
+      <div class="mb-6 flex items-center justify-between">
         <div>
-          <FieldLayout v-if="tabs.data" :tabs="tabs.data" :data="lead.doc" />
-          <ErrorMessage v-if="error" class="mt-4" :message="__(error)" />
+          <h3 class="text-3xl-semibold leading-6 text-ink-gray-9">
+            {{
+              showDuplicateDialog
+                ? __('Potential Existing Leads')
+                : __('Create Lead')
+            }}
+          </h3>
+        </div>
+
+        <div class="flex items-center gap-1">
+          <Button
+            v-if="
+              !showDuplicateDialog &&
+              isManager() &&
+              !isMobileView
+            "
+            variant="ghost"
+            class="w-7"
+            :tooltip="__('Edit Fields Layout')"
+            :icon="EditIcon"
+            @click="openQuickEntryModal"
+          />
+
+          <Button
+            variant="ghost"
+            class="w-7"
+            icon="lucide-x"
+            @click="show = false"
+          />
         </div>
       </div>
-      <div class="px-4 pb-7 pt-4 sm:px-6">
-        <div class="flex flex-row-reverse gap-2">
+
+      <!-- Create Lead Form -->
+      <template v-if="!showDuplicateDialog">
+        <FieldLayout
+          v-if="tabs.data"
+          :tabs="tabs.data"
+          :data="lead.doc"
+        />
+
+        <ErrorMessage
+          v-if="error"
+          class="mt-4"
+          :message="__(error)"
+        />
+      </template>
+
+      <!-- Duplicate Leads -->
+      <template v-else>
+        <div class="text-base text-ink-gray-6">
+          {{
+            __('We found {0} existing lead(s) with the same email address or mobile number.', [
+              duplicateLeads.length,
+            ])
+          }}
+        </div>
+
+        <div class="mt-6 max-h-[420px] space-y-3 overflow-y-auto">
+
+          <div
+            v-for="duplicate in duplicateLeads"
+            :key="duplicate.name"
+            class="rounded-lg border border-outline-gray-2 p-4 transition-colors hover:border-outline-gray-4"
+          >
+            <div class="flex items-start justify-between gap-4">
+
+              <div class="flex-1">
+
+                <div class="text-lg font-semibold text-ink-gray-9">
+                  {{ duplicate.lead_name }}
+                </div>
+
+                <div
+                  v-if="duplicate.email"
+                  class="mt-2 text-sm text-ink-gray-7"
+                >
+                  {{ duplicate.email }}
+                </div>
+
+                <div
+                  v-if="duplicate.mobile_no"
+                  class="text-sm text-ink-gray-7"
+                >
+                  {{ duplicate.mobile_no }}
+                </div>
+
+                <div
+                  v-if="duplicate.organization"
+                  class="mt-2 text-sm text-ink-gray-7"
+                >
+                  <strong>{{ __('Organization') }}:</strong>
+                  {{ duplicate.organization }}
+                </div>
+
+                <div
+                  v-if="duplicate.status"
+                  class="text-sm text-ink-gray-7"
+                >
+                  <strong>{{ __('Status') }}:</strong>
+                  {{ duplicate.status }}
+                </div>
+
+                <div class="mt-3">
+                  <div class="mb-2 text-xs font-medium uppercase tracking-wide text-ink-gray-6">
+                    {{ __('Matched By') }}
+                  </div>
+
+                  <div class="flex flex-wrap gap-2">
+                    <span
+                      v-for="match in duplicate.matched_on"
+                      :key="match"
+                      class="rounded-full bg-surface-gray-2 px-3 py-1 text-xs"
+                    >
+                      {{ match }}
+                    </span>
+                  </div>
+                </div>
+
+              </div>
+
+              <Button
+                variant="outline"
+                :label="__('Open Lead')"
+                @click.stop="openExistingLead(duplicate.name)"
+              />
+
+            </div>
+          </div>
+
+        </div>
+      </template>
+    </div>
+
+    <!-- Footer -->
+    <div class="px-4 pb-7 pt-4 sm:px-6">
+      <div class="flex flex-row-reverse gap-2">
+
+        <template v-if="!showDuplicateDialog">
           <Button
             variant="solid"
             :label="__('Create')"
             :loading="isLeadCreating"
             @click="createNewLead"
           />
-        </div>
+        </template>
+
+        <template v-else>
+
+          <Button
+            variant="solid"
+            :label="__('Create Anyway')"
+            :loading="isLeadCreating"
+            @click="continueAnyway"
+          />
+
+          <Button
+            variant="subtle"
+            :label="__('Back')"
+            @click="goBack"
+          />
+
+        </template>
+
       </div>
-    </template>
-  </Dialog>
+    </div>
+  </template>
+</Dialog>
 </template>
 
 <script setup>
@@ -55,7 +185,7 @@ import { showQuickEntryModal, quickEntryProps } from '@/composables/modals'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 import { createResource } from 'frappe-ui'
 import { useDocument } from '@/data/document'
-import { computed, onMounted, ref, nextTick } from 'vue'
+import { computed, onMounted, ref, nextTick, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 const props = defineProps({
@@ -71,6 +201,9 @@ const show = defineModel({ type: Boolean })
 const router = useRouter()
 const error = ref(null)
 const isLeadCreating = ref(false)
+
+const showDuplicateDialog = ref(false)
+const duplicateLeads = ref([])
 
 const { document: lead, triggerOnBeforeCreate } = useDocument('CRM Lead')
 
@@ -108,13 +241,11 @@ const createLead = createResource({
   url: 'frappe.client.insert',
 })
 
-async function createNewLead() {
-  if (lead.doc.website && !lead.doc.website.startsWith('http')) {
-    lead.doc.website = 'https://' + lead.doc.website
-  }
+const checkDuplicateLead = createResource({
+  url: 'crm.fcrm.doctype.crm_lead.crm_lead.find_duplicate_leads',
+})
 
-  await triggerOnBeforeCreate?.()
-
+function insertLead() {
   createLead.submit(
     {
       doc: {
@@ -125,10 +256,12 @@ async function createNewLead() {
     {
       validate() {
         error.value = null
+
         if (!lead.doc.first_name) {
           error.value = __('First Name is mandatory')
           return error.value
         }
+
         if (lead.doc.annual_revenue) {
           if (typeof lead.doc.annual_revenue === 'string') {
             lead.doc.annual_revenue = lead.doc.annual_revenue.replace(/,/g, '')
@@ -137,6 +270,7 @@ async function createNewLead() {
             return error.value
           }
         }
+
         if (
           lead.doc.mobile_no &&
           isNaN(lead.doc.mobile_no.replace(/[-+() ]/g, ''))
@@ -144,43 +278,109 @@ async function createNewLead() {
           error.value = __('Mobile No. should be a number')
           return error.value
         }
+
         if (lead.doc.email && !lead.doc.email.includes('@')) {
           error.value = __('Invalid email address')
           return error.value
         }
+
         if (!lead.doc.status) {
           error.value = __('Status is required')
           return error.value
         }
+
         isLeadCreating.value = true
       },
+
       onSuccess(data) {
         capture('lead_created')
         isLeadCreating.value = false
         show.value = false
         lead.doc = {}
-        router.push({ name: 'Lead', params: { leadId: data.name } })
+
+        router.push({
+          name: 'Lead',
+          params: {
+            leadId: data.name,
+          },
+        })
+
         updateOnboardingStep('create_first_lead', true, false, () => {
           localStorage.setItem('firstLead' + user, data.name)
         })
       },
+
       onError(err) {
         isLeadCreating.value = false
+
         if (!err.messages) {
           error.value = err.message
           return
         }
+
         error.value = err.messages.join('\n')
       },
     },
   )
 }
 
+async function createNewLead() {
+  if (lead.doc.website && !lead.doc.website.startsWith('http')) {
+    lead.doc.website = 'https://' + lead.doc.website
+  }
+
+  await triggerOnBeforeCreate?.()
+
+  const existingLeads = await checkDuplicateLead.submit({
+    email: lead.doc.email,
+    mobile_no: lead.doc.mobile_no,
+  })
+
+  if (!existingLeads || existingLeads.length === 0) {
+    insertLead()
+    return
+  }
+
+  duplicateLeads.value = existingLeads
+  showDuplicateDialog.value = true
+}
+
+function continueAnyway() {
+  showDuplicateDialog.value = false
+  insertLead()
+}
+
+function goBack() {
+  error.value = null
+  showDuplicateDialog.value = false
+}
+
+function openExistingLead(leadName) {
+  show.value = false
+
+  router.push({
+    name: 'Lead',
+    params: {
+      leadId: leadName,
+    },
+  })
+}
+
 function openQuickEntryModal() {
   showQuickEntryModal.value = true
-  quickEntryProps.value = { doctype: 'CRM Lead' }
+  quickEntryProps.value = {
+    doctype: 'CRM Lead',
+  }
+
   nextTick(() => (show.value = false))
 }
+
+watch(show, (value) => {
+  if (!value) {
+    showDuplicateDialog.value = false
+    duplicateLeads.value = []
+  }
+})
 
 onMounted(() => {
   lead.doc.no_of_employees = '1-10'
@@ -189,8 +389,10 @@ onMounted(() => {
   if (!lead.doc?.lead_owner) {
     lead.doc.lead_owner = getUser().name
   }
+
   if (!lead.doc?.status && leadStatuses.value[0]?.value) {
     lead.doc.status = leadStatuses.value[0].value
   }
 })
 </script>
+


### PR DESCRIPTION
This PR improves the lead creation flow by warning users when a lead with the same email address or mobile number already exists.

Instead of immediately allowing another lead to be created, users are presented with the matching lead(s), where they can review the existing records, open an existing lead, or choose to continue creating a new one if needed.

## Changes

* Display matching leads before creating a duplicate lead
* Allow users to review existing leads
* Provide an option to open an existing lead
* Allow users to continue creating the lead if required
* Preserve entered form values while reviewing duplicates

## Testing

* Created a unique lead
* Verified duplicate detection by email
* Verified duplicate detection by mobile number
* Verified duplicate detection by both email and mobile number
* Verified opening an existing lead
* Verified creating the lead anyway
* Verified returning to the form preserves entered values
* Verified the frontend builds successfully
