### PR TITLE
fix: translate remaining untranslated UI strings (empty states, Kanban)

### DIFF
--- a/frontend/src/components/IconPicker.vue
+++ b/frontend/src/components/IconPicker.vue
@@ -35,11 +35,11 @@
               <FormControl
                 v-model="search"
                 type="text"
-                placeholder="Search by keyword"
+                :placeholder="__('Search by keyword')"
                 :debounce="300"
               />
             </div>
-            <Button @click="setRandom">Random</Button>
+            <Button @click="setRandom">{{ __('Random') }}</Button>
           </div>
           <div class="w-96"></div>
           <div v-for="(emojis, group) in emojiGroups" :key="group" class="px-3">

--- a/frontend/src/components/Kanban/KanbanSettings.vue
+++ b/frontend/src/components/Kanban/KanbanSettings.vue
@@ -20,7 +20,7 @@
           <template #target="{ togglePopover }">
             <Button
               class="w-full !justify-start"
-              :label="columnField.label"
+              :label="__(columnField.label)"
               @click="togglePopover()"
             />
           </template>
@@ -36,7 +36,7 @@
           <template #target="{ togglePopover }">
             <Button
               class="w-full !justify-start"
-              :label="titleField.label"
+              :label="__(titleField.label)"
               @click="togglePopover()"
             />
           </template>
@@ -59,7 +59,7 @@
             >
               <div class="flex items-center gap-2">
                 <DragVerticalIcon class="h-3.5 cursor-grab" />
-                <div>{{ field.label }}</div>
+                <div>{{ __(field.label) }}</div>
               </div>
               <div>
                 <Button
@@ -82,7 +82,7 @@
           </template>
           <template #item-label="{ option }">
             <div class="flex flex-col gap-1 text-ink-gray-9">
-              <div>{{ option.label }}</div>
+              <div>{{ __(option.label) }}</div>
               <div class="text-ink-gray-4 text-sm">
                 {{ `${option.fieldname} - ${option.fieldtype}` }}
               </div>

--- a/frontend/src/components/Kanban/KanbanView.vue
+++ b/frontend/src/components/Kanban/KanbanView.vue
@@ -50,7 +50,7 @@
                   </div>
                 </template>
               </Popover>
-              <div class="text-ink-gray-9">{{ column.column.name }}</div>
+              <div class="text-ink-gray-9">{{ __(column.column.name) }}</div>
             </div>
             <div class="flex">
               <Dropdown :options="actions(column)">

--- a/frontend/src/components/ListViews/EmptyState.vue
+++ b/frontend/src/components/ListViews/EmptyState.vue
@@ -34,12 +34,12 @@ const props = defineProps({
 })
 
 const computedTitle = computed(() => {
-  return props.title ? props.title : __('No {0} Found', [__(props.name)])
+  return props.title ? __(props.title) : __('No {0} Found', [__(props.name)])
 })
 
 const computedDescription = computed(() => {
   return props.description
-    ? props.description
+    ? __(props.description)
     : __(
         'It appears that there are currently no {0} available. You can create more {0} by using the Create button.',
         [__(props.name)],

--- a/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
+++ b/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
@@ -38,9 +38,11 @@
             >
               <div>
                 {{
-                  documentRoutingOptions.find(
-                    (option) => option.value == assignmentRuleData.rule,
-                  )?.label
+                  __(
+                    documentRoutingOptions.find(
+                      (option) => option.value == assignmentRuleData.rule,
+                    )?.label,
+                  )
                 }}
               </div>
               <span class="lucide-chevron-down size-4" aria-hidden="true" />

--- a/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
+++ b/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
@@ -64,7 +64,7 @@
                 "
               >
                 <span>
-                  {{ option.label }}
+                  {{ __(option.label) }}
                 </span>
                 <span
                   v-if="assignmentRuleData.rule == option.value"

--- a/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
+++ b/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
@@ -41,7 +41,7 @@
                   __(
                     documentRoutingOptions.find(
                       (option) => option.value == assignmentRuleData.rule,
-                    )?.label,
+                    )?.label || '',
                   )
                 }}
               </div>

--- a/frontend/src/components/Settings/Profile/UserEmailSettings.vue
+++ b/frontend/src/components/Settings/Profile/UserEmailSettings.vue
@@ -39,7 +39,7 @@
         <TextEditor
           editor-class="prose-sm min-h-28 max-w-full border rounded-b-lg border-t-0 p-2 border-outline-elevation-2"
           :content="user.doc.email_signature"
-          placeholder="Type something..."
+          :placeholder="__('Type something...')"
           :bubbleMenu="true"
           :fixed-menu="true"
           @change="(val) => (user.doc.email_signature = val)"


### PR DESCRIPTION
## Summary
- `EmptyState.vue`'s `computedTitle`/`computedDescription` returned an explicitly-passed `title`/`description` prop raw, without `__()` — only the `name`-based fallback text was translated. This silently broke translation for every call site that passes an explicit `title`/`description` instead of relying on the `name` fallback (Activities empty states, Notifications, SLA Policies, Lead Sources, Email Templates, Assignment Rules). Fixed by wrapping both props in `__()`.
- `IconPicker.vue`: search placeholder and "Random" button text were unwrapped literals.
- `AssignmentRules/AssigneeRules.vue`: the routing-option dropdown (`option.label`) was rendered raw in two places — the "currently selected" display and the list items in the open dropdown.
- `Settings/Profile/UserEmailSettings.vue`: email signature editor placeholder was unwrapped.
- `Kanban/KanbanView.vue`: column headers (`column.column.name`, i.e. the lead/deal status name) were rendered raw — fixes #2428.
- `Kanban/KanbanSettings.vue`: the Kanban Settings dialog (Column Field / Title Field / Fields Order / Add Field) rendered raw DocType field labels straight from field metadata, never through `__()`.

All fixes are the same shape: wrap an existing value in `__()`; no behavior change for English, no new strings introduced. Verified against a live ru/uk-localized deployment — Kanban columns, Kanban Settings dialog, and the empty-state messages listed above all rendered as English before this fix and localized correctly after.

(Re-opened against `develop` — the original PR targeted `main` and was auto-closed by Mergify. Also folds in a fix for a second `AssigneeRules.vue` occurrence caught by the greptile-apps review on that PR.)

## Test plan
- [x] Confirmed each affected string was previously bypassing `__()` (either passed as a static `title`/`description` prop to `EmptyState.vue`, or interpolated raw in a template)
- [x] Built and deployed to a live CRM instance with custom ru/uk Translation records; visually confirmed each string now renders translated
- [x] No new strings added, no logic/behavior changes — pure `__()` wrapping

Fixes #2428