### PR TITLE
fix: make lead/deal owner mirror assign_to (assignment-driven, overridable)

### DIFF
--- a/crm/api/todo.py
+++ b/crm/api/todo.py
@@ -7,11 +7,10 @@ from crm.fcrm.doctype.crm_notification.crm_notification import notify_user
 def after_insert(doc, method):
 	if doc.reference_type in ["CRM Lead", "CRM Deal"] and doc.reference_name and doc.allocated_to:
 		fieldname = "lead_owner" if doc.reference_type == "CRM Lead" else "deal_owner"
-		owner = frappe.db.get_value(doc.reference_type, doc.reference_name, fieldname)
-		if not owner:
-			frappe.db.set_value(
-				doc.reference_type, doc.reference_name, fieldname, doc.allocated_to, update_modified=False
-			)
+		# Mirror assign_to: the latest assignment owns the record, overriding any prior owner.
+		frappe.db.set_value(
+			doc.reference_type, doc.reference_name, fieldname, doc.allocated_to, update_modified=False
+		)
 
 	if doc.reference_type in ["CRM Lead", "CRM Deal", "CRM Task"] and doc.reference_name and doc.allocated_to:
 		notify_assigned_user(doc)
@@ -34,10 +33,9 @@ def clear_owner_on_unassign(doc):
 	if doc.reference_type not in ["CRM Lead", "CRM Deal"]:
 		return
 	fieldname = "lead_owner" if doc.reference_type == "CRM Lead" else "deal_owner"
-	owner = frappe.db.get_value(doc.reference_type, doc.reference_name, fieldname)
-	# Only clear when the user being unassigned is the current owner.
-	if owner and owner == doc.allocated_to:
-		frappe.db.set_value(doc.reference_type, doc.reference_name, fieldname, None, update_modified=False)
+	# Mirror assign_to: cancelling an assignment clears the owner. Wrinkle (accepted):
+	# removing one of several manual co-assignees also clears, since owner is single-valued.
+	frappe.db.set_value(doc.reference_type, doc.reference_name, fieldname, None, update_modified=False)
 
 
 def notify_assigned_user(doc, is_cancelled=False):

--- a/crm/fcrm/doctype/crm_deal/test_crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/test_crm_deal.py
@@ -174,14 +174,22 @@ class TestCRMDeal(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"), "crm.user2@example.com")
 
-	def test_non_owner_removal_leaves_owner(self):
-		"""Removing a non-owner assignee does not touch the owner"""
-		deal = create_test_deal(organization="Non Owner Org", deal_owner="crm.user1@example.com")
+	def test_assignment_overrides_owner(self):
+		"""A new assignment takes ownership even when an owner already exists (newest owns)."""
+		deal = create_test_deal(organization="Override Org", deal_owner="crm.user1@example.com")
 		assign_add({"assign_to": ["crm.user2@example.com"], "doctype": "CRM Deal", "name": deal.name})
+		self.assertEqual(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"), "crm.user2@example.com")
 
-		assign_remove("CRM Deal", deal.name, "crm.user2@example.com")
+	def test_removing_any_assignee_clears_owner(self):
+		"""Accepted simplification: cancelling ANY assignment clears the owner,
+		even when other assignees remain (owner is single-valued, _assign is a list)."""
+		deal = create_test_deal(organization="Wrinkle Org", deal_owner="crm.user1@example.com")
+		assign_add({"assign_to": ["crm.user2@example.com"], "doctype": "CRM Deal", "name": deal.name})
+		# newest assignment owns
+		self.assertEqual(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"), "crm.user2@example.com")
 
-		self.assertEqual(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"), "crm.user1@example.com")
+		assign_remove("CRM Deal", deal.name, "crm.user1@example.com")  # remove a non-owner assignee
+		self.assertIsNone(frappe.db.get_value("CRM Deal", deal.name, "deal_owner"))
 
 	def test_task_unassign_does_not_touch_owner(self):
 		"""Cancelling a CRM Task assignment is a no-op for owner fields"""

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.desk.form.assign_to import add as assign_add
 from frappe.desk.form.assign_to import remove as assign_remove
 from frappe.tests import IntegrationTestCase
 
@@ -539,6 +540,12 @@ class TestCRMLead(IntegrationTestCase):
 		assign_remove("CRM Lead", lead.name, "crm.user1@example.com")
 
 		self.assertIsNone(frappe.db.get_value("CRM Lead", lead.name, "lead_owner"))
+
+	def test_assignment_overrides_owner(self):
+		"""A new assignment takes ownership even when an owner already exists (newest owns)."""
+		lead = create_lead(first_name="Override", lead_owner="crm.user1@example.com")
+		assign_add({"assign_to": ["crm.user2@example.com"], "doctype": "CRM Lead", "name": lead.name})
+		self.assertEqual(frappe.db.get_value("CRM Lead", lead.name, "lead_owner"), "crm.user2@example.com")
 
 
 def create_lead(**kwargs):


### PR DESCRIPTION
## Problem

The `ToDo` hooks in `crm/api/todo.py` sync `lead_owner` / `deal_owner` from assignment events, but with **asymmetric guards**:

- `after_insert` set the owner **only when it was empty** (`if not owner:`)
- `clear_owner_on_unassign` cleared it **only when the unassigned user matched the owner** (`if owner == doc.allocated_to:`)

This made the owner a sticky, semi-independent field. Once set (manually or otherwise), an **Assignment Rule could not override it**, leaving stale "ghost owners" that blocked reassignment routing.

## Fix

Make the owner follow the **same pattern the framework already uses for `assign_to`** — purely assignment-driven, no stickiness. Frappe's Assignment Rule does `assign_to.clear()` then `assign_to._add(one_user)` on every reassign; we mirror that:

- **on assign** (`ToDo.after_insert`): always set the owner to the assignee → the latest assignment owns the record and overrides any prior owner.
- **on unassign** (`ToDo` cancelled): always clear the owner (Lead/Deal only; Task is unaffected).

### Accepted trade-off

Because `owner` is single-valued but `_assign` is a list, removing one of several **manually** co-assigned users also clears the owner. The Assignment Rule path never hits this (it clears then adds a single user), so ownership always lands correctly for rule-driven routing.

## Tests

- `test_assignment_overrides_owner` (lead + deal) — a new assignment takes ownership even when an owner already exists.
- `test_removing_any_assignee_clears_owner` (deal) — replaces `test_non_owner_removal_leaves_owner`; documents the accepted clear-on-any-unassign behavior.
- Existing `test_owner_cleared_on_unassign`, `test_reassignment_moves_owner`, `test_task_unassign_does_not_touch_owner`, and creation/update-owner tests pass unchanged.

All `crm_lead` (21) and `crm_deal` (23) backend tests pass locally, plus a manual `bench console` walkthrough confirming override-on-assign and clear-on-unassign against a real record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)