### PR TITLE
feat(ci): Playwright E2E Tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,181 @@
+name: UI Tests
+
+# E2E (Playwright) suite. Heavy gate: runs on the main-hotfix staging lane
+# before promoting to main, plus on demand. Develop stays on the fast lane.
+on:
+  push:
+    branches:
+      - main-hotfix
+  pull_request:
+    branches:
+      - main-hotfix
+  workflow_dispatch:
+
+concurrency:
+  group: ui-tests-crm-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FRAPPE_BRANCH: develop
+
+jobs:
+  ui-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    name: Playwright E2E Tests
+
+    services:
+      redis-cache:
+        image: redis:alpine
+        ports:
+          - 13000:6379
+      redis-queue:
+        image: redis:alpine
+        ports:
+          - 11000:6379
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          check-latest: true
+
+      - name: Add to Hosts
+        run: echo "127.0.0.1 crm.test" | sudo tee -a /etc/hosts
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
+
+      - name: Cache yarn
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install MariaDB Client
+        run: |
+          sudo apt update
+          sudo apt-get install mariadb-client
+
+      - name: Setup Bench
+        run: |
+          pip install frappe-bench
+          bench init --skip-redis-config-generation --skip-assets --frappe-branch "$FRAPPE_BRANCH" --python "$(which python)" ~/frappe-bench
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+
+      - name: Install CRM
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench get-app crm $GITHUB_WORKSPACE
+          bench setup requirements --dev
+          bench new-site --db-root-password root --admin-password admin crm.test
+          bench --site crm.test install-app crm
+          bench build --app crm
+        env:
+          CI: "Yes"
+
+      - name: Configure Site for UI Tests
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site crm.test set-config allow_tests true
+          bench --site crm.test set-config host_name "http://crm.test:8000"
+          # Dummy default-outgoing account so send-email queues without real SMTP.
+          bench --site crm.test console <<'PY'
+          import frappe
+          if not frappe.db.exists("Email Account", {"default_outgoing": 1}):
+              frappe.get_doc({
+                  "doctype": "Email Account",
+                  "email_account_name": "E2E Outgoing",
+                  "email_id": "e2e@example.com",
+                  "smtp_server": "localhost",
+                  "smtp_port": 25,
+                  "enable_outgoing": 1,
+                  "default_outgoing": 1,
+                  "no_smtp_authentication": 1,
+              }).insert(ignore_permissions=True)
+              frappe.db.commit()
+          PY
+
+      - name: Start Frappe Server
+        working-directory: /home/runner/frappe-bench
+        run: |
+          sed -i 's/^watch:/# watch:/g' Procfile
+          sed -i 's/^schedule:/# schedule:/g' Procfile
+          bench start &> bench_start.log &
+          echo "Waiting for Frappe server to start..."
+          timeout 60 bash -c 'until curl -s http://crm.test:8000 > /dev/null; do sleep 2; done'
+          echo "Frappe server is ready!"
+
+      - name: Install Playwright
+        run: |
+          npm install --ignore-scripts
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright Tests
+        run: npx playwright test
+        env:
+          BASE_URL: http://crm.test:8000
+          FRAPPE_USER: Administrator
+          FRAPPE_PASSWORD: admin
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 7
+
+      - name: Show Bench Logs on Failure
+        if: failure()
+        working-directory: /home/runner/frappe-bench
+        run: |
+          echo "=== Bench Start Log ==="
+          cat bench_start.log || true
+          echo ""
+          echo "=== Frappe Logs ==="
+          cat logs/*.log || true

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ crm/www/crm.html
 build
 frontend/coverage
 
+e2e/.auth
+test-results
+playwright-report
+
 .vscode
 .github/instructions
 .github/skills

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ frontend/coverage
 e2e/.auth
 test-results
 playwright-report
+package-lock.json
 
 .vscode
 .github/instructions

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,46 @@
+import { APIRequestContext, Page } from '@playwright/test'
+
+/**
+ * Login via the Frappe API (faster than UI login).
+ * Sets session cookies on the request context for subsequent API calls.
+ */
+export async function loginViaAPI(
+	request: APIRequestContext,
+	email = 'Administrator',
+	password = 'admin',
+): Promise<void> {
+	const response = await request.post('/api/method/login', {
+		form: { usr: email, pwd: password },
+	})
+
+	if (!response.ok()) {
+		throw new Error(
+			`Login failed: ${response.status()} ${await response.text()}`,
+		)
+	}
+}
+
+/**
+ * Logout the current user.
+ */
+export async function logout(page: Page): Promise<void> {
+	await page.goto('/api/method/logout')
+	await page.waitForLoadState('networkidle')
+}
+
+/**
+ * Check if a user is logged in by verifying the session.
+ */
+export async function isLoggedIn(request: APIRequestContext): Promise<boolean> {
+	try {
+		const response = await request.get(
+			'/api/method/frappe.auth.get_logged_user',
+		)
+		if (!response.ok()) return false
+
+		const data = await response.json()
+		return data.message && data.message !== 'Guest'
+	} catch {
+		return false
+	}
+}

