### PR TITLE
fix: remove deprecated pulse api

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -16,9 +16,8 @@ async function shouldCapturePersona() {
   })
   if (captured) return false
   // The wizard only feeds telemetry; skip it entirely if the user opted out.
-  const { enabled } = await call(
-    'frappe.utils.telemetry.pulse.client.boot_config',
-  )
+  const { enabled } =
+    (await call('frappe.utils.telemetry.pulse.client.boot_config')) || {}
   return !!enabled
 }
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -16,10 +16,10 @@ async function shouldCapturePersona() {
   })
   if (captured) return false
   // The wizard only feeds telemetry; skip it entirely if the user opted out.
-  const telemetryEnabled = await call(
-    'frappe.utils.telemetry.pulse.client.is_enabled',
+  const { enabled } = await call(
+    'frappe.utils.telemetry.pulse.client.boot_config',
   )
-  return !!telemetryEnabled
+  return !!enabled
 }
 
 const routes = [


### PR DESCRIPTION
removes usage of `pulse.client.is_enabled` from telemetry and uses `pulse.client.boot_config` instead