### PR TITLE
fix: remove orphaned crm.api.event scheduler hooks

### DIFF
--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -213,13 +213,9 @@ doc_events = {
 # ---------------
 
 scheduler_events = {
-	"all": ["crm.api.event.trigger_offset_event_notifications"],
-	"hourly": ["crm.api.event.trigger_hourly_event_notifications"],
 	"daily": [
-		"crm.api.event.trigger_daily_event_notifications",
 		"crm.fcrm.doctype.crm_view_settings.crm_view_settings.clear_old_versions",
 	],
-	"weekly": ["crm.api.event.trigger_weekly_event_notifications"],
 	"daily_long": ["crm.lead_syncing.background_sync.sync_leads_from_sources_daily"],
 	"hourly_long": ["crm.lead_syncing.background_sync.sync_leads_from_sources_hourly"],
 	"monthly_long": ["crm.lead_syncing.background_sync.sync_leads_from_sources_monthly"],


### PR DESCRIPTION
## Problem

On every `bench migrate` (and `install-app crm`) the **"Syncing jobs"** step fails on the release line:

```
crm.api.event.trigger_offset_event_notifications is not a valid method: No module named 'crm.api.event'
crm.api.event.trigger_hourly_event_notifications  is not a valid method: No module named 'crm.api.event'
crm.api.event.trigger_daily_event_notifications   is not a valid method: No module named 'crm.api.event'
crm.api.event.trigger_weekly_event_notifications  is not a valid method: No module named 'crm.api.event'
```

`crm/hooks.py` declares four `scheduler_events` pointing at `crm.api.event.*`, but `crm/api/event.py` **does not exist on this branch** — the event-notification feature (and its module) lives only on `develop` (#1501), including all of its frontend surface.

## Root cause

These four hook lines were never an intentional backport. They arrived via a botched conflict resolution while cherry-picking #2235 (`clear_old_versions`) onto the release line: the merge conflict in `crm/hooks.py` was committed with markers, then "resolved" keeping the wrong side — dragging in the `crm.api.event.*` entries. The only thing #2235 actually needed was `clear_old_versions`.

There is **no other trace** of the event feature on this branch (no `event.py`, no frontend, no other references) — the hooks are pure dangling pointers.

## Fix

Remove the four orphaned `crm.api.event.*` scheduler entries; keep `clear_old_versions` (what #2235 intended).

## Testing

Fresh `bench new-site … --install-app crm` from this branch: the "Syncing jobs" step now runs clean with no `crm.api.event` error, and only the expected jobs register (`clear_old_versions` + the `lead_syncing.background_sync.*` jobs).

> [!NOTE] 
>  this is a **bug fix**, not a decision to drop the feature. If event notifications are wanted on the release line, that should be a deliberate, full backport of #1501 (backend + frontend), not these dangling hooks. **Same reason for why this is not a backported PR**