### PR TITLE
fix: date 'Between' filter throws 'split is not a function'

### DIFF
--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -519,7 +519,11 @@ function clearfilter(close) {
 function updateValue(value, filter) {
   value = value.target ? value.target.value : value
   if (filter.operator === 'between') {
-    filter.value = [value.split(',')[0], value.split(',')[1]]
+    // DateRangePicker emits a [from, to] array; tolerate a legacy "from,to" string too
+    if (typeof value === 'string') {
+      value = value.split(',').map((v) => v.trim())
+    }
+    filter.value = value
   } else {
     filter.value = value
   }


### PR DESCRIPTION
## Problem

Applying a date **"Between"** filter (e.g. *Created On*) throws and the filter never applies:

```
TypeError: x.split is not a function
    at me (Filter.vue:522)
    at onChange (Filter.vue:109)
```

Fixes #2438

## Cause

For a date field with the `between` operator, the value control is `DateRangePicker`. Since `frappe-ui@1.0.0-beta.19` (the pinned version), `DateRangePicker` emits its `change` value as a **`[from, to]` array** (`DateRangeValue = [string, string] | []`).

`updateValue()` in `Filter.vue` still assumed a comma-separated **string** and called `value.split(',')` on it — which throws on an array.

```js
if (filter.operator === 'between') {
  filter.value = [value.split(',')[0], value.split(',')[1]]   // value is an array → crash
}
```

## Fix

Store the array directly, while still tolerating a legacy `"from,to"` string:

```js
if (filter.operator === 'between') {
  if (typeof value === 'string') {
    value = value.split(',').map((v) => v.trim())
  }
  filter.value = value
}
```

The resulting `filter.value` shape (a two-element `[from, to]` array) is unchanged, so the backend between-filter contract is unaffected.

## Testing

- Reproduced the crash on `develop`: Leads → Filter → *Created On* → **Between** → pick a range → `split is not a function`.
- With the fix, the same flow applies the filter cleanly with no console error.
- Verified other operators (Equals, Like, In) and non-date fields are unaffected (the change is scoped to the `between` branch).
