### PR TITLE
feat: render state options on address form when India Compliance is installed

### DIFF
--- a/crm/tests/test_state_options.py
+++ b/crm/tests/test_state_options.py
@@ -68,13 +68,9 @@ class TestGetBoot(FrappeTestCase):
 		self.assertIn("state_options", boot)
 		self.assertIsInstance(boot["state_options"], dict)
 
-	def test_boot_survives_state_options_failure(self):
-		# Even if the state lookup somehow raises, get_boot itself must succeed.
-		with patch("crm.www.crm.get_state_options", side_effect=Exception("boom")):
-			with self.assertRaises(Exception):
-				# Sanity: the mock does raise when called directly...
-				get_state_options()
-		# ...but get_state_options in production swallows errors, so boot is safe.
+	def test_boot_degrades_when_state_lookup_fails(self):
+		# The v15 boot-context concern: if get_installed_apps misbehaves, get_boot must
+		# still succeed and state_options must be an empty map (never break page load).
 		with patch("frappe.get_installed_apps", side_effect=Exception("boot context")):
 			boot = get_boot()
 		self.assertEqual(boot["state_options"], {})

--- a/crm/tests/test_state_options.py
+++ b/crm/tests/test_state_options.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from crm.www.crm import get_boot, get_state_options
+
+
+def _fake_india_compliance(states: dict) -> dict:
+	"""Build a fake `india_compliance.gst_india.constants` module tree for sys.modules.
+
+	`from india_compliance.gst_india.constants import INDIAN_STATES` imports each parent
+	package, so all three levels must be present.
+	"""
+	root = ModuleType("india_compliance")
+	gst = ModuleType("india_compliance.gst_india")
+	constants = ModuleType("india_compliance.gst_india.constants")
+	constants.INDIAN_STATES = states
+	return {
+		"india_compliance": root,
+		"india_compliance.gst_india": gst,
+		"india_compliance.gst_india.constants": constants,
+	}
+
+
+class TestGetStateOptions(FrappeTestCase):
+	def test_returns_a_dict(self):
+		# Never raises; always a dict regardless of what's installed.
+		self.assertIsInstance(get_state_options(), dict)
+
+	def test_empty_without_india_compliance(self):
+		with patch("frappe.get_installed_apps", return_value=["frappe", "crm"]):
+			self.assertEqual(get_state_options(), {})
+
+	def test_resilient_when_get_installed_apps_raises(self):
+		# The v15 boot-context concern: get_installed_apps blowing up must NOT break boot.
+		with patch("frappe.get_installed_apps", side_effect=Exception("boot context")):
+			self.assertEqual(get_state_options(), {})
+
+	def test_resilient_when_import_fails(self):
+		# App reported installed but constant import fails (e.g. version mismatch).
+		with patch("frappe.get_installed_apps", return_value=["frappe", "crm", "india_compliance"]):
+			# No fake module injected -> ImportError -> graceful {}.
+			self.assertEqual(get_state_options(), {})
+
+	def test_returns_states_when_app_installed(self):
+		states = {"Goa": "30", "Kerala": "32", "Punjab": "03"}
+		with (
+			patch(
+				"frappe.get_installed_apps",
+				return_value=["frappe", "crm", "india_compliance"],
+			),
+			patch.dict(sys.modules, _fake_india_compliance(states)),
+		):
+			result = get_state_options()
+		self.assertEqual(list(result.keys()), ["India"])
+		self.assertEqual(result["India"], ["Goa", "Kerala", "Punjab"])
+
+
+class TestGetBoot(FrappeTestCase):
+	def test_boot_includes_state_options_and_does_not_raise(self):
+		boot = get_boot()
+		self.assertIn("state_options", boot)
+		self.assertIsInstance(boot["state_options"], dict)
+
+	def test_boot_survives_state_options_failure(self):
+		# Even if the state lookup somehow raises, get_boot itself must succeed.
+		with patch("crm.www.crm.get_state_options", side_effect=Exception("boom")):
+			with self.assertRaises(Exception):
+				# Sanity: the mock does raise when called directly...
+				get_state_options()
+		# ...but get_state_options in production swallows errors, so boot is safe.
+		with patch("frappe.get_installed_apps", side_effect=Exception("boot context")):
+			boot = get_boot()
+		self.assertEqual(boot["state_options"], {})

--- a/crm/www/crm.py
+++ b/crm/www/crm.py
@@ -54,8 +54,33 @@ def get_boot():
 				"user": frappe.db.get_value("User", frappe.session.user, "time_zone")
 				or get_system_timezone(),
 			},
+			"state_options": get_state_options(),
 		}
 	)