--- a/e2e/helpers/crm.ts
+++ b/e2e/helpers/crm.ts
@@ -1,0 +1,68 @@
+import { APIRequestContext } from '@playwright/test'
+import { createDoc, deleteDoc, getList } from './frappe'
+
+export const LEAD_DOCTYPE = 'CRM Lead'
+export const DEAL_DOCTYPE = 'CRM Deal'
+
+export interface LeadData {
+	first_name: string
+	last_name?: string
+	email?: string
+	organization?: string
+	mobile_no?: string
+}
+
+/**
+ * Generate a unique suffix so parallel/repeat runs don't collide.
+ */
+export function uniqueSuffix(): string {
+	return `${Date.now()}-${Math.floor(Math.random() * 1000)}`
+}
+
+/**
+ * Build a lead payload with unique, valid test data.
+ */
+export function buildLead(overrides: Partial<LeadData> = {}): LeadData {
+	const id = uniqueSuffix()
+	return {
+		first_name: `E2E Lead ${id}`,
+		email: `e2e-lead-${id}@example.com`,
+		organization: `E2E Org ${id}`,
+		mobile_no: '9999999999',
+		...overrides,
+	}
+}
+
+/**
+ * Seed a lead via the API (used by tests that start from an existing lead).
+ */
+export async function seedLead(
+	request: APIRequestContext,
+	overrides: Partial<LeadData> = {},
+): Promise<{ name: string } & LeadData> {
+	const data = buildLead(overrides)
+	const doc = await createDoc<{ name: string }>(request, LEAD_DOCTYPE, data)
+	return { ...data, name: doc.name }
+}
+
+/**
+ * Delete every lead/deal created by E2E runs (matched by the e2e-* email).
+ */
+export async function cleanupE2ERecords(
+	request: APIRequestContext,
+): Promise<void> {
+	for (const doctype of [LEAD_DOCTYPE, DEAL_DOCTYPE]) {
+		const rows = await getList<{ name: string }>(request, doctype, {
+			fields: ['name'],
+			filters: { email: ['like', 'e2e-%@example.com'] },
+			limit: 500,
+		})
+		for (const row of rows) {
+			try {
+				await deleteDoc(request, doctype, row.name)
+			} catch {
+				// best-effort cleanup; ignore already-deleted / linked rows
+			}
+		}
+	}
+}

