### PR TITLE
fix: use bg-surface-gray-1 for desktop sidebar background

### DIFF
--- a/frontend/src/components/Layouts/DesktopLayout.vue
+++ b/frontend/src/components/Layouts/DesktopLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex h-screen w-screen">
-    <div class="h-full border-r bg-surface-gray-1">
+    <div class="h-full border-r bg-surface-sidebar">
       <AppSidebar />
     </div>
     <div class="flex-1 flex flex-col h-full overflow-auto bg-surface-base">

--- a/frontend/src/components/Layouts/DesktopLayout.vue
+++ b/frontend/src/components/Layouts/DesktopLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex h-screen w-screen">
-    <div class="h-full border-r bg-surface-sidebar">
+    <div class="h-full border-r bg-surface-gray-1">
       <AppSidebar />
     </div>
     <div class="flex-1 flex flex-col h-full overflow-auto bg-surface-base">

--- a/frontend/src/components/Mobile/MobileSidebar.vue
+++ b/frontend/src/components/Mobile/MobileSidebar.vue
@@ -11,7 +11,7 @@
         leave-to="-translate-x-full"
       >
         <div
-          class="relative z-10 flex h-full w-[260px] flex-col justify-between border-r bg-surface-sidebar transition-all duration-300 ease-in-out"
+          class="relative z-10 flex h-full w-[260px] flex-col justify-between border-r bg-surface-gray-1 transition-all duration-300 ease-in-out"
         >
           <div>
             <UserDropdown class="p-2" :isCollapsed="!sidebarOpened" />

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -6,15 +6,15 @@
     @close="activeSettingsPage = ''"
   >
     <template #body>
-      <div class="flex h-[calc(100vh_-_8rem)] bg-surface-sidebar">
+      <div class="flex h-[calc(100vh_-_8rem)] bg-surface-gray-1">
         <div
-          class="flex flex-col m-1 rounded-l-lg w-56 shrink-0 bg-surface-sidebar overflow-y-auto"
+          class="flex flex-col m-1 rounded-l-lg w-56 shrink-0 bg-surface-gray-1 overflow-y-auto"
         >
           <template v-for="(tab, i) in tabs" :key="tab.label">
             <div v-if="!tab.hideLabel && i != 0" class="mx-1 mb-0.5 mt-[5px]" />
             <div
               v-if="!tab.hideLabel"
-              class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-sidebar"
+              class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-gray-1"
             >
               <span>{{ __(tab.label) }}</span>
             </div>


### PR DESCRIPTION
## fix: use `bg-surface-gray-1` for desktop sidebar background

### Problem
The desktop layout sidebar uses `bg-surface-sidebar` for its background. In
frappe-ui's design token system (`tailwind/generated/colors.json`), the dark
mode value for `surface.sidebar` is mapped to `neutral/transparent`
(`#ffffff00`), which means the sidebar renders with a fully transparent
background in dark mode — visually broken.

Light mode is unaffected (`surface.sidebar` = `gray-50` there).

### Fix
Replace `bg-surface-sidebar` → `bg-surface-gray-1` in `DesktopLayout.vue`.
`surface.gray-1` correctly resolves to `gray-50` in light mode and `gray-900`
in dark mode, providing the intended sidebar background in both themes.

> **Note:** This is a temporary workaround. The root cause is upstream in
> `frappe-ui` — `surface.sidebar` in dark mode is set to `transparent` in
> the generated color tokens, which appears to be unintentional. A separate
> issue has been filed in `frappe/frappe-ui` to fix the token value. Once
> resolved and `frappe-ui` is updated as a dependency, this workaround can
> be reverted.

### Affected file
- `frontend/src/components/Layouts/DesktopLayout.vue`

Fixes #2348 