+
+
+def get_state_options() -> dict[str, list[str]]:
+	"""Country -> list of states, so the frontend can render a state dropdown.
+
+	Sourced from India Compliance's own constant when that app is installed, so the
+	options stay in sync with the desk. Returns an empty map (state field stays free
+	text) on any failure.
+
+	This runs inside ``get_boot``, so it must never raise — a failure here would break
+	the whole CRM page load. ``frappe.get_installed_apps`` can return `[]` or raise in
+	unauthenticated/boot contexts (notably on v15), so the lookup is wrapped defensively.
+	"""
+	try:
+		if "india_compliance" not in frappe.get_installed_apps():
+			return {}
+
+		from india_compliance.gst_india.constants import INDIAN_STATES
+
+		return {"India": list(INDIAN_STATES)}
+	except Exception:
+		# Degrade silently to free-text: this runs in boot, so the except branch
+		# must not do anything that can itself raise (e.g. logging to a missing dir).
+		return {}
 
 
 def get_default_route():

--- a/frontend/src/components/FieldLayout/Field.vue
+++ b/frontend/src/components/FieldLayout/Field.vue
@@ -321,7 +321,10 @@ import {
 } from '@/utils'
 import { flt, formatNumber, formatCurrency } from '@/utils/numberFormat.js'
 import { getMeta } from '@/stores/meta'
-import { parseLinkFilters } from '@/utils/fieldTransforms'
+import {
+  parseLinkFilters,
+  applyStateFieldOptions,
+} from '@/utils/fieldTransforms'
 import { usersStore } from '@/stores/users'
 import { useDocument } from '@/data/document'
 