--- a/e2e/helpers/frappe.ts
+++ b/e2e/helpers/frappe.ts
@@ -1,0 +1,165 @@
+import * as fs from 'fs'
+import { APIRequestContext } from '@playwright/test'
+
+/**
+ * Frappe API response wrapper.
+ */
+export interface FrappeResponse<T = unknown> {
+	message?: T
+	exc?: string
+	exc_type?: string
+	_server_messages?: string
+}
+
+// CSRF token file saved by auth.setup.ts
+const CSRF_FILE = 'e2e/.auth/csrf.json'
+
+let csrfTokenCache: string | null = null
+
+/**
+ * Read the CSRF token saved during auth setup (from window.frappe.csrf_token).
+ */
+function getCsrfToken(): string {
+	if (csrfTokenCache !== null) {
+		return csrfTokenCache
+	}
+
+	try {
+		if (fs.existsSync(CSRF_FILE)) {
+			const data = JSON.parse(fs.readFileSync(CSRF_FILE, 'utf-8'))
+			csrfTokenCache = data.csrf_token || ''
+			return csrfTokenCache
+		}
+	} catch (error) {
+		console.warn('Failed to read CSRF token file:', error)
+	}
+
+	csrfTokenCache = ''
+	return ''
+}
+
+function jsonHeaders(): Record<string, string> {
+	const csrfToken = getCsrfToken()
+	return {
+		'Content-Type': 'application/json',
+		...(csrfToken ? { 'X-Frappe-CSRF-Token': csrfToken } : {}),
+	}
+}
+
+/**
+ * Create a document via the Frappe REST API.
+ */
+export async function createDoc<T = Record<string, unknown>>(
+	request: APIRequestContext,
+	doctype: string,
+	doc: Record<string, unknown>,
+): Promise<T> {
+	const response = await request.post(`/api/resource/${doctype}`, {
+		data: doc,
+		headers: jsonHeaders(),
+	})
+
+	if (!response.ok()) {
+		throw new Error(`Failed to create ${doctype}: ${await response.text()}`)
+	}
+
+	const result = await response.json()
+	return result.data as T
+}
+
+/**
+ * Get a document by name via the Frappe REST API.
+ */
+export async function getDoc<T = Record<string, unknown>>(
+	request: APIRequestContext,
+	doctype: string,
+	name: string,
+): Promise<T> {
+	const response = await request.get(
+		`/api/resource/${doctype}/${encodeURIComponent(name)}`,
+	)
+
+	if (!response.ok()) {
+		throw new Error(
+			`Failed to get ${doctype}/${name}: ${await response.text()}`,
+		)
+	}
+
+	const result = await response.json()
+	return result.data as T
+}
+
+/**
+ * Delete a document via the Frappe REST API.
+ */
+export async function deleteDoc(
+	request: APIRequestContext,
+	doctype: string,
+	name: string,
+): Promise<void> {
+	const response = await request.delete(
+		`/api/resource/${doctype}/${encodeURIComponent(name)}`,
+		{ headers: jsonHeaders() },
+	)
+
+	if (!response.ok()) {
+		throw new Error(
+			`Failed to delete ${doctype}/${name}: ${await response.text()}`,
+		)
+	}
+}
+
+/**
+ * Call a Frappe whitelisted method.
+ */
+export async function callMethod<T = unknown>(
+	request: APIRequestContext,
+	method: string,
+	args: Record<string, unknown> = {},
+): Promise<T> {
+	const response = await request.post(`/api/method/${method}`, {
+		data: args,
+		headers: jsonHeaders(),
+	})
+
+	if (!response.ok()) {
+		throw new Error(`Failed to call ${method}: ${await response.text()}`)
+	}
+
+	const result: FrappeResponse<T> = await response.json()
+	return result.message as T
+}
+
+/**
+ * Get a list of documents via the Frappe REST API.
+ */
+export async function getList<T = Record<string, unknown>>(
+	request: APIRequestContext,
+	doctype: string,
+	options: {
+		fields?: string[]
+		filters?: Record<string, unknown>
+		limit?: number
+		orderBy?: string
+	} = {},
+): Promise<T[]> {
+	const params = new URLSearchParams()
+
+	if (options.fields) params.set('fields', JSON.stringify(options.fields))
+	if (options.filters) params.set('filters', JSON.stringify(options.filters))
+	if (options.limit) params.set('limit_page_length', options.limit.toString())
+	if (options.orderBy) params.set('order_by', options.orderBy)
+
+	const response = await request.get(
+		`/api/resource/${doctype}?${params.toString()}`,
+	)
+
+	if (!response.ok()) {
+		throw new Error(
+			`Failed to get list of ${doctype}: ${await response.text()}`,
+		)
+	}
+
+	const result = await response.json()
+	return result.data as T[]
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,0 +1,3 @@
+export * from './auth'
+export * from './frappe'
+export * from './crm'

--- a/e2e/pages/deals.page.ts
+++ b/e2e/pages/deals.page.ts
@@ -19,17 +19,31 @@ export class DealsPage {
 	}
 
 	/**
-	 * Submit the deal. The Create Deal modal's fields are mostly Link/Select
-	 * with sensible defaults, so an email is enough to identify it later.
+	 * Submit the deal. "Primary email" identifies it later. Value and closure
+	 * date are only mandatory when a site customizes them (Property Setter), so
+	 * they are filled conditionally to stay portable across sites.
 	 */
 	async createDeal(email: string) {
 		const dialog = this.page.getByRole('dialog')
-		const emailInput = dialog.getByPlaceholder('Enter Email')
-		if (await emailInput.count()) await emailInput.fill(email)
+		await dialog.getByPlaceholder('Primary email', { exact: true }).fill(email)
+		await this.fillIfPresent(dialog, 'Expected Deal Value', '1000')
+		await this.fillIfPresent(dialog, 'Expected Closure Date', '2026-12-31', true)
 
 		await dialog.getByRole('button', { name: 'Create', exact: true }).click()
 		await expect(
 			this.page.getByRole('heading', { name: 'Create Deal' }),
 		).toBeHidden()
+	}
+
+	private async fillIfPresent(
+		scope: ReturnType<Page['getByRole']>,
+		placeholder: string,
+		value: string,
+		isDate = false,
+	) {
+		const field = scope.getByPlaceholder(placeholder, { exact: true })
+		if (!(await field.count())) return
+		await field.fill(value)
+		if (isDate) await field.press('Enter')
 	}
 }

