### PR TITLE
fix: scope state-lookup failure test to get_state_options only

### DIFF
--- a/crm/tests/test_state_options.py
+++ b/crm/tests/test_state_options.py
@@ -34,25 +34,31 @@ class TestGetStateOptions(FrappeTestCase):
 		self.assertIsInstance(get_state_options(), dict)
 
 	def test_empty_without_india_compliance(self):
-		with patch("frappe.get_installed_apps", return_value=["frappe", "crm"]):
+		with patch("crm.www.crm.get_installed_apps", return_value=["frappe", "crm"]):
 			self.assertEqual(get_state_options(), {})
 
 	def test_resilient_when_get_installed_apps_raises(self):
 		# The v15 boot-context concern: get_installed_apps blowing up must NOT break boot.
-		with patch("frappe.get_installed_apps", side_effect=Exception("boot context")):
+		with patch("crm.www.crm.get_installed_apps", side_effect=Exception("boot context")):
 			self.assertEqual(get_state_options(), {})
 
 	def test_resilient_when_import_fails(self):
-		# App reported installed but constant import fails (e.g. version mismatch).
-		with patch("frappe.get_installed_apps", return_value=["frappe", "crm", "india_compliance"]):
-			# No fake module injected -> ImportError -> graceful {}.
+		# App reported installed but the constant import fails (e.g. version mismatch).
+		# Inject a constants module lacking INDIAN_STATES so the import fails deterministically,
+		# regardless of whether india_compliance is actually importable in this environment.
+		broken = _fake_india_compliance({})
+		del broken["india_compliance.gst_india.constants"].INDIAN_STATES
+		with (
+			patch("crm.www.crm.get_installed_apps", return_value=["frappe", "crm", "india_compliance"]),
+			patch.dict(sys.modules, broken),
+		):
 			self.assertEqual(get_state_options(), {})
 
 	def test_returns_states_when_app_installed(self):
 		states = {"Goa": "30", "Kerala": "32", "Punjab": "03"}
 		with (
 			patch(
-				"frappe.get_installed_apps",
+				"crm.www.crm.get_installed_apps",
 				return_value=["frappe", "crm", "india_compliance"],
 			),
 			patch.dict(sys.modules, _fake_india_compliance(states)),
@@ -69,12 +75,11 @@ class TestGetBoot(FrappeTestCase):
 		self.assertIsInstance(boot["state_options"], dict)
 
 	def test_boot_degrades_when_state_lookup_fails(self):
-		# The v15 boot-context concern: when india_compliance isn't available, get_boot must
-		# still succeed and state_options must be an empty map (never break page load).
-		# NB: get_installed_apps is used by other boot steps too (e.g. get_translated_doctypes
-		# -> hook resolution), so we drive the degrade path with a non-raising mock rather than
-		# a global side_effect. The raise-resilience of get_state_options itself is covered by
-		# test_resilient_when_get_installed_apps_raises.
-		with patch("frappe.get_installed_apps", return_value=["frappe", "crm"]):
+		# The v15 boot-context concern: if the state lookup misbehaves, get_boot must still
+		# succeed and state_options must be an empty map (never break page load). Patch only
+		# the binding used by get_state_options — patching frappe.get_installed_apps globally
+		# would break unrelated earlier boot steps (get_translated_doctypes resolves hooks via
+		# get_installed_apps), which is what made this test fail in CI.
+		with patch("crm.www.crm.get_installed_apps", side_effect=Exception("boot context")):
 			boot = get_boot()
 		self.assertEqual(boot["state_options"], {})

--- a/crm/www/crm.py
+++ b/crm/www/crm.py
@@ -2,7 +2,7 @@
 # GNU GPLv3 License. See license.txt
 
 import frappe
-from frappe import _
+from frappe import _, get_installed_apps
 from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 from frappe.translate import get_messages_for_boot, get_translated_doctypes
 from frappe.utils import cint, get_system_timezone
@@ -67,11 +67,11 @@ def get_state_options() -> dict[str, list[str]]:
 	text) on any failure.
 
 	This runs inside ``get_boot``, so it must never raise — a failure here would break
-	the whole CRM page load. ``frappe.get_installed_apps`` can return `[]` or raise in
+	the whole CRM page load. ``get_installed_apps`` can return `[]` or raise in
 	unauthenticated/boot contexts (notably on v15), so the lookup is wrapped defensively.
 	"""
 	try:
-		if "india_compliance" not in frappe.get_installed_apps():
+		if "india_compliance" not in get_installed_apps():
 			return {}
 
 		from india_compliance.gst_india.constants import INDIAN_STATES


### PR DESCRIPTION
test_boot_degrades_when_state_lookup_fails patched the global frappe.get_installed_apps, but get_boot calls get_translated_doctypes before get_state_options and that resolves filter hooks via get_installed_apps. Any global tampering broke that earlier boot step: side_effect raised "boot context", and return_value=[frappe,crm] raised AppNotInstalledError for erpnext in CI (v15).

Import get_installed_apps into crm.www.crm and call it unqualified so tests can patch only that binding, leaving frappe's internal callers intact. Point every test patch at crm.www.crm.get_installed_apps, and make test_resilient_when_import_fails deterministic by injecting a constants module without INDIAN_STATES instead of relying on india_compliance being absent.