### PR TITLE
fix: show "Save" instead of "Create" on new email template button

### DIFF
--- a/frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue
+++ b/frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue
@@ -18,8 +18,7 @@
           <span class="text-sm text-ink-gray-7">{{ __('Enabled') }}</span>
         </div>
         <Button
-          :label="__('Update')"
-          icon-left="lucide-plus"
+          :label="__('Save')"
           variant="solid"
           :disabled="!dirty"
           :loading="renameDoc.loading || templates.setValue.loading"

--- a/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
+++ b/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
@@ -20,8 +20,7 @@
           <span class="text-sm text-ink-gray-7">{{ __('Enabled') }}</span>
         </div>
         <Button
-          :label="templateData?.name ? __('Duplicate') : __('Create')"
-          icon-left="lucide-plus"
+          :label="templateData?.name ? __('Duplicate') : __('Save')"
           variant="solid"
           @click="createTemplate"
         />

--- a/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
+++ b/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
@@ -21,6 +21,7 @@
         </div>
         <Button
           :label="templateData?.name ? __('Duplicate') : __('Save')"
+          :icon-left="templateData?.name ? 'lucide-copy' : undefined"
           variant="solid"
           @click="createTemplate"
         />


### PR DESCRIPTION
## Problem

When creating a new email template (**Settings → Email Templates → New**), the primary button is labelled **"Create"** with a plus (`lucide-plus`) icon. Every other CRM settings editor — SLA Policies, Assignment Rules — uses a plain **"Save"** button. The inconsistency is confusing.

Fixes #2441