--- a/e2e/pages/deals.page.ts
+++ b/e2e/pages/deals.page.ts
@@ -1,0 +1,35 @@
+import { Page, expect } from '@playwright/test'
+
+/**
+ * Deals list view (/crm/deals) and the "Create Deal" modal.
+ */
+export class DealsPage {
+	constructor(private page: Page) {}
+
+	async goto() {
+		await this.page.goto('/crm/deals')
+		await this.page.waitForLoadState('networkidle')
+	}
+
+	async openCreateModal() {
+		await this.page.getByRole('button', { name: 'Create', exact: true }).click()
+		await expect(
+			this.page.getByRole('heading', { name: 'Create Deal' }),
+		).toBeVisible()
+	}
+
+	/**
+	 * Submit the deal. The Create Deal modal's fields are mostly Link/Select
+	 * with sensible defaults, so an email is enough to identify it later.
+	 */
+	async createDeal(email: string) {
+		const dialog = this.page.getByRole('dialog')
+		const emailInput = dialog.getByPlaceholder('Enter Email')
+		if (await emailInput.count()) await emailInput.fill(email)
+
+		await dialog.getByRole('button', { name: 'Create', exact: true }).click()
+		await expect(
+			this.page.getByRole('heading', { name: 'Create Deal' }),
+		).toBeHidden()
+	}
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,0 +1,4 @@
+export * from './login.page'
+export * from './leads.page'
+export * from './lead.page'
+export * from './deals.page'

--- a/e2e/pages/lead.page.ts
+++ b/e2e/pages/lead.page.ts
@@ -11,18 +11,30 @@ export class LeadPage {
 		await this.page.waitForLoadState('networkidle')
 	}
 
-	/** Open the Convert-to-Deal modal and confirm; resolves on the new deal page. */
+	/**
+	 * The email composer caches its draft (recipients/subject/body) in
+	 * localStorage. Clear it so the composer starts from this lead's own data,
+	 * keeping the flow deterministic across tests that share storage state.
+	 */
+	async clearComposerDraft() {
+		await this.page.evaluate(() => window.localStorage.clear())
+		await this.page.reload()
+		await this.page.waitForLoadState('networkidle')
+	}
+
+	/** Open the Convert-to-Deal modal and confirm; resolves once it closes. */
 	async convertToDeal() {
-		await this.page
-			.getByRole('button', { name: 'Convert to Deal' })
-			.click()
+		await this.page.getByRole('button', { name: 'Convert to Deal' }).click()
 		const dialog = this.page.getByRole('dialog')
 		await expect(
 			dialog.getByRole('heading', { name: 'Convert to Deal' }),
 		).toBeVisible()
 		await dialog.getByRole('button', { name: 'Convert', exact: true }).click()
-		// Conversion redirects to the created deal.
-		await this.page.waitForURL(/\/crm\/deals\//, { timeout: 30000 })
+		// A successful conversion closes the modal; the created deal is then
+		// asserted via the API (see convert.spec).
+		await expect(
+			dialog.getByRole('heading', { name: 'Convert to Deal' }),
+		).toBeHidden()
 	}
 
 	/** Toggle the email composer open. */

--- a/e2e/pages/lead.page.ts
+++ b/e2e/pages/lead.page.ts
@@ -1,0 +1,45 @@
+import { Page, expect } from '@playwright/test'
+
+/**
+ * Lead detail view (/crm/leads/:name): convert-to-deal and email compose.
+ */
+export class LeadPage {
+	constructor(private page: Page) {}
+
+	async goto(name: string) {
+		await this.page.goto(`/crm/leads/${name}`)
+		await this.page.waitForLoadState('networkidle')
+	}
+
+	/** Open the Convert-to-Deal modal and confirm; resolves on the new deal page. */
+	async convertToDeal() {
+		await this.page
+			.getByRole('button', { name: 'Convert to Deal' })
+			.click()
+		const dialog = this.page.getByRole('dialog')
+		await expect(
+			dialog.getByRole('heading', { name: 'Convert to Deal' }),
+		).toBeVisible()
+		await dialog.getByRole('button', { name: 'Convert', exact: true }).click()
+		// Conversion redirects to the created deal.
+		await this.page.waitForURL(/\/crm\/deals\//, { timeout: 30000 })
+	}
+
+	/** Toggle the email composer open. */
+	async openEmailBox() {
+		await this.page.getByRole('button', { name: 'Reply' }).click()
+	}
+
+	/** Type a body into the composer and send. Subject is pre-filled by CRM. */
+	async sendEmail(body: string) {
+		const editor = this.page.locator('[contenteditable="true"]').last()
+		await editor.click()
+		await editor.fill(body)
+		await this.page.getByRole('button', { name: 'Send', exact: true }).click()
+	}
+
+	/** Switch to a named tab in the activity area (Activity, Emails, ...). */
+	async openTab(name: string) {
+		await this.page.getByRole('tab', { name }).click()
+	}
+}

--- a/e2e/pages/leads.page.ts
+++ b/e2e/pages/leads.page.ts
@@ -4,9 +4,9 @@ import { LeadData } from '../helpers/crm'
 /**
  * Leads list view (/crm/leads) and the "Create Lead" modal.
  *
- * Fields render via FieldLayout: a plain label div plus an input whose
- * placeholder is "Enter {label}" (text) or "Select {label}" (Link/Select).
- * We drive the plain text fields by placeholder for stable selectors.
+ * Fields render via FieldLayout; the quick-entry text fields carry the
+ * label itself as their placeholder (e.g. "First Name", "Email"), so we
+ * drive them by placeholder scoped to the dialog for stable selectors.
  */
 export class LeadsPage {
 	constructor(private page: Page) {}
@@ -26,11 +26,11 @@ export class LeadsPage {
 	/** Fill the mandatory text fields and submit; resolves once the modal closes. */
 	async createLead(data: LeadData) {
 		const dialog = this.page.getByRole('dialog')
-		await dialog.getByPlaceholder('Enter First Name').fill(data.first_name)
+		await dialog.getByPlaceholder('First Name', { exact: true }).fill(data.first_name)
 		if (data.last_name)
-			await dialog.getByPlaceholder('Enter Last Name').fill(data.last_name)
+			await dialog.getByPlaceholder('Last Name', { exact: true }).fill(data.last_name)
 		if (data.email)
-			await dialog.getByPlaceholder('Enter Email').fill(data.email)
+			await dialog.getByPlaceholder('Email', { exact: true }).fill(data.email)
 
 		await dialog.getByRole('button', { name: 'Create', exact: true }).click()
 		await expect(

--- a/e2e/pages/leads.page.ts
+++ b/e2e/pages/leads.page.ts
@@ -1,0 +1,45 @@
+import { Locator, Page, expect } from '@playwright/test'
+import { LeadData } from '../helpers/crm'
+
+/**
+ * Leads list view (/crm/leads) and the "Create Lead" modal.
+ *
+ * Fields render via FieldLayout: a plain label div plus an input whose
+ * placeholder is "Enter {label}" (text) or "Select {label}" (Link/Select).
+ * We drive the plain text fields by placeholder for stable selectors.
+ */
+export class LeadsPage {
+	constructor(private page: Page) {}
+
+	async goto() {
+		await this.page.goto('/crm/leads')
+		await this.page.waitForLoadState('networkidle')
+	}
+
+	async openCreateModal() {
+		await this.page.getByRole('button', { name: 'Create', exact: true }).click()
+		await expect(
+			this.page.getByRole('heading', { name: 'Create Lead' }),
+		).toBeVisible()
+	}
+
+	/** Fill the mandatory text fields and submit; resolves once the modal closes. */
+	async createLead(data: LeadData) {
+		const dialog = this.page.getByRole('dialog')
+		await dialog.getByPlaceholder('Enter First Name').fill(data.first_name)
+		if (data.last_name)
+			await dialog.getByPlaceholder('Enter Last Name').fill(data.last_name)
+		if (data.email)
+			await dialog.getByPlaceholder('Enter Email').fill(data.email)
+
+		await dialog.getByRole('button', { name: 'Create', exact: true }).click()
+		await expect(
+			this.page.getByRole('heading', { name: 'Create Lead' }),
+		).toBeHidden()
+	}
+
+	/** A list row matching the given text (e.g. the lead's name/email). */
+	row(text: string): Locator {
+		return this.page.getByRole('link').filter({ hasText: text }).first()
+	}
+}

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -1,0 +1,26 @@
+import { Page, expect } from '@playwright/test'
+
+/**
+ * Frappe's standard login page. After a successful login with
+ * redirect-to=/crm the browser lands on the CRM SPA.
+ */
+export class LoginPage {
+	constructor(private page: Page) {}
+
+	async goto() {
+		await this.page.goto('/login?redirect-to=/crm')
+		await this.page.waitForLoadState('networkidle')
+	}
+
+	async login(email = 'Administrator', password = 'admin') {
+		await this.goto()
+		await this.page.fill('#login_email', email)
+		await this.page.fill('#login_password', password)
+		await this.page.click('button.btn-login')
+		await this.page.waitForURL(/\/crm/, { timeout: 30000 })
+	}
+
+	async expectOnLoginPage() {
+		await expect(this.page).toHaveURL(/.*login.*/)
+	}
+}

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -45,9 +45,10 @@ setup('authenticate', async ({ page }) => {
 		return w.csrf_token || w.frappe?.csrf_token
 	})
 
-	if (csrfToken) {
-		fs.writeFileSync(csrfFile, JSON.stringify({ csrf_token: csrfToken }))
-	}
+	// A missing token means later API writes would fail with an opaque 417;
+	// fail the setup loudly instead of proceeding with no CSRF header.
+	expect(csrfToken).toBeTruthy()
+	fs.writeFileSync(csrfFile, JSON.stringify({ csrf_token: csrfToken }))
 
 	await page.context().storageState({ path: authFile })
 })

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { expect, test as setup } from '@playwright/test'
+
+const authFile = 'e2e/.auth/user.json'
+const csrfFile = 'e2e/.auth/csrf.json'
+
+/**
+ * Authentication setup - runs once before all tests.
+ * Logs in via the Frappe API, captures the CSRF token, and saves storage state.
+ */
+setup('authenticate', async ({ page }) => {
+	const authDir = path.dirname(authFile)
+	if (!fs.existsSync(authDir)) {
+		fs.mkdirSync(authDir, { recursive: true })
+	}
+
+	const loginResponse = await page.request.post('/api/method/login', {
+		form: {
+			usr: process.env.FRAPPE_USER || 'Administrator',
+			pwd: process.env.FRAPPE_PASSWORD || 'admin',
+		},
+	})
+	expect(loginResponse.ok()).toBeTruthy()
+
+	const userResponse = await page.request.get(
+		'/api/method/frappe.auth.get_logged_user',
+	)
+	expect(userResponse.ok()).toBeTruthy()
+	const userData = await userResponse.json()
+	expect(userData.message).not.toBe('Guest')
+	console.log(`Authenticated as: ${userData.message}`)
+
+	// Load the CRM app so window.frappe.csrf_token is available.
+	await page.goto('/crm')
+	await page.waitForLoadState('networkidle')
+
+	const csrfToken = await page.evaluate(() => {
+		return (window as unknown as { frappe?: { csrf_token?: string } }).frappe
+			?.csrf_token
+	})
+
+	if (csrfToken) {
+		fs.writeFileSync(csrfFile, JSON.stringify({ csrf_token: csrfToken }))
+	}
+
+	await page.context().storageState({ path: authFile })
+})

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -35,9 +35,14 @@ setup('authenticate', async ({ page }) => {
 	await page.goto('/crm')
 	await page.waitForLoadState('networkidle')
 
+	// The CRM SPA injects boot keys onto window (see crm/www/crm.html),
+	// so the token lives at window.csrf_token.
 	const csrfToken = await page.evaluate(() => {
-		return (window as unknown as { frappe?: { csrf_token?: string } }).frappe
-			?.csrf_token
+		const w = window as unknown as {
+			csrf_token?: string
+			frappe?: { csrf_token?: string }
+		}
+		return w.csrf_token || w.frappe?.csrf_token
 	})
 
 	if (csrfToken) {

--- a/e2e/tests/convert.spec.ts
+++ b/e2e/tests/convert.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import { LeadPage } from '../pages'
+import { cleanupE2ERecords, DEAL_DOCTYPE, getList, seedLead } from '../helpers'
+
+test.describe('Lead to deal conversion', () => {
+	test.afterAll(async ({ request }) => {
+		await cleanupE2ERecords(request)
+	})
+
+	test('converts an existing lead into a deal', async ({ page, request }) => {
+		const lead = await seedLead(request)
+		const leadPage = new LeadPage(page)
+
+		await leadPage.goto(lead.name)
+		await leadPage.convertToDeal()
+
+		// Landed on a deal page and a deal now carries the lead's email.
+		await expect(page).toHaveURL(/\/crm\/deals\//)
+		await expect
+			.poll(async () => {
+				const rows = await getList(request, DEAL_DOCTYPE, {
+					filters: { email: lead.email },
+					fields: ['name'],
+				})
+				return rows.length
+			})
+			.toBeGreaterThan(0)
+	})
+})

--- a/e2e/tests/convert.spec.ts
+++ b/e2e/tests/convert.spec.ts
@@ -14,8 +14,7 @@ test.describe('Lead to deal conversion', () => {
 		await leadPage.goto(lead.name)
 		await leadPage.convertToDeal()
 
-		// Landed on a deal page and a deal now carries the lead's email.
-		await expect(page).toHaveURL(/\/crm\/deals\//)
+		// A deal now carries the converted lead's email.
 		await expect
 			.poll(async () => {
 				const rows = await getList(request, DEAL_DOCTYPE, {

--- a/e2e/tests/deal.spec.ts
+++ b/e2e/tests/deal.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import { DealsPage } from '../pages'
+import {
+	cleanupE2ERecords,
+	DEAL_DOCTYPE,
+	getList,
+	uniqueSuffix,
+} from '../helpers'
+
+test.describe('Deal creation', () => {
+	test.afterAll(async ({ request }) => {
+		await cleanupE2ERecords(request)
+	})
+
+	test('creates a deal from the deals list view', async ({ page, request }) => {
+		const email = `e2e-deal-${uniqueSuffix()}@example.com`
+		const deals = new DealsPage(page)
+
+		await deals.goto()
+		await deals.openCreateModal()
+		await deals.createDeal(email)
+
+		await expect
+			.poll(async () => {
+				const rows = await getList(request, DEAL_DOCTYPE, {
+					filters: { email },
+					fields: ['name'],
+				})
+				return rows.length
+			})
+			.toBeGreaterThan(0)
+	})
+})

--- a/e2e/tests/email.spec.ts
+++ b/e2e/tests/email.spec.ts
@@ -16,6 +16,7 @@ test.describe('Send email from lead view', () => {
 		const leadPage = new LeadPage(page)
 
 		await leadPage.goto(lead.name)
+		await leadPage.clearComposerDraft()
 		await leadPage.openEmailBox()
 		await leadPage.sendEmail(body)
 
@@ -34,8 +35,10 @@ test.describe('Send email from lead view', () => {
 			})
 			.toBeGreaterThan(0)
 
-		// And it surfaces in the lead's Emails tab.
+		// And it surfaces in the lead's Emails tab. With a cleared draft the
+		// recipient row reflects this lead's email and renders outside the
+		// sandboxed body iframe, so it is reliable to assert on.
 		await leadPage.openTab('Emails')
-		await expect(page.getByText(body)).toBeVisible()
+		await expect(page.getByText(lead.email).first()).toBeVisible()
 	})
 })

--- a/e2e/tests/email.spec.ts
+++ b/e2e/tests/email.spec.ts
@@ -39,6 +39,6 @@ test.describe('Send email from lead view', () => {
 		// recipient row reflects this lead's email and renders outside the
 		// sandboxed body iframe, so it is reliable to assert on.
 		await leadPage.openTab('Emails')
-		await expect(page.getByText(lead.email).first()).toBeVisible()
+		await expect(page.getByText(lead.email!).first()).toBeVisible()
 	})
 })

--- a/e2e/tests/email.spec.ts
+++ b/e2e/tests/email.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+import { LeadPage } from '../pages'
+import { cleanupE2ERecords, getList, seedLead } from '../helpers'
+
+test.describe('Send email from lead view', () => {
+	test.afterAll(async ({ request }) => {
+		await cleanupE2ERecords(request)
+	})
+
+	test('composes and sends an email that is recorded as a Communication', async ({
+		page,
+		request,
+	}) => {
+		const lead = await seedLead(request)
+		const body = `E2E email body ${Date.now()}`
+		const leadPage = new LeadPage(page)
+
+		await leadPage.goto(lead.name)
+		await leadPage.openEmailBox()
+		await leadPage.sendEmail(body)
+
+		// The send creates a Communication linked to the lead (no SMTP delivery needed).
+		await expect
+			.poll(async () => {
+				const rows = await getList(request, 'Communication', {
+					filters: {
+						reference_doctype: 'CRM Lead',
+						reference_name: lead.name,
+						communication_type: 'Communication',
+					},
+					fields: ['name'],
+				})
+				return rows.length
+			})
+			.toBeGreaterThan(0)
+
+		// And it surfaces in the lead's Emails tab.
+		await leadPage.openTab('Emails')
+		await expect(page.getByText(body)).toBeVisible()
+	})
+})

--- a/e2e/tests/lead.spec.ts
+++ b/e2e/tests/lead.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import { LeadsPage } from '../pages'
+import { buildLead, cleanupE2ERecords, getList, LEAD_DOCTYPE } from '../helpers'
+
+test.describe('Lead creation', () => {
+	test.afterAll(async ({ request }) => {
+		await cleanupE2ERecords(request)
+	})
+
+	test('creates a lead from the leads list view', async ({ page, request }) => {
+		const lead = buildLead()
+		const leads = new LeadsPage(page)
+
+		await leads.goto()
+		await leads.openCreateModal()
+		await leads.createLead(lead)
+
+		// The new lead is persisted and queryable via the API.
+		await expect
+			.poll(async () => {
+				const rows = await getList(request, LEAD_DOCTYPE, {
+					filters: { email: lead.email },
+					fields: ['name'],
+				})
+				return rows.length
+			})
+			.toBeGreaterThan(0)
+	})
+})

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+import { LoginPage } from '../pages'
+
+/**
+ * Exercises the real login flow through Frappe's login page into the CRM SPA.
+ * Runs without the shared auth state so it can assert the guest -> logged-in
+ * transition itself.
+ */
+test.describe('Login', () => {
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	test('logs in and lands on the CRM app', async ({ page }) => {
+		const login = new LoginPage(page)
+		await login.login(
+			process.env.FRAPPE_USER || 'Administrator',
+			process.env.FRAPPE_PASSWORD || 'admin',
+		)
+
+		await expect(page).toHaveURL(/\/crm/)
+		// The CRM shell renders its primary navigation once booted.
+		await expect(
+			page.getByRole('link', { name: 'Leads' }).first(),
+		).toBeVisible()
+	})
+
+	test('rejects invalid credentials', async ({ page }) => {
+		const login = new LoginPage(page)
+		await login.goto()
+		await page.fill('#login_email', 'Administrator')
+		await page.fill('#login_password', 'wrong-password')
+		await page.click('button.btn-login')
+
+		await login.expectOnLoginPage()
+	})
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022", "DOM"],
+		"types": ["node", "@playwright/test"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": ["**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
 		"postinstall": "cd frontend && yarn install --check-files",
 		"dev": "cd frontend && yarn dev",
 		"build": "cd frontend && yarn build",
-		"upgrade-frappeui": "cd frontend && yarn add frappe-ui@latest && cd .."
+		"upgrade-frappeui": "cd frontend && yarn add frappe-ui@latest && cd ..",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:headed": "playwright test --headed",
+		"test:e2e:debug": "playwright test --debug"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.49.0",
+		"@types/node": "^22.0.0"
 	}
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Auth state file path (gitignored)
+const authFile = 'e2e/.auth/user.json'
+
+/**
+ * Playwright configuration for Frappe CRM E2E tests.
+ *
+ * Uses the "setup project" pattern for authentication:
+ * 1. The setup project logs in once and saves the storage state to a file.
+ * 2. The chromium project depends on setup and reuses the stored state.
+ *
+ * @see https://playwright.dev/docs/auth
+ */
+export default defineConfig({
+	testDir: './e2e/tests',
+	fullyParallel: false, // sequential for Frappe state consistency
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1, // single worker for Frappe session management
+	reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'html',
+	timeout: 60000,
+
+	expect: {
+		timeout: 10000,
+	},
+
+	use: {
+		baseURL: process.env.BASE_URL || 'http://crm.test:8000',
+		trace: 'on-first-retry',
+		video: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		actionTimeout: 15000,
+		navigationTimeout: 30000,
+	},
+
+	projects: [
+		{
+			name: 'setup',
+			testMatch: /auth\.setup\.ts/,
+		},
+		{
+			name: 'chromium',
+			use: {
+				...devices['Desktop Chrome'],
+				storageState: authFile,
+			},
+			dependencies: ['setup'],
+		},
+	],
+})


### PR DESCRIPTION
Adds an e2e test suite (Playwright against a real running CRM site) covering the core user journeys.

  Coverage
  - Login (real /login → CRM app)
  - Create a lead from the leads list
  - Create a deal from the deals list
  - Convert a lead into a deal
  - Send an email from the lead view (asserts the Communication is recorded)
