### PR TITLE
fix: pass frappe._dict to get_item_price in Item sync (fixes AttributeError on Item insert)

### DIFF
--- a/crm/integrations/erpnext/item.py
+++ b/crm/integrations/erpnext/item.py
@@ -23,7 +23,7 @@ def get_item_price_rate(item_code: str, uom: str | None = None):
 	price_list = frappe.db.get_single_value("Selling Settings", "selling_price_list")
 	if not price_list:
 		return None
-	pctx = {"price_list": price_list, "uom": uom, "transaction_date": frappe.utils.nowdate()}
+	pctx = frappe._dict({"price_list": price_list, "uom": uom, "transaction_date": frappe.utils.nowdate()})
 	rows = get_item_price(pctx, item_code)
 	return rows[0].price_list_rate if rows else None
 


### PR DESCRIPTION
### Problem

`crm/integrations/erpnext/item.py::get_item_price_rate()` builds a **plain `dict`** and passes it to ERPNext's `get_item_price()`:

```python
pctx = {"price_list": price_list, "uom": uom, "transaction_date": frappe.utils.nowdate()}
rows = get_item_price(pctx, item_code)
```

But `erpnext.stock.get_item_details.get_item_price` is typed `pctx: frappe._dict` and reads it with **attribute access** (`pctx.price_list`, `pctx.uom`, `pctx.batch_no`, `pctx.customer`, `pctx.supplier`). A plain dict has no such attributes:

```
AttributeError: 'dict' object has no attribute 'price_list'
```

Because `get_item_price_rate` is called from `_catalogue_data()` in both `after_insert` and `on_update`, **every Item insert/update rolls back** whenever ERPNext sync is enabled and a `selling_price_list` is configured — Items simply cannot be created (via UI or REST).

### Fix

Wrap the payload in `frappe._dict`, which supports attribute access and returns `None` for the optional keys `get_item_price` probes:

```python
pctx = frappe._dict({"price_list": price_list, "uom": uom, "transaction_date": frappe.utils.nowdate()})
```

One line, no behavior change beyond fixing the crash.

### Testing

On a bench with `Selling Settings.selling_price_list` set, calling `get_item_price_rate(item_code, uom)` raised the `AttributeError` before this change and returns the correct `price_list_rate` after it; Item inserts with ERPNext sync enabled succeed again.
