### PR TITLE
feat: tint Kanban column background with the column's color

### DIFF
--- a/frontend/src/components/Kanban/KanbanView.vue
+++ b/frontend/src/components/Kanban/KanbanView.vue
@@ -11,7 +11,7 @@
       <template #item="{ element: column }">
         <div
           v-if="!column.column.delete"
-          class="flex flex-col gap-2.5 min-w-72 w-72 rounded-lg p-2.5"
+          class="flex flex-col gap-2.5 min-w-72 w-72 hover:bg-surface-gray-2 rounded-lg p-2.5"
           :class="parseBgColor(column.column.color)"
         >
           <div class="flex gap-2 items-center group justify-between">

--- a/frontend/src/components/Kanban/KanbanView.vue
+++ b/frontend/src/components/Kanban/KanbanView.vue
@@ -11,7 +11,8 @@
       <template #item="{ element: column }">
         <div
           v-if="!column.column.delete"
-          class="flex flex-col gap-2.5 min-w-72 w-72 hover:bg-surface-gray-2 rounded-lg p-2.5"
+          class="flex flex-col gap-2.5 min-w-72 w-72 rounded-lg p-2.5"
+          :class="parseBgColor(column.column.color)"
         >
           <div class="flex gap-2 items-center group justify-between">
             <div class="flex items-center text-base">
@@ -179,7 +180,7 @@
 import RefreshIcon from '@/components/Icons/RefreshIcon.vue'
 import Autocomplete from '@/components/frappe-ui/Autocomplete.vue'
 import IndicatorIcon from '@/components/Icons/IndicatorIcon.vue'
-import { isTouchScreenDevice, colors, parseColor } from '@/utils'
+import { isTouchScreenDevice, colors, parseColor, parseBgColor } from '@/utils'
 import Draggable from 'vuedraggable'
 import { Dropdown, Popover } from 'frappe-ui'
 import { computed } from 'vue'

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -433,6 +433,14 @@ export function parseColor(color) {
   return textColor
 }
 
+export function parseBgColor(color) {
+  if (!color) return ''
+  if (color == 'black') {
+    return '!bg-gray-100'
+  }
+  return `!bg-${color}-50`
+}
+
 export function isEmoji(str) {
   const emojiList = gemoji.map((emoji) => emoji.emoji)
   return emojiList.includes(str)


### PR DESCRIPTION
## Summary

Proposal from #2430 — a column's color (set via the existing color picker on each Kanban column) currently only tints the small indicator dot next to the column title. This tints the whole column background too, mirroring how the classic Desk Kanban board (`frappe/frappe/public/js/frappe/views/kanban/kanban_column.html`) already colors its column background from the same kind of indicator value.

Adds `parseBgColor()` next to the existing `parseColor()` in `frontend/src/utils/index.js` and applies it to the column container in `KanbanView.vue`, using the `!bg-` Tailwind pattern already covered by the project's safelist (`safelist: [{ pattern: /!(text|bg)-/, ... }]`) — no config changes needed.

```js
export function parseBgColor(color) {
  if (!color) return ''
  if (color == 'black') return '!bg-gray-100'
  return `!bg-${color}-50`
}
```

Flagging this as a feature/design proposal rather than a plain bugfix — happy to adjust the shade/opacity or scope it differently if maintainers have a preference, this is meant as a starting point for discussion with a working implementation attached.

(Re-opened against `develop` — the original PR targeted `main` and was auto-closed by Mergify. Also restores `hover:bg-surface-gray-2` on the column container, dropped by mistake in the first version and caught by the greptile-apps review — it was silently killing the hover highlight on columns with no color assigned.)

## Test plan
- [x] Verified live on a deployed CRM instance: columns now show a light background tint matching their assigned color, indicator dot unchanged
- [x] No behavior change for columns without an explicit color (falls back to no tint, same as before)
- [x] Hover highlight confirmed working again on uncolored columns

Relates to #2430