### PR TITLE
fix: ERPNext Item sync fails in ERPNext v15

### DIFF
--- a/crm/integrations/erpnext/item.py
+++ b/crm/integrations/erpnext/item.py
@@ -25,7 +25,11 @@ def get_item_price_rate(item_code: str, uom: str | None = None):
 		return None
 	pctx = frappe._dict({"price_list": price_list, "uom": uom, "transaction_date": frappe.utils.nowdate()})
 	rows = get_item_price(pctx, item_code)
-	return rows[0].price_list_rate if rows else None
+	if not rows:
+		return None
+	row = rows[0]
+
+	return row.price_list_rate if isinstance(row, dict) else row[1]
 
 
 def _catalogue_data(doc) -> dict:


### PR DESCRIPTION
when ERPNext integration is enabled, on every Item save, v15's get_item_price returns tuples  ie (query.run()), v16 returns dicts (query.run(as_dict=True)).  The patch reads `price_list_rate` by attribute when the row is dict (v16) and by index [1] when it's a tuple (v15), so Item save works on both. 

Relevant Error Traceback:
```
File "apps/crm/crm/integrations/erpnext/item.py", line 35, in _catalogue_data
      rate = get_item_price_rate(doc.name, doc.get("stock_uom"))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "apps/crm/crm/integrations/erpnext/item.py", line 28, in get_item_price_rate
      return rows[0].price_list_rate if rows else None
             ^^^^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'tuple' object has no attribute 'price_list_rate' this happens in ERPNext
  v15 {
      "exception": "AttributeError: 'tuple' object has no attribute 'price_list_rate'",
      "exc_type": "AttributeError",
      "_exc_source": "crm (app)"
  }
```