### PR TITLE
feat(settings): add search bar to settings modal

### DIFF
--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -3,21 +3,47 @@
     v-model:open="showSettings"
     :size="'5xl'"
     :disableOutsideClickToClose="disableSettingModalOutsideClick"
-    @close="activeSettingsPage = ''"
+    @close="
+      activeSettingsPage = '';
+      searchQuery = '';
+    "
   >
     <template #body>
       <div class="flex h-[calc(100vh_-_8rem)] bg-surface-sidebar">
         <div
           class="flex flex-col m-1 rounded-l-lg w-56 shrink-0 bg-surface-sidebar overflow-y-auto"
         >
-          <template v-for="(tab, i) in tabs" :key="tab.label">
-            <div v-if="!tab.hideLabel && i != 0" class="mx-1 mb-0.5 mt-[5px]" />
+          <!-- Search Bar -->
+          <div class="sticky top-0 z-20 bg-surface-sidebar p-2">
+            <input
+              v-model="searchQuery"
+              :placeholder="__('Search settings...')"
+              class="w-full rounded-md border border-outline-gray-2 bg-surface-white px-3 py-2 text-sm focus:outline-none focus:ring-0 focus:border-outline-gray-4"
+            />
+          </div>
+
+          <!-- No Results -->
+          <div
+            v-if="filteredTabs.length === 0"
+            class="p-4 text-sm text-ink-gray-5"
+          >
+            {{ __('No settings found.') }}
+          </div>
+
+          <!-- Settings List -->
+          <template v-else v-for="(tab, i) in filteredTabs" :key="tab.label">
+            <div
+              v-if="!tab.hideLabel && i != 0"
+              class="mx-1 mb-0.5 mt-[5px]"
+            />
+
             <div
               v-if="!tab.hideLabel"
-              class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-sidebar"
+              class="h-7.5 px-2 py-[7px] my-[3px] flex gap-1.5 text-xs-medium text-ink-gray-5 sticky top-0 z-10 bg-surface-sidebar"
             >
               <span>{{ __(tab.label) }}</span>
             </div>
+
             <nav class="space-y-[3px] px-1">
               <SidebarLink
                 v-for="item in tab.items"
@@ -35,15 +61,20 @@
             </nav>
           </template>
         </div>
+
         <div
           class="flex flex-col flex-1 overflow-y-auto bg-surface-elevation-2"
         >
-          <component :is="activeTab.component" v-if="activeTab" />
+          <component
+            :is="activeTab.component"
+            v-if="activeTab"
+          />
         </div>
       </div>
     </template>
   </Dialog>
 </template>
+
 <script setup>
 import LucideLayoutDashboard from '~icons/lucide/layout-dashboard'
 import LucideNetwork from '~icons/lucide/network'
@@ -92,6 +123,8 @@ import SlaConfig from './Sla/SlaConfig.vue'
 const { isManager, getUser } = usersStore()
 
 const user = computed(() => getUser() || {})
+
+const searchQuery = ref('')
 
 const tabs = computed(() => {
   let _tabs = [
@@ -255,17 +288,82 @@ const tabs = computed(() => {
   })
 })
 
+function getMatchScore(label, query) {
+  const text = label.toLowerCase()
+
+  // Exact beginning of label
+  if (text.startsWith(query)) return 3
+
+  // Beginning of any word
+  if (text.split(/\s+/).some(word => word.startsWith(query))) return 2
+
+  // Anywhere in label
+  if (text.includes(query)) return 1
+
+  return 0
+}
+
+const filteredTabs = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  if (!query) {
+    return tabs.value
+  }
+
+  return tabs.value
+    .map((tab) => {
+      // If section title matches, keep the entire section
+      const sectionScore = getMatchScore(tab.label, query)
+
+      if (sectionScore > 0) {
+        return {
+          ...tab,
+          maxScore: sectionScore,
+        }
+      }
+
+      const items = tab.items
+        .map((item) => ({
+          ...item,
+          score: getMatchScore(item.label, query),
+        }))
+        .filter((item) => item.score > 0)
+        .sort((a, b) => b.score - a.score)
+
+      return {
+        ...tab,
+        items,
+        maxScore: items.length
+          ? Math.max(...items.map((item) => item.score))
+          : 0,
+      }
+    })
+    .filter((tab) => tab.items.length > 0)
+    .sort((a, b) => b.maxScore - a.maxScore)
+})
+
 const activeTab = ref(tabs.value[0].items[0])
 
 function setActiveTab(tabName) {
   activeTab.value =
     (tabName &&
       tabs.value
-        .map((tab) => tab.items)
-        .flat()
-        .find((tab) => tab.label === tabName)) ||
+        .flatMap((tab) => tab.items)
+        .find((item) => item.label === tabName)) ||
     tabs.value[0].items[0]
 }
 
