### PR TITLE
chore: Patch Release v1.77.1

### DIFF
--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -213,13 +213,9 @@ doc_events = {
 # ---------------
 
 scheduler_events = {
-	"all": ["crm.api.event.trigger_offset_event_notifications"],
-	"hourly": ["crm.api.event.trigger_hourly_event_notifications"],
 	"daily": [
-		"crm.api.event.trigger_daily_event_notifications",
 		"crm.fcrm.doctype.crm_view_settings.crm_view_settings.clear_old_versions",
 	],
-	"weekly": ["crm.api.event.trigger_weekly_event_notifications"],
 	"daily_long": ["crm.lead_syncing.background_sync.sync_leads_from_sources_daily"],
 	"hourly_long": ["crm.lead_syncing.background_sync.sync_leads_from_sources_hourly"],
 	"monthly_long": ["crm.lead_syncing.background_sync.sync_leads_from_sources_monthly"],


### PR DESCRIPTION
Removes `crm.api.event` scheduler hooks, that were accidentally pushed in main-hotfix due to improper merge conflict resolution. For more check https://github.com/frappe/crm/pull/2405