@@ -459,6 +462,14 @@ const field = computed(() => {
   if (overrides) {
     Object.assign(field, overrides)
   }
+
+  // ── Country-driven state dropdown (e.g. India Compliance installed) ──
+  field = applyStateFieldOptions(
+    field,
+    data.value,
+    doctype,
+    window.state_options,
+  )
 
   if (field.fieldtype == 'Select' && typeof field.options === 'string') {
     field.options = field.options.split('\n').map((option) => {

--- a/frontend/src/utils/fieldTransforms.js
+++ b/frontend/src/utils/fieldTransforms.js
@@ -80,10 +80,11 @@ export function processField(rawField, options = {}) {
  * Otherwise the field is returned unchanged (free text).
  *
  * Autocomplete (not Select) is used so a legacy free-text state value that isn't in
- * the list is still preserved.
+ * the list is still preserved. Such a value is also prepended to the options, so the
+ * Combobox shows its label rather than a blank (it derives the label from options).
  *
  * @param {object} field - processed field object (from processField)
- * @param {object} doc - the document data (reads `doc.country`)
+ * @param {object} doc - the document data (reads `doc.country` and `doc.state`)
  * @param {string} doctype - the field's doctype; only 'Address' is enhanced
  * @param {object} [stateOptionsByCountry] - { India: ['Goa', ...] } from the boot
  * @returns {object} the field, possibly with fieldtype='Autocomplete' + options set
@@ -98,8 +99,13 @@ export function applyStateFieldOptions(
     return field
   }
 
-  const options = stateOptionsByCountry?.[doc?.country]
-  if (!options?.length) return field
+  const states = stateOptionsByCountry?.[doc?.country]
+  if (!states?.length) return field
+
+  // Keep an existing out-of-list value visible (the Combobox labels by matching options).
+  const current = doc?.state
+  const options =
+    current && !states.includes(current) ? [current, ...states] : states
 
   return { ...field, fieldtype: 'Autocomplete', options }
 }

--- a/frontend/src/utils/fieldTransforms.js
+++ b/frontend/src/utils/fieldTransforms.js
@@ -72,6 +72,39 @@ export function processField(rawField, options = {}) {
 }
 
 /**
+ * Turn the Address `state` field into a country-driven Autocomplete.
+ *
+ * When a regional app (e.g. India Compliance) is installed, the CRM boot exposes a
+ * `{ country: [states] }` map. If the address's country has a known state list, the
+ * plain-text `state` field is rendered as a searchable dropdown of those states.
+ * Otherwise the field is returned unchanged (free text).
+ *
+ * Autocomplete (not Select) is used so a legacy free-text state value that isn't in
+ * the list is still preserved.
+ *
+ * @param {object} field - processed field object (from processField)
+ * @param {object} doc - the document data (reads `doc.country`)
+ * @param {string} doctype - the field's doctype; only 'Address' is enhanced
+ * @param {object} [stateOptionsByCountry] - { India: ['Goa', ...] } from the boot
+ * @returns {object} the field, possibly with fieldtype='Autocomplete' + options set
+ */
+export function applyStateFieldOptions(
+  field,
+  doc,
+  doctype,
+  stateOptionsByCountry,
+) {
+  if (!field || doctype !== 'Address' || field.fieldname !== 'state') {
+    return field
+  }
+
+  const options = stateOptionsByCountry?.[doc?.country]
+  if (!options?.length) return field
+
+  return { ...field, fieldtype: 'Autocomplete', options }
+}
+
+/**
  * Find mandatory fields that are missing values in the doc.
  * Respects script overrides for reqd and hidden.
  *

--- a/frontend/tests/unit/applyStateFieldOptions.test.js
+++ b/frontend/tests/unit/applyStateFieldOptions.test.js
@@ -15,6 +15,26 @@ describe('applyStateFieldOptions', () => {
     expect(result.options).toEqual(['Goa', 'Kerala', 'Punjab'])
   })
 
+  it('prepends an out-of-list current state value so it stays visible', () => {
+    const result = applyStateFieldOptions(
+      stateField,
+      { country: 'India', state: 'California' },
+      'Address',
+      stateOptions,
+    )
+    expect(result.options).toEqual(['California', 'Goa', 'Kerala', 'Punjab'])
+  })
+
+  it('does not duplicate a current value already in the list', () => {
+    const result = applyStateFieldOptions(
+      stateField,
+      { country: 'India', state: 'Goa' },
+      'Address',
+      stateOptions,
+    )
+    expect(result.options).toEqual(['Goa', 'Kerala', 'Punjab'])
+  })
+
   it('does not mutate the input field', () => {
     applyStateFieldOptions(
       stateField,

--- a/frontend/tests/unit/applyStateFieldOptions.test.js
+++ b/frontend/tests/unit/applyStateFieldOptions.test.js
@@ -1,0 +1,93 @@
+import { applyStateFieldOptions } from '@/utils/fieldTransforms'
+
+const stateField = { fieldname: 'state', fieldtype: 'Data', label: 'State' }
+const stateOptions = { India: ['Goa', 'Kerala', 'Punjab'] }
+
+describe('applyStateFieldOptions', () => {
+  it('turns the Address state field into an Autocomplete for a known country', () => {
+    const result = applyStateFieldOptions(
+      stateField,
+      { country: 'India' },
+      'Address',
+      stateOptions,
+    )
+    expect(result.fieldtype).toBe('Autocomplete')
+    expect(result.options).toEqual(['Goa', 'Kerala', 'Punjab'])
+  })
+
+  it('does not mutate the input field', () => {
+    applyStateFieldOptions(
+      stateField,
+      { country: 'India' },
+      'Address',
+      stateOptions,
+    )
+    expect(stateField.fieldtype).toBe('Data')
+    expect(stateField.options).toBeUndefined()
+  })
+
+  it('leaves the field unchanged when the country has no state list', () => {
+    const result = applyStateFieldOptions(
+      stateField,
+      { country: 'France' },
+      'Address',
+      stateOptions,
+    )
+    expect(result).toBe(stateField)
+  })
+
+  it('leaves the field unchanged when there is no country', () => {
+    expect(
+      applyStateFieldOptions(stateField, {}, 'Address', stateOptions),
+    ).toBe(stateField)
+    expect(
+      applyStateFieldOptions(stateField, null, 'Address', stateOptions),
+    ).toBe(stateField)
+  })
+
+  it('leaves the field unchanged when no options map is provided (app absent)', () => {
+    expect(
+      applyStateFieldOptions(
+        stateField,
+        { country: 'India' },
+        'Address',
+        undefined,
+      ),
+    ).toBe(stateField)
+    expect(
+      applyStateFieldOptions(stateField, { country: 'India' }, 'Address', {}),
+    ).toBe(stateField)
+  })
+
+  it('only applies to the Address doctype', () => {
+    const result = applyStateFieldOptions(
+      stateField,
+      { country: 'India' },
+      'CRM Lead',
+      stateOptions,
+    )
+    expect(result).toBe(stateField)
+  })
+
+  it('only applies to the state field', () => {
+    const cityField = { fieldname: 'city', fieldtype: 'Data' }
+    const result = applyStateFieldOptions(
+      cityField,
+      { country: 'India' },
+      'Address',
+      stateOptions,
+    )
+    expect(result).toBe(cityField)
+  })
+
+  it('handles a nullish field safely', () => {
+    expect(
+      applyStateFieldOptions(
+        null,
+        { country: 'India' },
+        'Address',
+        stateOptions,
+      ),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
The Address state field is plain free text in Frappe/CRM, while India Compliance turns it into a state dropdown on the desk via client-side JS that the CRM SPA never runs. Bring the same behaviour to the CRM address form: expose a country -> states map in the boot (sourced from India Compliance's own INDIAN_STATES constant when the app is installed) and render the Address `state` field as an Autocomplete of those states.

The boot lookup is wrapped defensively so it can never break page load if get_installed_apps misbehaves in an unauthenticated/boot context.