### PR TITLE
fix: validate lead first name before creation

### DIFF
--- a/frontend/src/components/Modals/LeadModal.vue
+++ b/frontend/src/components/Modals/LeadModal.vue
@@ -125,10 +125,20 @@ async function createNewLead() {
     {
       validate() {
         error.value = null
-        if (!lead.doc.first_name) {
+        const firstName = lead.doc.first_name?.trim()
+
+        if (!firstName) {
           error.value = __('First Name is mandatory')
           return error.value
         }
+
+        if (!/[\p{L}]/u.test(firstName)) {
+          error.value = __('First Name must contain at least one letter')
+          return error.value
+        }
+        
+        lead.doc.first_name = firstName
+
         if (lead.doc.annual_revenue) {
           if (typeof lead.doc.annual_revenue === 'string') {
             lead.doc.annual_revenue = lead.doc.annual_revenue.replace(/,/g, '')


### PR DESCRIPTION
## Summary

This PR adds frontend validation for the **First Name** field in the Lead quick entry form.

## Changes

- Ensure the First Name field is not empty or whitespace-only.
- Require the First Name to contain at least one alphabetic character.
- Continue allowing valid names containing spaces, punctuation, or numbers (e.g. `O'Connor`, `Jean-Luc`, `R2D2`, `A.P.J.`).

## Testing

Verified the following cases:

### Accepted
- John
- Jason Sanjay
- O'Connor
- Jean-Luc
- A.P.J.
- R2D2
- தமிழ்
- 张伟
- أحمد

### Rejected
- Empty input
- Whitespace-only input
- 123
- ###
- @@@
- ...