-watch(activeSettingsPage, (activePage) => setActiveTab(activePage))
+watch(activeSettingsPage, (activePage) => {
+  setActiveTab(activePage)
+})
+
+watch(filteredTabs, (newTabs) => {
+  if (!newTabs.length) return
+
+  const visibleItems = newTabs.flatMap((tab) => tab.items)
+
+  if (!visibleItems.find((item) => item.label === activeTab.value?.label)) {
+    activeTab.value = visibleItems[0]
+  }
+})
 </script>

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -345,12 +345,15 @@ const filteredTabs = computed(() => {
 const activeTab = ref(tabs.value[0].items[0])
 
 function setActiveTab(tabName) {
-  activeTab.value =
-    (tabName &&
-      tabs.value
-        .flatMap((tab) => tab.items)
-        .find((item) => item.label === tabName)) ||
-    tabs.value[0].items[0]
+  const items = filteredTabs.value.flatMap((tab) => tab.items)
+
+  const selected =
+    items.find((item) => item.label === tabName) ||
+    items[0] ||
+    null
+
+  activeTab.value = selected
+  activeSettingsPage.value = selected?.label || ''
 }
 
 watch(activeSettingsPage, (activePage) => {
@@ -358,12 +361,17 @@ watch(activeSettingsPage, (activePage) => {
 })
 
 watch(filteredTabs, (newTabs) => {
-  if (!newTabs.length) return
+  if (!newTabs.length) {
+    activeTab.value = null
+    activeSettingsPage.value = ''
+    return
+  }
 
   const visibleItems = newTabs.flatMap((tab) => tab.items)
 
   if (!visibleItems.find((item) => item.label === activeTab.value?.label)) {
     activeTab.value = visibleItems[0]
+    activeSettingsPage.value = visibleItems[0].label
   }
 })
 </script>


### PR DESCRIPTION
## Summary

This PR adds a search bar to the Settings modal, making it easier to quickly locate settings without manually scrolling through the sidebar.

### Before
Users had to manually browse through different sections to find a specific setting.

### After
A search bar is available at the top of the Settings sidebar, allowing users to filter settings live as they type.

**Search bar**
<img width="1033" height="854" alt="image" src="https://github.com/user-attachments/assets/9c5b5a95-8108-4c49-af0f-1ce93a37a3fd" />

**Searching for a setting**
<img width="1033" height="854" alt="image" src="https://github.com/user-attachments/assets/10fa18af-08d7-4b05-96b2-1dc21aee3fe1" />

### Changes

- Added a search bar to the top of the Settings sidebar.
- Filters settings dynamically as the user types.
- Supports case-insensitive search.
- Searches across both settings and section names.
- Displays a "No settings found" message when there are no matching results.
- Clears the search query when the Settings modal is closed.

### Testing

Tested the following scenarios:

- Live filtering while typing
- Case-insensitive search
- Section and setting name matching
- "No settings found" state
- Search reset when closing the Settings modal

Fixes #1672