### PR TITLE
chore: improve Brazilian Portuguese translations

### DIFF
--- a/crm/locale/pt_BR.po
+++ b/crm/locale/pt_BR.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: frontend/src/components/ViewControls.vue:1176
 msgid " (New)"
-msgstr ""
+msgstr " (Novo)"
 
 #: frontend/src/components/Filter.vue:587
 msgid "%John%"
@@ -240,7 +240,7 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/DashboardSettings.vue:135
 msgid "Access Key"
-msgstr ""
+msgstr "Chave de acesso"
 
 #: crm/api/exchange_rate.py:98 crm/api/exchange_rate.py:114
 msgid "Access Key is required for Service Provider: {0}"
@@ -266,11 +266,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:91
 msgid "Account Info & Security"
-msgstr ""
+msgstr "Conta e segurança"
 
 #: frontend/src/components/Settings/emailConfig.js:13
 msgid "Account Name"
-msgstr ""
+msgstr "Nome da conta"
 
 #. Label of the account_sid (Data) field in DocType 'CRM Exotel Settings'
 #. Label of the account_sid (Data) field in DocType 'CRM Twilio Settings'
@@ -283,7 +283,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/emailConfig.js:178
 msgid "Account name is required"
-msgstr ""
+msgstr "O nome da conta é obrigatório"
 
 #: frontend/src/components/Settings/Settings.vue:177
 msgid "Accounts"
@@ -318,7 +318,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/EmailAccountList.vue:19
 msgid "Add Account"
-msgstr ""
+msgstr "Adicionar conta"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:8
 msgid "Add Assignee"
@@ -334,7 +334,7 @@ msgstr ""
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:2
 msgid "Add Chart"
-msgstr ""
+msgstr "Adicionar gráfico"
 
 #: frontend/src/components/ColumnSettings.vue:68
 #: frontend/src/components/FieldLayoutEditor.vue:565
@@ -349,13 +349,13 @@ msgstr "Adicionar coluna"
 #: frontend/src/components/Settings/Sla/SlaAssignmentConditions.vue:26
 #: frontend/src/components/Settings/Sla/SlaAssignmentConditions.vue:63
 msgid "Add Condition"
-msgstr ""
+msgstr "Adicionar condição"
 
 #: frontend/src/components/ConditionsFilter/CFConditions.vue:81
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRulesSection.vue:71
 #: frontend/src/components/Settings/Sla/SlaAssignmentConditions.vue:69
 msgid "Add Condition Group"
-msgstr ""
+msgstr "Adicionar grupo de condições"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:389
 msgid "Add Description"
@@ -367,12 +367,12 @@ msgstr ""
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:100
 msgid "Add Email"
-msgstr ""
+msgstr "Adicionar e-mail"
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:4
 #: frontend/src/components/Settings/Users.vue:21
 msgid "Add Existing User"
-msgstr ""
+msgstr "Adicionar usuário existente"
 
 #: frontend/src/components/Controls/GridFieldsEditorModal.vue:61
 #: frontend/src/components/FieldLayoutEditor.vue:228
@@ -384,7 +384,7 @@ msgstr ""
 #: frontend/src/components/Filter.vue:139
 #: frontend/src/components/ViewControls.vue:107
 msgid "Add Filter"
-msgstr ""
+msgstr "Adicionar filtro"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:430
 msgid "Add Lead or Deal"
@@ -397,7 +397,7 @@ msgstr ""
 
 #: frontend/src/pages/Contact.vue:436
 msgid "Add Mobile Number..."
-msgstr ""
+msgstr "Adicionar número de celular..."
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:20
 msgid "Add Note"
@@ -409,11 +409,11 @@ msgstr ""
 #: frontend/src/components/Settings/CalendarSettings.vue:143
 #: frontend/src/components/Settings/CalendarSettings.vue:243
 msgid "Add Notification"
-msgstr ""
+msgstr "Adicionar notificação"
 
 #: frontend/src/pages/Contact.vue:437
 msgid "Add Organization..."
-msgstr ""
+msgstr "Adicionar organização..."
 
 #: frontend/src/components/Controls/Grid.vue:452
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:163
@@ -444,11 +444,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:36
 msgid "Add User"
-msgstr ""
+msgstr "Adicionar usuário"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:159
 msgid "Add Users"
-msgstr ""
+msgstr "Adicionar usuários"
 
 #. Label of the add_weekly_holidays_section (Section Break) field in DocType
 #. 'CRM Holiday List'
@@ -458,11 +458,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRulesSection.vue:20
 msgid "Add a Condition"
-msgstr ""
+msgstr "Adicionar uma condição"
 
 #: frontend/src/components/Settings/Sla/SlaAssignmentConditions.vue:15
 msgid "Add a Custom Condition"
-msgstr ""
+msgstr "Adicionar uma condição personalizada"
 
 #: frontend/src/components/Telephony/ExotelCallUI.vue:183
 #: frontend/src/components/Telephony/TwilioCallUI.vue:57
@@ -475,7 +475,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/LeadSyncing/leadSyncSourceConfig.js:25
 msgid "Add a name for your source"
-msgstr ""
+msgstr "Dê um nome para a origem"
 
 #: frontend/src/components/Telephony/TaskPanel.vue:16
 msgid "Add description..."
@@ -483,7 +483,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/HierarchyRow.vue:63
 msgid "Add direct reports"
-msgstr ""
+msgstr "Adicionar subordinados diretos"
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:12
 msgid "Add existing system users to this CRM. Assign them a role to grant access with their current credentials."
@@ -494,7 +494,7 @@ msgstr ""
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:113
 #: frontend/src/components/Settings/Users.vue:53
 msgid "Add one to get started."
-msgstr ""
+msgstr "Adicione um item para começar."
 
 #. Description of the 'Icon' (Code) field in DocType 'CRM Dropdown Item'
 #: crm/fcrm/doctype/crm_dropdown_item/crm_dropdown_item.json
@@ -503,7 +503,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:219
 msgid "Add time targets around support milestones like first response"
-msgstr ""
+msgstr "Defina prazos para etapas do atendimento, como a primeira resposta."
 
 #. Label of the add_to_holidays (Button) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
@@ -512,15 +512,15 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:466
 msgid "Add your first comment"
-msgstr ""
+msgstr "Adicione seu primeiro comentário"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:11
 msgid "Add, edit, and manage email templates for various CRM communications"
-msgstr ""
+msgstr "Adicione, edite e gerencie modelos de e-mail usados nas comunicações do CRM."
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue:12
 msgid "Add, edit, and manage sources for automatic lead syncing to your CRM"
-msgstr ""
+msgstr "Adicione, edite e gerencie origens para sincronizar leads automaticamente com o CRM."
 
 #. Label of the address (Link) field in DocType 'CRM Organization'
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
@@ -562,7 +562,7 @@ msgstr "Dia inteiro"
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/CalendarSettings.vue:158
 msgid "All Day Event Notifications"
-msgstr ""
+msgstr "Notificações de eventos do dia inteiro"
 
 #: frontend/src/components/Settings/Sla/SlaPriorityList.vue:205
 msgid "All available priorities have already been added"
@@ -629,15 +629,15 @@ msgstr "Nome do Aplicativo"
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:16
 msgid "Appearance"
-msgstr ""
+msgstr "Aparência"
 
 #: frontend/src/components/Settings/BrandSettings.vue:65
 msgid "Appears in the left sidebar. Recommended size is 32x32 px in PNG or SVG"
-msgstr ""
+msgstr "Aparece na barra lateral esquerda. O tamanho recomendado é 32 x 32 px, em PNG ou SVG."
 
 #: frontend/src/components/Settings/BrandSettings.vue:100
 msgid "Appears next to the title in your browser tab. Recommended size is 32x32 px in PNG or ICO"
-msgstr ""
+msgstr "Aparece ao lado do título na guia do navegador. O tamanho recomendado é 32 x 32 px, em PNG ou ICO."
 
 #: frontend/src/components/Kanban/KanbanSettings.vue:98
 #: frontend/src/components/Kanban/KanbanView.vue:46
@@ -650,7 +650,7 @@ msgstr "Aplicar"
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:64
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:71
 msgid "Apply On"
-msgstr ""
+msgstr "Aplicar em"
 
 #. Label of the view (Select) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
@@ -697,7 +697,7 @@ msgstr ""
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:576
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:346
 msgid "Are you sure you want to go back? Unsaved changes will be lost."
-msgstr ""
+msgstr "Tem certeza de que deseja voltar? As alterações que não foram salvas serão perdidas."
 
 #: frontend/src/composables/frappecloud.js:24
 msgid "Are you sure you want to login to your Frappe Cloud dashboard?"
@@ -713,7 +713,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:236
 msgid "Are you sure you want to set the currency as {0}? This cannot be changed later."
-msgstr ""
+msgstr "Tem certeza de que deseja definir {0} como moeda? Essa escolha não poderá ser alterada depois."
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:237
 msgid "Are you sure you want to unlink {0} linked item(s)?"
@@ -768,7 +768,7 @@ msgstr ""
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:605
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:606
 msgid "Assignment Condition"
-msgstr ""
+msgstr "Condição de atribuição"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:609
 msgid "Assignment Days"
@@ -816,7 +816,7 @@ msgstr "Cronograma de atribuições"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:104
 msgid "Assignment conditions"
-msgstr ""
+msgstr "Condições de atribuição"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:305
 msgid "Assignment conditions are invalid or corrupt, recreate the conditions."
@@ -843,7 +843,7 @@ msgstr "Anexar"
 #: frontend/src/components/EmailEditor.vue:163 frontend/src/pages/Deal.vue:114
 #: frontend/src/pages/Lead.vue:161
 msgid "Attach a File"
-msgstr ""
+msgstr "Anexar arquivo"
 
 #: frontend/src/components/Controls/AttachControl.vue:14
 msgid "Attach file…"
@@ -874,7 +874,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:49
 msgid "Auto Update Expected Deal Value"
-msgstr ""
+msgstr "Atualizar automaticamente o valor esperado do negócio"
 
 #. Label of the auto_update_expected_deal_value (Check) field in DocType 'FCRM
 #. Settings'
@@ -916,11 +916,11 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/DashboardSettings.vue:53
 msgid "Automatically update \"Expected Deal Value\" based on the total value of associated products in a deal"
-msgstr ""
+msgstr "Atualiza automaticamente o valor esperado do negócio com base no valor total dos produtos vinculados."
 
 #: frontend/src/components/Settings/Settings.vue:190
 msgid "Automation & Rules"
-msgstr ""
+msgstr "Automação e regras"
 
 #: crm/api/dashboard.py:252
 msgid "Average deal value of non won/lost deals"
@@ -944,23 +944,23 @@ msgstr ""
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:77
 msgid "Avg Deal Value"
-msgstr ""
+msgstr "Valor médio dos negócios"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:74
 msgid "Avg Ongoing Deal Value"
-msgstr ""
+msgstr "Valor médio dos negócios em andamento"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:83
 msgid "Avg Time to Close a Deal"
-msgstr ""
+msgstr "Tempo médio para fechar um negócio"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:79
 msgid "Avg Time to Close a Lead"
-msgstr ""
+msgstr "Tempo médio para fechar um lead"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:76
 msgid "Avg Won Deal Value"
-msgstr ""
+msgstr "Valor médio dos negócios ganhos"
 
 #: crm/api/dashboard.py:418
 msgid "Avg. deal value"
@@ -985,7 +985,7 @@ msgstr ""
 #: frontend/src/components/Dashboard/AddChartModal.vue:22
 #: frontend/src/components/Dashboard/AddChartModal.vue:66
 msgid "Axis Chart"
-msgstr ""
+msgstr "Gráfico de eixos"
 
 #: frontend/src/components/Activities/EmailArea.vue:58
 #: frontend/src/components/EmailEditor.vue:62
@@ -1001,7 +1001,7 @@ msgstr "Voltar"
 
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:9
 msgid "Back to All Logs"
-msgstr ""
+msgstr "Voltar para todos os registros"
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:25
 msgid "Back to File Upload"
@@ -1012,7 +1012,7 @@ msgstr ""
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:83
 msgid "Background Sync Frequency"
-msgstr ""
+msgstr "Frequência da sincronização em segundo plano"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -1037,11 +1037,11 @@ msgstr "Logotipo da Marca"
 
 #: frontend/src/components/Settings/BrandSettings.vue:30
 msgid "Brand Name"
-msgstr ""
+msgstr "Nome da marca"
 
 #: frontend/src/components/Settings/BrandSettings.vue:7
 msgid "Brand Settings"
-msgstr ""
+msgstr "Configurações da marca"
 
 #. Label of the branding_tab (Tab Break) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -1082,7 +1082,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_dashboard/crm_dashboard.json
 #: frontend/src/pages/Dashboard.vue:307
 msgid "CRM Dashboard"
-msgstr ""
+msgstr "Painel do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -1261,7 +1261,7 @@ msgstr "Calendário"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:8
 msgid "Calendar Settings"
-msgstr ""
+msgstr "Configurações do calendário"
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:9
 msgid "Call Details"
@@ -1306,7 +1306,7 @@ msgstr ""
 #: frontend/src/pages/Deal.vue:586 frontend/src/pages/Lead.vue:438
 #: frontend/src/pages/MobileDeal.vue:457 frontend/src/pages/MobileLead.vue:305
 msgid "Calls"
-msgstr ""
+msgstr "Chamadas"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:55
 msgid "Camera"
@@ -1380,7 +1380,7 @@ msgstr "Capturar"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:591
 msgid "Capturing Leads"
-msgstr ""
+msgstr "Captação de leads"
 
 #. Label of the category (Data) field in DocType 'Facebook Page'
 #: crm/lead_syncing/doctype/facebook_page/facebook_page.json
@@ -1406,7 +1406,7 @@ msgstr "Alterar Senha"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:162
 msgid "Change Photo"
-msgstr ""
+msgstr "Alterar foto"
 
 #: frontend/src/components/Activities/TaskArea.vue:44
 msgid "Change Status"
@@ -1415,19 +1415,19 @@ msgstr "Alterar Status"
 #: frontend/src/components/Layouts/AppSidebar.vue:510
 #: frontend/src/components/Layouts/AppSidebar.vue:519
 msgid "Change deal status"
-msgstr ""
+msgstr "Alterar status do negócio"
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:60
 msgid "Change language of the application."
-msgstr ""
+msgstr "Altere o idioma do aplicativo."
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:71
 msgid "Change timezone of the application."
-msgstr ""
+msgstr "Altere o fuso horário do aplicativo."
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:117
 msgid "Change your account password for security."
-msgstr ""
+msgstr "Altere a senha da sua conta para manter a segurança."
 
 #: frontend/src/pages/Dashboard.vue:22
 msgid "Chart"
@@ -1456,7 +1456,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:6
 msgid "Choose how you want to use the application by setting your preferences."
-msgstr ""
+msgstr "Defina suas preferências para escolher como deseja usar o aplicativo."
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue:9
 msgid "Choose how {0} are assigned among salespeople."
@@ -1464,7 +1464,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/EmailAdd.vue:9
 msgid "Choose the Email Service Provider you want to configure."
-msgstr ""
+msgstr "Escolha o provedor de e-mail que deseja configurar."
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:306
 msgid "Choose the days of the week when this rule should be active."
@@ -1639,15 +1639,15 @@ msgstr ""
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:163
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:190
 msgid "Configure"
-msgstr ""
+msgstr "Configurar"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:18
 msgid "Configure Telephony Settings for your CRM"
-msgstr ""
+msgstr "Configure a telefonia do CRM"
 
 #: frontend/src/components/Settings/HomeActions.vue:10
 msgid "Configure actions that appear on the home dropdown"
-msgstr ""
+msgstr "Configure as ações exibidas no menu da página inicial"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:10
 msgid "Configure default settings for your CRM system, including default currency, date formats, and other system-wide preferences to ensure consistency across your system."
@@ -1655,23 +1655,23 @@ msgstr ""
 
 #: frontend/src/components/Settings/GeneralSettings.vue:8
 msgid "Configure general settings for your application"
-msgstr ""
+msgstr "Configure as opções gerais do aplicativo"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:10
 msgid "Configure how your dashboard calculates, formats, and displays key metrics, including forecasting, deal values, and currency settings"
-msgstr ""
+msgstr "Configure como o Painel calcula, formata e exibe métricas importantes, incluindo previsões, valores dos negócios e moeda."
 
 #: frontend/src/components/Settings/DashboardSettings.vue:102
 msgid "Configure the Exchange Rate Provider for your CRM"
-msgstr ""
+msgstr "Configure o provedor de cotação de moedas do CRM"
 
 #: frontend/src/components/Settings/BrandSettings.vue:10
 msgid "Configure your Brand Name, Logo, and Favicon"
-msgstr ""
+msgstr "Configure o nome, o logotipo e o favicon da sua marca"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:12
 msgid "Configure your Calendar Settings like Default View and Event Notifications here"
-msgstr ""
+msgstr "Configure a visualização padrão do calendário e as notificações de eventos."
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:184
 msgid "Configure your Exotel Telephony Integration Settings here"
@@ -1689,12 +1689,12 @@ msgstr "Confirmar"
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:39
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:66
 msgid "Confirm Delete"
-msgstr ""
+msgstr "Confirmar exclusão"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:640
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:399
 msgid "Confirm Overwrite"
-msgstr ""
+msgstr "Confirmar substituição"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:30
 msgid "Confirm Password"
@@ -1706,7 +1706,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:274
 msgid "Connect ERPNext to Frappe CRM"
-msgstr ""
+msgstr "Conectar o ERPNext ao Frappe CRM"
 
 #: frontend/src/pages/Welcome.vue:35
 msgid "Connect your Email"
@@ -1723,11 +1723,11 @@ msgstr "Contato"
 
 #: frontend/src/pages/Deal.vue:682 frontend/src/pages/MobileDeal.vue:551
 msgid "Contact Added"
-msgstr ""
+msgstr "Contato adicionado"
 
 #: frontend/src/pages/Deal.vue:672 frontend/src/pages/MobileDeal.vue:541
 msgid "Contact Already Added"
-msgstr ""
+msgstr "Contato já adicionado"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:290
 msgid "Contact Already Exists"
@@ -1739,7 +1739,7 @@ msgstr ""
 
 #: frontend/src/pages/Deal.vue:693 frontend/src/pages/MobileDeal.vue:562
 msgid "Contact Removed"
-msgstr ""
+msgstr "Contato removido"
 
 #: frontend/src/components/Modals/AboutModal.vue:70
 msgid "Contact Support"
@@ -1752,7 +1752,7 @@ msgstr ""
 #: frontend/src/pages/MobileContact.vue:472
 #: frontend/src/pages/MobileContact.vue:482
 msgid "Contact Updated"
-msgstr ""
+msgstr "Contato atualizado"
 
 #: frontend/src/components/Modals/EditValueModal.vue:19
 msgid "Contact Us"
@@ -1764,7 +1764,7 @@ msgstr ""
 
 #: frontend/src/pages/Contact.vue:289
 msgid "Contact image updated"
-msgstr ""
+msgstr "Imagem do contato atualizada"
 
 #. Label of the contacts_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the contacts (Table) field in DocType 'CRM Deal'
@@ -1774,7 +1774,7 @@ msgstr ""
 #: frontend/src/pages/Contact.vue:244 frontend/src/pages/MobileContact.vue:226
 #: frontend/src/pages/MobileOrganization.vue:349
 msgid "Contacts"
-msgstr ""
+msgstr "Contatos"
 
 #. Label of the content (Text Editor) field in DocType 'FCRM Note'
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
@@ -1799,26 +1799,26 @@ msgstr ""
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:75
 msgid "Controls how numbers are displayed (e.g., commas, decimal separators)"
-msgstr ""
+msgstr "Define como os números são exibidos, incluindo separadores de milhar e casas decimais."
 
 #: frontend/src/components/Layouts/AppSidebar.vue:405
 #: frontend/src/components/ListBulkActions.vue:86
 #: frontend/src/components/Modals/ConvertToDealModal.vue:83
 #: frontend/src/pages/MobileLead.vue:54
 msgid "Convert"
-msgstr ""
+msgstr "Converter"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:396
 #: frontend/src/components/Layouts/AppSidebar.vue:404
 msgid "Convert lead to deal"
-msgstr ""
+msgstr "Converter lead em negócio"
 
 #: frontend/src/components/ListBulkActions.vue:78
 #: frontend/src/components/ListBulkActions.vue:195
 #: frontend/src/components/Modals/ConvertToDealModal.vue:7
 #: frontend/src/pages/Lead.vue:38
 msgid "Convert to Deal"
-msgstr ""
+msgstr "Converter em negócio"
 
 #. Label of the converted (Check) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -1901,7 +1901,7 @@ msgstr ""
 #: frontend/src/components/Modals/ViewModal.vue:9
 #: frontend/src/components/ViewControls.vue:697
 msgid "Create View"
-msgstr ""
+msgstr "Criar visualização"
 
 #: frontend/src/components/Modals/EventModal.vue:12
 msgid "Create an Event"
@@ -1929,15 +1929,15 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:371
 msgid "Create your first lead"
-msgstr ""
+msgstr "Crie seu primeiro lead"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:445
 msgid "Create your first note"
-msgstr ""
+msgstr "Crie sua primeira nota"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:424
 msgid "Create your first task"
-msgstr ""
+msgstr "Crie sua primeira tarefa"
 
 #. Label of the currency (Link) field in DocType 'CRM Deal'
 #. Label of the currency (Link) field in DocType 'CRM Organization'
@@ -1956,11 +1956,11 @@ msgstr "Precisão da moeda"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:250
 msgid "Currency set as {0} successfully"
-msgstr ""
+msgstr "Moeda definida como {0} com sucesso"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:8
 msgid "Current Password"
-msgstr ""
+msgstr "Senha atual"
 
 #: crm/api/dashboard.py:896
 msgid "Current pipeline distribution"
@@ -1968,31 +1968,31 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:621
 msgid "Custom Actions"
-msgstr ""
+msgstr "Ações personalizadas"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:571
 msgid "Custom Branding"
-msgstr ""
+msgstr "Personalização da marca"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:620
 msgid "Custom Fields"
-msgstr ""
+msgstr "Campos personalizados"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:623
 msgid "Custom List Actions"
-msgstr ""
+msgstr "Ações personalizadas da lista"
 
 #: frontend/src/pages/Dashboard.vue:228
 msgid "Custom Range"
-msgstr ""
+msgstr "Período personalizado"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:622
 msgid "Custom Statuses"
-msgstr ""
+msgstr "Status personalizados"
 
 #: frontend/src/pages/Deal.vue:499
 msgid "Customer Created Successfully"
-msgstr ""
+msgstr "Cliente criado com sucesso"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:617
 #: frontend/src/components/Settings/Settings.vue:206
@@ -2028,15 +2028,15 @@ msgstr "Painel"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:70
 msgid "Dashboard Currency"
-msgstr ""
+msgstr "Moeda do Painel"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:74
 msgid "Dashboard number cards & charts will show currency in the selected format. Once set, cannot be edited."
-msgstr ""
+msgstr "Os indicadores e gráficos do Painel usarão o formato da moeda selecionada. Depois de definida, ela não poderá ser alterada."
 
 #: frontend/src/components/Settings/DashboardSettings.vue:224
 msgid "Dashboard settings updated successfully"
-msgstr ""
+msgstr "Configurações do Painel atualizadas com sucesso"
 
 #: frontend/src/components/Activities/DataFields.vue:6
 #: frontend/src/components/Layouts/AppSidebar.vue:610
@@ -2061,7 +2061,7 @@ msgstr "Data"
 
 #: frontend/src/components/Modals/EventModal.vue:78
 msgid "Date & Time"
-msgstr ""
+msgstr "Data e hora"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:111
 msgid "Date Format"
@@ -2083,7 +2083,7 @@ msgstr "Dia"
 #: frontend/src/components/Telephony/ExotelCallUI.vue:200
 #: frontend/src/pages/Tasks.vue:132
 msgid "Deal"
-msgstr ""
+msgstr "Negócio"
 
 #. Label of the deal_owner (Link) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json frontend/src/pages/Contact.vue:541
@@ -2091,7 +2091,7 @@ msgstr ""
 #: frontend/src/pages/MobileOrganization.vue:483
 #: frontend/src/pages/Organization.vue:513
 msgid "Deal Owner"
-msgstr ""
+msgstr "Responsável pelo negócio"
 
 #. Label of the deal_status (Link) field in DocType 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
@@ -2127,27 +2127,27 @@ msgstr ""
 #: frontend/src/pages/MobileDeal.vue:391
 #: frontend/src/pages/MobileOrganization.vue:343
 msgid "Deals"
-msgstr ""
+msgstr "Negócios"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:93
 msgid "Deals by Ongoing & Won Stage"
-msgstr ""
+msgstr "Negócios em andamento e ganhos por etapa"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:96
 msgid "Deals by Salesperson"
-msgstr ""
+msgstr "Negócios por vendedor"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:103
 msgid "Deals by Source"
-msgstr ""
+msgstr "Negócios por origem"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:101
 msgid "Deals by Stage"
-msgstr ""
+msgstr "Negócios por etapa"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:95
 msgid "Deals by Territory"
-msgstr ""
+msgstr "Negócios por território"
 
 #: crm/api/dashboard.py:846
 msgid "Deals by ongoing & won stage"
@@ -2229,7 +2229,7 @@ msgstr "Envio Padrão"
 
 #: frontend/src/components/Settings/EmailAccountCard.vue:36
 msgid "Default Sending & Inbox"
-msgstr ""
+msgstr "Envio e caixa de entrada padrão"
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:62
 msgid "Default Service Level Agreement already exists for {0}"
@@ -2314,7 +2314,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/InviteUserPage.vue:79
 msgid "Delete Invitation"
-msgstr ""
+msgstr "Excluir convite"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:223
 msgid "Delete Linked Item"
@@ -2322,7 +2322,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:222
 msgid "Delete Only User"
-msgstr ""
+msgstr "Excluir somente o usuário"
 
 #: frontend/src/pages/MobileOrganization.vue:274
 msgid "Delete Organization"
@@ -2335,7 +2335,7 @@ msgstr ""
 #: frontend/src/components/ViewControls.vue:1116
 #: frontend/src/components/ViewControls.vue:1124
 msgid "Delete View"
-msgstr ""
+msgstr "Excluir visualização"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:14
 msgid "Delete or unlink linked documents"
@@ -2422,7 +2422,7 @@ msgstr ""
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:29
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:29
 msgid "Disable"
-msgstr ""
+msgstr "Desativar"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:434
 msgid "Disable ERPNext Integration"
@@ -2446,7 +2446,7 @@ msgstr "Descartar"
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:25
 msgid "Discard Changes"
-msgstr ""
+msgstr "Descartar alterações"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:911
 msgid "Discard Unsaved Changes?"
@@ -2473,7 +2473,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:114
 msgid "Display format for dates across the system"
-msgstr ""
+msgstr "Formato usado para exibir datas em todo o sistema"
 
 #. Label of the dt (Link) field in DocType 'CRM Form Script'
 #. Label of the dt (Link) field in DocType 'CRM Global Settings'
@@ -2499,7 +2499,7 @@ msgstr "Tipo de Documento"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:242
 msgid "Document created successfully"
-msgstr ""
+msgstr "Documento criado com sucesso"
 
 #: frontend/src/data/document.js:41
 msgid "Document does not exist"
@@ -2525,7 +2525,7 @@ msgstr "Concluído"
 #: frontend/src/components/Dashboard/AddChartModal.vue:29
 #: frontend/src/components/Dashboard/AddChartModal.vue:67
 msgid "Donut Chart"
-msgstr ""
+msgstr "Gráfico de rosca"
 
 #: frontend/src/components/Activities/AudioPlayer.vue:166
 #: frontend/src/components/ViewControls.vue:268
@@ -2677,7 +2677,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/EmailEdit.vue:6
 msgid "Edit Email"
-msgstr ""
+msgstr "Editar e-mail"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:19
 msgid "Edit Event"
@@ -2777,15 +2777,15 @@ msgstr "Conta de e-mail"
 
 #: frontend/src/components/Settings/EmailAdd.vue:145
 msgid "Email Account created successfully"
-msgstr ""
+msgstr "Conta de e-mail criada com sucesso"
 
 #: frontend/src/components/Settings/EmailEdit.vue:211
 msgid "Email Account updated successfully"
-msgstr ""
+msgstr "Conta de e-mail atualizada com sucesso"
 
 #: frontend/src/components/Settings/EmailAccountList.vue:7
 msgid "Email Accounts"
-msgstr ""
+msgstr "Contas de e-mail"
 
 #: frontend/src/components/Calendar/Attendee.vue:278
 msgid "Email Already Exists"
@@ -2793,7 +2793,7 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:608
 msgid "Email Communication"
-msgstr ""
+msgstr "Comunicação por e-mail"
 
 #: frontend/src/components/EmailEditor.vue:222
 msgid "Email From Lead"
@@ -2805,7 +2805,7 @@ msgstr "ID de e-mail"
 
 #: frontend/src/components/Settings/emailConfig.js:181
 msgid "Email ID is required"
-msgstr ""
+msgstr "O endereço de e-mail é obrigatório"
 
 #. Label of the email_sent_at (Datetime) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -2823,7 +2823,7 @@ msgstr "Modelo de e-mail"
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:2
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:7
 msgid "Email Templates"
-msgstr ""
+msgstr "Modelos de e-mail"
 
 #: frontend/src/components/Controls/EmailMultiSelect.vue:254
 msgid "Email already exists"
@@ -2835,7 +2835,7 @@ msgstr "Email enviado"
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:181
 msgid "Email settings updated successfully"
-msgstr ""
+msgstr "Configurações de e-mail atualizadas com sucesso"
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:51
 #: frontend/src/pages/Deal.vue:566 frontend/src/pages/Lead.vue:418
@@ -2845,7 +2845,7 @@ msgstr "E-mails"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:96
 msgid "Emails & Signature"
-msgstr ""
+msgstr "E-mails e assinatura"
 
 #: frontend/src/components/ListViews/ListRows.vue:12
 msgid "Empty"
@@ -2875,7 +2875,7 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/DashboardSettings.vue:31
 msgid "Enable Forecasting"
-msgstr ""
+msgstr "Ativar previsão de vendas"
 
 #: frontend/src/components/Settings/emailConfig.js:28
 msgid "Enable Incoming"
@@ -2942,7 +2942,7 @@ msgstr "Data de término"
 
 #: frontend/src/components/Settings/Sla/utils.js:172
 msgid "End Date cannot be before start date"
-msgstr ""
+msgstr "A data final não pode ser anterior à data inicial"
 
 #. Label of the end_time (Datetime) field in DocType 'CRM Call Log'
 #. Label of the end_time (Time) field in DocType 'CRM Service Day'
@@ -2954,7 +2954,7 @@ msgstr ""
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:45
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:46
 msgid "End Time"
-msgstr ""
+msgstr "Horário de término"
 
 #: frontend/src/composables/event.js:250
 msgid "End Time Should Be After Start Time"
@@ -2962,7 +2962,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:189
 msgid "End Time is required"
-msgstr ""
+msgstr "O horário de término é obrigatório"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:204
 msgid "End Time must be after Start Time"
@@ -2974,7 +2974,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:160
 msgid "Enter Access Key"
-msgstr ""
+msgstr "Digite a chave de acesso"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:91
 msgid "Enter Access Token"
@@ -2982,7 +2982,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/BrandSettings.vue:41
 msgid "Enter Brand Name"
-msgstr ""
+msgstr "Digite o nome da marca"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:109
 msgid "Enter Exotel Number"
@@ -3062,7 +3062,7 @@ msgstr ""
 #: frontend/src/pages/Deal.vue:766 frontend/src/pages/Lead.vue:498
 #: frontend/src/pages/MobileDeal.vue:619 frontend/src/pages/MobileLead.vue:360
 msgid "Error updating field"
-msgstr ""
+msgstr "Erro ao atualizar o campo"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:672
 msgid "Event Details"
@@ -3076,7 +3076,7 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/CalendarSettings.vue:62
 msgid "Event Notifications"
-msgstr ""
+msgstr "Notificações de eventos"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:285
 msgid "Event Title"
@@ -3118,7 +3118,7 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/GeneralSettings.vue:140
 msgid "Exact"
-msgstr ""
+msgstr "Data e hora exatas"
 
 #: frontend/src/components/ViewControls.vue:282
 #: frontend/src/components/ViewControls.vue:290
@@ -3137,7 +3137,7 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/DashboardSettings.vue:99
 msgid "Exchange Rate Provider"
-msgstr ""
+msgstr "Provedor de cotação de moedas"
 
 #. Option for the 'Telephony Medium' (Select) field in DocType 'CRM Call Log'
 #. Option for the 'Default Medium' (Select) field in DocType 'CRM Telephony
@@ -3214,7 +3214,7 @@ msgstr "Tipo de exportação"
 
 #: frontend/src/components/ViewControls.vue:296
 msgid "Export all {0} record(s)"
-msgstr ""
+msgstr "Exportar todos os {0} registros"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
@@ -3343,7 +3343,7 @@ msgstr ""
 #: frontend/src/components/Settings/DefaultsSettings.vue:169
 #: frontend/src/components/Settings/ERPNextSettings.vue:342
 msgid "Failed to save settings"
-msgstr ""
+msgstr "Não foi possível salvar as configurações"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:265
 msgid "Failed to save workday: {0}"
@@ -3415,7 +3415,7 @@ msgstr ""
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/BrandSettings.vue:97
 msgid "Favicon"
-msgstr ""
+msgstr "Favicon"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:38
 #: frontend/src/components/Modals/EditValueModal.vue:5
@@ -3513,7 +3513,7 @@ msgstr ""
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:91
 msgid "Forecasted Revenue"
-msgstr ""
+msgstr "Receita prevista"
 
 #: crm/api/dashboard.py:718
 msgid "Forecasted revenue"
@@ -3540,7 +3540,7 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:638
 msgid "Frappe CRM mobile"
-msgstr ""
+msgstr "Frappe CRM para celular"
 
 #: frontend/src/components/Settings/emailConfig.js:81
 msgid "Frappe Mail Site"
@@ -3601,7 +3601,7 @@ msgstr "Nome Completo"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:92
 msgid "Funnel Conversion"
-msgstr ""
+msgstr "Conversão do funil"
 
 #: crm/api/dashboard.py:787
 msgid "Funnel conversion"
@@ -3626,7 +3626,7 @@ msgstr "Geral"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:5
 msgid "General Settings"
-msgstr ""
+msgstr "Configurações gerais"
 
 #: crm/api/dashboard.py:1068
 msgid "Geographic distribution of deals and revenue"
@@ -3646,7 +3646,7 @@ msgstr ""
 
 #: frontend/src/pages/Deal.vue:104 frontend/src/pages/Lead.vue:151
 msgid "Go to Website"
-msgstr ""
+msgstr "Acessar site"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:524
 msgid "Going?"
@@ -3756,7 +3756,7 @@ msgstr ""
 #: frontend/src/components/Settings/HomeActions.vue:7
 #: frontend/src/components/Settings/Settings.vue:209
 msgid "Home Actions"
-msgstr ""
+msgstr "Ações da página inicial"
 
 #. Option for the 'Background Sync Frequency' (Select) field in DocType 'Lead
 #. Sync Source'
@@ -3903,7 +3903,7 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:628
 msgid "Integration"
-msgstr ""
+msgstr "Integração"
 
 #: crm/integrations/exotel/handler.py:72
 msgid "Integration Not Enabled"
@@ -4019,7 +4019,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/InviteUserPage.vue:187
 msgid "Invitations sent successfully"
-msgstr ""
+msgstr "Convites enviados com sucesso"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:80
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:151
@@ -4032,27 +4032,27 @@ msgstr ""
 
 #: frontend/src/components/Settings/InviteUserPage.vue:32
 msgid "Invite By Email"
-msgstr ""
+msgstr "Convidar por e-mail"
 
 #: frontend/src/components/Settings/Users.vue:25
 msgid "Invite New User"
-msgstr ""
+msgstr "Convidar novo usuário"
 
 #: frontend/src/components/Settings/Settings.vue:159
 msgid "Invite User"
-msgstr ""
+msgstr "Convidar usuário"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:573
 msgid "Invite Users"
-msgstr ""
+msgstr "Convidar usuários"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:10
 msgid "Invite users to access CRM. Specify their roles to control access and permissions"
-msgstr ""
+msgstr "Convide usuários para acessar o CRM e defina suas funções para controlar acessos e permissões."
 
 #: frontend/src/components/Layouts/AppSidebar.vue:383
 msgid "Invite your team"
-msgstr ""
+msgstr "Convide sua equipe"
 
 #. Label of the invited_by (Link) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -4199,7 +4199,7 @@ msgstr "Idioma"
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:37
 msgid "Language & Time"
-msgstr ""
+msgstr "Idioma e horário"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue:108
 msgid "Last"
@@ -4231,7 +4231,7 @@ msgstr "Últimos 90 dias"
 #: frontend/src/pages/Organization.vue:518
 #: frontend/src/pages/Organization.vue:546
 msgid "Last Modified"
-msgstr ""
+msgstr "Última alteração"
 
 #: frontend/src/components/Filter.vue:653
 msgid "Last Month"
@@ -4339,7 +4339,7 @@ msgstr ""
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue:7
 msgid "Lead Sources"
-msgstr ""
+msgstr "Origens de leads"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -4357,7 +4357,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Settings.vue:237
 msgid "Lead Syncing"
-msgstr ""
+msgstr "Sincronização de leads"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:311
 msgid "Lead and deal visibility will no longer be restricted by the reporting tree. Are you sure?"
@@ -4388,11 +4388,11 @@ msgstr ""
 #: frontend/src/pages/InvalidPage.vue:9 frontend/src/pages/Lead.vue:369
 #: frontend/src/pages/MobileLead.vue:239
 msgid "Leads"
-msgstr ""
+msgstr "Leads"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:102
 msgid "Leads by Source"
-msgstr ""
+msgstr "Leads por origem"
 
 #: crm/api/dashboard.py:984
 msgid "Leads by source"
@@ -4530,7 +4530,7 @@ msgstr "Perdido"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:94
 msgid "Lost Deal Reasons"
-msgstr ""
+msgstr "Motivos de perda dos negócios"
 
 #. Label of the lost_details_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the lost_details_tab (Tab Break) field in DocType 'CRM Lead'
@@ -4583,12 +4583,12 @@ msgstr "Fazer chamada"
 #: frontend/src/components/Activities/AttachmentArea.vue:39
 #: frontend/src/components/ViewControls.vue:1105
 msgid "Make Private"
-msgstr ""
+msgstr "Tornar privada"
 
 #: frontend/src/components/Activities/AttachmentArea.vue:39
 #: frontend/src/components/ViewControls.vue:1105
 msgid "Make Public"
-msgstr ""
+msgstr "Tornar pública"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:141
 #: frontend/src/components/Activities/ActivityHeader.vue:184
@@ -4596,7 +4596,7 @@ msgstr ""
 #: frontend/src/pages/Lead.vue:127 frontend/src/pages/Leads.vue:537
 #: frontend/src/pages/MobileContact.vue:73
 msgid "Make a Call"
-msgstr ""
+msgstr "Fazer uma ligação"
 
 #: frontend/src/components/Activities/AttachmentArea.vue:98
 msgid "Make attachment {0}"
@@ -4612,11 +4612,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:35
 msgid "Makes \"Expected Closure Date\" and \"Expected Deal Value\" mandatory for deal value forecasting"
-msgstr ""
+msgstr "Torna a data prevista de fechamento e o valor esperado obrigatórios para calcular a previsão dos negócios."
 
 #: frontend/src/components/Settings/Users.vue:11
 msgid "Manage CRM users by adding or inviting them, and assign roles to control their access and permissions"
-msgstr ""
+msgstr "Adicione ou convide usuários do CRM e atribua funções para controlar acessos e permissões."
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:4
 msgid "Manage ERPNext integration settings"
@@ -4624,7 +4624,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:100
 msgid "Manage your account emails and email signature for communication."
-msgstr ""
+msgstr "Gerencie as contas de e-mail e a assinatura usada nas comunicações."
 
 #: frontend/src/components/Settings/EmailAccountList.vue:11
 msgid "Manage your email accounts to send and receive emails directly from CRM. You can add multiple accounts and set one as default for incoming and outgoing emails."
@@ -4632,11 +4632,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:36
 msgid "Manage your email signature"
-msgstr ""
+msgstr "Gerencie sua assinatura de e-mail"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:5
 msgid "Manage your profile & login information."
-msgstr ""
+msgstr "Gerencie seu perfil e seus dados de acesso."
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:4
 msgid "Manage your service level agreement policies"
@@ -4650,7 +4650,7 @@ msgstr ""
 #: frontend/src/components/Settings/Users.vue:232
 #: frontend/src/components/Settings/Users.vue:235
 msgid "Manager"
-msgstr ""
+msgstr "Gerente"
 
 #: frontend/src/components/Modals/DoctypeModal.vue:122
 #: frontend/src/data/document.js:68
@@ -4739,11 +4739,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:628
 msgid "Missing mandatory fields: {0}"
-msgstr ""
+msgstr "Campos obrigatórios não preenchidos: {0}"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:641
 msgid "Mobile App Installation"
-msgstr ""
+msgstr "Instalação do aplicativo para celular"
 
 #. Label of the mobile_no (Data) field in DocType 'CRM Contacts'
 #. Label of the mobile_no (Data) field in DocType 'CRM Lead'
@@ -4796,7 +4796,7 @@ msgstr "Mensal"
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:466
 #: frontend/src/components/ViewControls.vue:234
 msgid "More Options"
-msgstr ""
+msgstr "Mais opções"
 
 #: frontend/src/components/FieldLayoutEditor.vue:617
 msgid "Move Last Column to Next Section"
@@ -4860,7 +4860,7 @@ msgstr "Nome"
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:148
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:154
 msgid "Name is required"
-msgstr ""
+msgstr "O nome é obrigatório"
 
 #. Label of the naming_series (Select) field in DocType 'CRM Deal'
 #. Label of the naming_series (Select) field in DocType 'CRM Product'
@@ -4990,7 +4990,7 @@ msgstr "Novo {0}"
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/GeneralSettings.vue:144
 msgid "Newest First"
-msgstr ""
+msgstr "Mais recentes primeiro"
 
 #: frontend/src/components/Filter.vue:709
 msgid "Next 6 Months"
@@ -5029,7 +5029,7 @@ msgstr ""
 #: frontend/src/components/Modals/SidePanelModal.vue:51
 #: frontend/src/pages/Deal.vue:281 frontend/src/pages/MobileDeal.vue:209
 msgid "No Contacts Added"
-msgstr ""
+msgstr "Nenhum contato adicionado"
 
 #: frontend/src/components/Controls/Grid.vue:440
 msgid "No Data"
@@ -5037,7 +5037,7 @@ msgstr "Nenhum dado"
 
 #: frontend/src/pages/Deal.vue:267
 msgid "No Details Added"
-msgstr ""
+msgstr "Nenhum detalhe adicionado"
 
 #: frontend/src/components/Activities/EventArea.vue:73
 msgid "No Events Scheduled"
@@ -5053,7 +5053,7 @@ msgstr "Sem rótulo"
 
 #: frontend/src/pages/Deal.vue:732
 msgid "No Mobile Number Set"
-msgstr ""
+msgstr "Nenhum número de celular definido"
 
 #: frontend/src/pages/MobileNotification.vue:65
 msgid "No New Notifications"
@@ -5061,7 +5061,7 @@ msgstr ""
 
 #: frontend/src/pages/Deal.vue:727
 msgid "No Primary Contact Set"
-msgstr ""
+msgstr "Nenhum contato principal definido"
 
 #: frontend/src/components/Settings/Sla/SlaPriorityList.vue:86
 msgid "No Priorities in the list"
@@ -5069,7 +5069,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:72
 msgid "No Results Found"
-msgstr ""
+msgstr "Nenhum resultado encontrado"
 
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:56
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:57
@@ -5080,7 +5080,7 @@ msgstr ""
 #: frontend/src/pages/Deals.vue:105 frontend/src/pages/Leads.vue:121
 #: frontend/src/pages/Tasks.vue:71
 msgid "No Title"
-msgstr ""
+msgstr "Sem título"
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:39
 msgid "No Users Found"
@@ -5089,7 +5089,7 @@ msgstr ""
 #: frontend/src/pages/MobileOrganization.vue:296
 #: frontend/src/pages/Organization.vue:333
 msgid "No Website Found"
-msgstr ""
+msgstr "Nenhum site encontrado"
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:156
 msgid "No Workdays in the List"
@@ -5114,7 +5114,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:107
 msgid "No matching users"
-msgstr ""
+msgstr "Nenhum usuário encontrado"
 
 #: frontend/src/components/Calendar/Attendee.vue:215
 #: frontend/src/components/Controls/EmailMultiSelect.vue:133
@@ -5132,7 +5132,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:112
 msgid "No users match the current filter."
-msgstr ""
+msgstr "Nenhum usuário corresponde ao filtro atual."
 
 #: frontend/src/components/ListViews/EmptyState.vue:37
 #: frontend/src/pages/MobileOrganization.vue:145
@@ -5272,7 +5272,7 @@ msgstr "Anotações"
 
 #: frontend/src/pages/Notes.vue:23
 msgid "Notes View"
-msgstr ""
+msgstr "Visualização de notas"
 
 #: frontend/src/components/Activities/EmailArea.vue:15
 #: frontend/src/components/Calendar/EventNotifications.vue:22
@@ -5318,7 +5318,7 @@ msgstr "Número"
 #: frontend/src/components/Dashboard/AddChartModal.vue:15
 #: frontend/src/components/Dashboard/AddChartModal.vue:65
 msgid "Number Chart"
-msgstr ""
+msgstr "Indicador numérico"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:71
 msgid "Number Format"
@@ -5334,11 +5334,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:95
 msgid "Number of decimal places for non-currency numeric fields"
-msgstr ""
+msgstr "Número de casas decimais para campos numéricos que não representam moeda"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:55
 msgid "Number of decimal places used for all currency values"
-msgstr ""
+msgstr "Número de casas decimais usado nos valores monetários"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:167
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:251
@@ -5362,7 +5362,7 @@ msgstr ""
 #: frontend/src/components/Settings/GeneralSettings.vue:123
 #: frontend/src/components/Settings/GeneralSettings.vue:143
 msgid "Oldest First"
-msgstr ""
+msgstr "Mais antigos primeiro"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Type' (Select) field in DocType 'CRM Lead Status'
@@ -5380,7 +5380,7 @@ msgstr ""
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:73
 msgid "Ongoing Deals"
-msgstr ""
+msgstr "Negócios em andamento"
 
 #: crm/api/dashboard.py:189
 msgid "Ongoing deals"
@@ -5424,7 +5424,7 @@ msgstr ""
 
 #: frontend/src/pages/Organization.vue:97
 msgid "Open Website"
-msgstr ""
+msgstr "Abrir site"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.js:6
 #: crm/fcrm/doctype/crm_lead/crm_lead.js:6
@@ -5499,7 +5499,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 #: frontend/src/pages/Deal.vue:67
 msgid "Organization Logo"
-msgstr ""
+msgstr "Logotipo da organização"
 
 #. Label of the organization_name (Data) field in DocType 'CRM Deal'
 #. Label of the organization_name (Data) field in DocType 'CRM Organization'
@@ -5517,7 +5517,7 @@ msgstr ""
 #: frontend/src/pages/MobileOrganization.vue:219
 #: frontend/src/pages/Organization.vue:257
 msgid "Organizations"
-msgstr ""
+msgstr "Organizações"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:151
 msgid "Organizer"
@@ -5525,7 +5525,7 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:605
 msgid "Other Features"
-msgstr ""
+msgstr "Outros recursos"
 
 #. Label of the organization_tab (Tab Break) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -5580,7 +5580,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/emailConfig.js:188
 msgid "Password is required"
-msgstr ""
+msgstr "A senha é obrigatória"
 
 #: crm/api/user.py:43
 msgid "Password is too weak. {0}"
@@ -5628,7 +5628,7 @@ msgstr "Pendente"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:61
 msgid "Pending Invites"
-msgstr ""
+msgstr "Convites pendentes"
 
 #: frontend/src/pages/Dashboard.vue:66
 msgid "Period"
@@ -5647,7 +5647,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:120
 msgid "Personal Mobile No."
-msgstr ""
+msgstr "Número de celular pessoal"
 
 #. Label of the phone (Data) field in DocType 'CRM Contacts'
 #. Label of the phone (Data) field in DocType 'CRM Lead'
@@ -5667,7 +5667,7 @@ msgstr "Números de telefone"
 
 #: frontend/src/components/ViewControls.vue:1097
 msgid "Pin View"
-msgstr ""
+msgstr "Fixar visualização"
 
 #. Label of the pinned (Check) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
@@ -5676,11 +5676,11 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:601
 msgid "Pinned View"
-msgstr ""
+msgstr "Visualização fixada"
 
 #: frontend/src/components/ViewControls.vue:686
 msgid "Pinned Views"
-msgstr ""
+msgstr "Visualizações fixadas"
 
 #: frontend/src/components/Activities/AudioPlayer.vue:176
 msgid "Playback Speed"
@@ -5700,7 +5700,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:239
 msgid "Please fix the errors in the form"
-msgstr ""
+msgstr "Corrija os erros do formulário"
 
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:88
 msgid "Please select a Priority"
@@ -5708,7 +5708,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:213
 msgid "Please select a currency before saving."
-msgstr ""
+msgstr "Selecione uma moeda antes de salvar."
 
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.py:67
 msgid "Please select a lead gen form before syncing!"
@@ -5728,15 +5728,15 @@ msgstr ""
 
 #: frontend/src/pages/Lead.vue:134
 msgid "Please set a mobile number to make calls"
-msgstr ""
+msgstr "Defina um número de celular para fazer ligações"
 
 #: frontend/src/pages/Deal.vue:109 frontend/src/pages/Lead.vue:156
 msgid "Please set a website to visit"
-msgstr ""
+msgstr "Defina um site para acessar"
 
 #: frontend/src/pages/Deal.vue:98 frontend/src/pages/Lead.vue:146
 msgid "Please set an email address to send emails"
-msgstr ""
+msgstr "Defina um endereço de e-mail para enviar mensagens"
 
 #: crm/integrations/exotel/handler.py:72
 msgid "Please setup Exotel intergration"
@@ -5772,11 +5772,11 @@ msgstr "Posição"
 #: frontend/src/components/Settings/PreferencesSettings.vue:4
 #: frontend/src/components/Settings/Settings.vue:112
 msgid "Preferences"
-msgstr ""
+msgstr "Preferências"
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:115
 msgid "Preferences Updated Successfully"
-msgstr ""
+msgstr "Preferências atualizadas com sucesso"
 
 #: frontend/src/pages/Deal.vue:215 frontend/src/pages/MobileDeal.vue:153
 msgid "Primary"
@@ -5784,7 +5784,7 @@ msgstr "Primário"
 
 #: frontend/src/pages/Deal.vue:704 frontend/src/pages/MobileDeal.vue:573
 msgid "Primary Contact Set"
-msgstr ""
+msgstr "Contato principal definido"
 
 #. Label of the email (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -5895,7 +5895,7 @@ msgstr "Perfil"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:194
 msgid "Profile Updated Successfully"
-msgstr ""
+msgstr "Perfil atualizado com sucesso"
 
 #: crm/api/dashboard.py:719
 msgid "Projected vs actual revenue based on deal probability"
@@ -5910,11 +5910,11 @@ msgstr "Público"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:600
 msgid "Public View"
-msgstr ""
+msgstr "Visualização pública"
 
 #: frontend/src/components/ViewControls.vue:680
 msgid "Public Views"
-msgstr ""
+msgstr "Visualizações públicas"
 
 #. Label of the qty (Float) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_products/crm_products.json
@@ -5939,7 +5939,7 @@ msgstr "Entrada rápida"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:624
 msgid "Quick Entry Layout"
-msgstr ""
+msgstr "Layout de cadastro rápido"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Global Settings'
 #: crm/fcrm/doctype/crm_global_settings/crm_global_settings.json
@@ -5948,7 +5948,7 @@ msgstr ""
 
 #: frontend/src/components/ViewControls.vue:741
 msgid "Quick filters updated successfully"
-msgstr ""
+msgstr "Filtros rápidos atualizados com sucesso"
 
 #. Label of the rate (Currency) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_products/crm_products.json
@@ -6052,7 +6052,7 @@ msgstr ""
 #: frontend/src/components/Settings/GeneralSettings.vue:98
 #: frontend/src/components/Settings/GeneralSettings.vue:139
 msgid "Relative"
-msgstr ""
+msgstr "Tempo relativo"
 
 #: frontend/src/components/Kanban/KanbanView.vue:169
 msgid "Reload Columns"
@@ -6086,7 +6086,7 @@ msgstr ""
 #: frontend/src/pages/MobileOrganization.vue:43
 #: frontend/src/pages/Organization.vue:53
 msgid "Remove Image"
-msgstr ""
+msgstr "Remover imagem"
 
 #: frontend/src/components/FieldLayoutEditor.vue:577
 #: frontend/src/components/FieldLayoutEditor.vue:583
@@ -6099,7 +6099,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:161
 msgid "Remove Photo"
-msgstr ""
+msgstr "Remover foto"
 
 #: frontend/src/components/FieldLayoutEditor.vue:480
 #: frontend/src/components/FieldLayoutEditor.vue:488
@@ -6172,7 +6172,7 @@ msgstr ""
 #: frontend/src/components/ColumnSettings.vue:86
 #: frontend/src/pages/Dashboard.vue:28
 msgid "Reset to Default"
-msgstr ""
+msgstr "Restaurar padrão"
 
 #. Label of the responded_on (Datetime) field in DocType 'CRM Rolling Response
 #. Time'
@@ -6398,7 +6398,7 @@ msgstr ""
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:7
 #: frontend/src/components/Settings/Settings.vue:165
 msgid "Sales Hierarchy"
-msgstr ""
+msgstr "Hierarquia de vendas"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:323
 msgid "Sales Hierarchy disabled"
@@ -6449,7 +6449,7 @@ msgstr "Gerente de Vendas"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:90
 msgid "Sales Trend"
-msgstr ""
+msgstr "Tendência de vendas"
 
 #. Name of a role
 #. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
@@ -6539,15 +6539,15 @@ msgstr "Salvar"
 #: frontend/src/components/ViewControls.vue:58
 #: frontend/src/components/ViewControls.vue:155
 msgid "Save Changes"
-msgstr ""
+msgstr "Salvar alterações"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:599
 msgid "Saved View"
-msgstr ""
+msgstr "Visualização salva"
 
 #: frontend/src/components/ViewControls.vue:674
 msgid "Saved Views"
-msgstr ""
+msgstr "Visualizações salvas"
 
 #: frontend/src/components/Telephony/TaskPanel.vue:8
 msgid "Schedule a task..."
@@ -6575,12 +6575,12 @@ msgstr ""
 
 #: frontend/src/components/Settings/Users.vue:69
 msgid "Search User"
-msgstr ""
+msgstr "Buscar usuário"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:83
 #: frontend/src/components/Settings/Hierarchy/UserMultiSelect.vue:6
 msgid "Search users"
-msgstr ""
+msgstr "Buscar usuários"
 
 #: frontend/src/components/FieldLayoutEditor.vue:457
 msgid "Section"
@@ -6616,11 +6616,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:119
 msgid "Select Provider"
-msgstr ""
+msgstr "Selecionar provedor"
 
 #: frontend/src/pages/Dashboard.vue:50
 msgid "Select Range"
-msgstr ""
+msgstr "Selecionar período"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:57
 msgid "Select Source Type"
@@ -6633,7 +6633,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/CalendarSettings.vue:54
 msgid "Select View"
-msgstr ""
+msgstr "Selecionar visualização"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:15
 msgid "Select Workday"
@@ -6681,7 +6681,7 @@ msgstr "Enviar"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:18
 msgid "Send Invites"
-msgstr ""
+msgstr "Enviar convites"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:6
 msgid "Send Invites To"
@@ -6693,11 +6693,11 @@ msgstr ""
 
 #: frontend/src/pages/Deal.vue:92 frontend/src/pages/Lead.vue:140
 msgid "Send an Email"
-msgstr ""
+msgstr "Enviar um e-mail"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:488
 msgid "Send email"
-msgstr ""
+msgstr "Enviar e-mail"
 
 #: frontend/src/components/CommunicationArea.vue:274
 msgid "Sending comment..."
@@ -6732,7 +6732,7 @@ msgstr "Definido"
 
 #: frontend/src/components/ViewControls.vue:1082
 msgid "Set As Default"
-msgstr ""
+msgstr "Definir como padrão"
 
 #: frontend/src/components/PrimaryDropdownItem.vue:27
 msgid "Set As Primary"
@@ -6740,7 +6740,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:235
 msgid "Set Currency"
-msgstr ""
+msgstr "Definir moeda"
 
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:29
 msgid "Set Default Priority"
@@ -6748,7 +6748,7 @@ msgstr ""
 
 #: frontend/src/pages/Lead.vue:119
 msgid "Set First Name"
-msgstr ""
+msgstr "Definir nome"
 
 #: frontend/src/components/Controls/GeolocationControl.vue:50
 msgid "Set Location"
@@ -6764,11 +6764,11 @@ msgstr ""
 
 #: frontend/src/pages/Deal.vue:78
 msgid "Set an Organization"
-msgstr ""
+msgstr "Vincular uma organização"
 
 #: frontend/src/pages/Deal.vue:661 frontend/src/pages/MobileDeal.vue:530
 msgid "Set as Primary Contact"
-msgstr ""
+msgstr "Definir como contato principal"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:113
 msgid "Set as default SLA"
@@ -6788,7 +6788,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/BrandSettings.vue:33
 msgid "Set the name of your brand. Appears in the left sidebar."
-msgstr ""
+msgstr "Defina o nome da sua marca. Ele será exibido na barra lateral esquerda."
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:9
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one"
@@ -6796,7 +6796,7 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:563
 msgid "Setting Up"
-msgstr ""
+msgstr "Configuração inicial"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:153
 msgid "Setting disabled successfully"
@@ -6846,15 +6846,15 @@ msgstr "Configurações"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:339
 msgid "Settings saved"
-msgstr ""
+msgstr "Configurações salvas"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:166
 msgid "Settings updated successfully"
-msgstr ""
+msgstr "Configurações atualizadas com sucesso"
 
 #: frontend/src/components/Settings/EmailAdd.vue:6
 msgid "Setup Email"
-msgstr ""
+msgstr "Configurar e-mail"
 
 #: crm/api/exchange_rate.py:149
 msgid "Setup the Exchange Rate Provider other than 'Frankfurter' in settings, as default provider does not support currency conversion for {0} to {1}."
@@ -6862,7 +6862,7 @@ msgstr ""
 
 #: frontend/src/components/Layouts/AppSidebar.vue:360
 msgid "Setup your password"
-msgstr ""
+msgstr "Defina sua senha"
 
 #: frontend/src/components/Activities/Activities.vue:249
 msgid "Show"
@@ -6893,7 +6893,7 @@ msgstr "Mostrar pré-visualização"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:86
 msgid "Show timestamps in the activity timeline as relative time (5 mins ago) or an exact date & time"
-msgstr ""
+msgstr "Exiba os horários da linha do tempo como tempo relativo, por exemplo, há 5 minutos, ou como data e hora exatas."
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
@@ -6966,7 +6966,7 @@ msgstr "Algo deu errado"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:246
 msgid "Something went wrong, try again later"
-msgstr ""
+msgstr "Algo deu errado. Tente novamente mais tarde."
 
 #: frontend/src/components/SortBy.vue:10 frontend/src/components/SortBy.vue:24
 #: frontend/src/components/SortBy.vue:226
@@ -7022,7 +7022,7 @@ msgstr ""
 
 #: frontend/src/components/ViewControls.vue:642
 msgid "Standard Views"
-msgstr ""
+msgstr "Visualizações padrão"
 
 #: frontend/src/composables/event.js:242
 msgid "Start & End Time Are Required"
@@ -7134,7 +7134,7 @@ msgstr "Alternar câmera"
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:26
 msgid "Switch between light, dark, or system theme"
-msgstr ""
+msgstr "Alterne entre os temas claro, escuro ou o padrão do sistema"
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:55
 msgid "Switch between outgoing email accounts when sending emails"
@@ -7182,11 +7182,11 @@ msgstr "Sistema"
 
 #: frontend/src/components/Settings/Settings.vue:119
 msgid "System Configuration"
-msgstr ""
+msgstr "Configuração do sistema"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:6
 msgid "System Defaults"
-msgstr ""
+msgstr "Padrões do sistema"
 
 #. Name of a role
 #. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
@@ -7248,7 +7248,7 @@ msgstr "Tarefas"
 
 #: frontend/src/components/Settings/Settings.vue:220
 msgid "Telephony"
-msgstr ""
+msgstr "Telefonia"
 
 #. Label of the telephony_medium (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
@@ -7257,7 +7257,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:9
 msgid "Telephony Settings"
-msgstr ""
+msgstr "Configurações de telefonia"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:214
 msgid "Template Deleted Successfully"
@@ -7429,11 +7429,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/GeneralSettings.vue:107
 msgid "Timeline sort order"
-msgstr ""
+msgstr "Ordem da linha do tempo"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:82
 msgid "Timeline timestamp format"
-msgstr ""
+msgstr "Formato de data e hora da linha do tempo"
 
 #: frontend/src/components/Filter.vue:357
 msgid "Timespan"
@@ -7441,7 +7441,7 @@ msgstr "Período de tempo"
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:68
 msgid "Timezone"
-msgstr ""
+msgstr "Fuso horário"
 
 #. Label of the title (Data) field in DocType 'CRM Task'
 #. Label of the title (Data) field in DocType 'FCRM Note'
@@ -7496,7 +7496,7 @@ msgstr "Ao usuário"
 
 #: frontend/src/components/Settings/EmailEdit.vue:121
 msgid "To know more about setting up email accounts, click"
-msgstr ""
+msgstr "Para saber mais sobre a configuração de contas de e-mail, clique"
 
 #: frontend/src/components/Filter.vue:673 frontend/src/pages/Calendar.vue:85
 msgid "Today"
@@ -7533,7 +7533,7 @@ msgstr ""
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:72
 msgid "Total Leads"
-msgstr ""
+msgstr "Total de leads"
 
 #. Description of the 'Net Total' (Currency) field in DocType 'CRM Deal'
 #. Description of the 'Net Total' (Currency) field in DocType 'CRM Lead'
@@ -7721,7 +7721,7 @@ msgstr ""
 
 #: frontend/src/components/ViewControls.vue:1097
 msgid "Unpin View"
-msgstr ""
+msgstr "Desafixar visualização"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:575
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:345
@@ -7759,7 +7759,7 @@ msgstr "Atualizar"
 
 #: frontend/src/components/Settings/EmailEdit.vue:75
 msgid "Update Account"
-msgstr ""
+msgstr "Atualizar conta"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:163
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:190
@@ -7815,7 +7815,7 @@ msgstr "Carregar imagem"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:162
 msgid "Upload Photo"
-msgstr ""
+msgstr "Enviar foto"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:168
 msgid "Upload Video"
@@ -7842,11 +7842,11 @@ msgstr "Usuário"
 
 #: frontend/src/components/Settings/Settings.vue:99
 msgid "User Configuration"
-msgstr ""
+msgstr "Configuração de usuários"
 
 #: frontend/src/components/Settings/Settings.vue:150
 msgid "User Management"
-msgstr ""
+msgstr "Gerenciamento de usuários"
 
 #. Label of the user_name (Data) field in DocType 'CRM Telephony Agent'
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
@@ -7912,7 +7912,7 @@ msgstr ""
 
 #: frontend/src/pages/Deal.vue:229
 msgid "View Contact"
-msgstr ""
+msgstr "Ver contato"
 
 #: frontend/src/components/Controls/GeolocationControl.vue:50
 msgid "View Location"
@@ -7924,7 +7924,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:9
 msgid "View documentation"
-msgstr ""
+msgstr "Ver documentação"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:596
 msgid "Views"
@@ -8032,7 +8032,7 @@ msgstr ""
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:75
 msgid "Won Deals"
-msgstr ""
+msgstr "Negócios ganhos"
 
 #: crm/api/dashboard.py:306
 msgid "Won deals"
@@ -8105,11 +8105,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/DashboardSettings.vue:145
 msgid "You can get your Access Key from "
-msgstr ""
+msgstr "Você pode obter sua chave de acesso em "
 
 #: frontend/src/components/Settings/InviteUserPage.vue:37
 msgid "You can invite multiple users by comma separating their email addresses"
-msgstr ""
+msgstr "Você pode convidar vários usuários separando os endereços de e-mail por vírgulas."
 
 #: crm/api/user.py:129
 msgid "You cannot remove yourself."
@@ -8169,11 +8169,11 @@ msgstr "Seu ID de login é"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:641
 msgid "Your old condition will be overwritten. Are you sure you want to save?"
-msgstr ""
+msgstr "A condição anterior será substituída. Tem certeza de que deseja salvar?"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:400
 msgid "Your old conditions will be overwritten. Are you sure you want to save?"
-msgstr ""
+msgstr "As condições anteriores serão substituídas. Tem certeza de que deseja salvar?"
 
 #: frontend/src/components/Activities/CommentArea.vue:9
 msgid "added a"


### PR DESCRIPTION
## Summary

- Add 263 reviewed Brazilian Portuguese translations.
- Improve coverage for navigation, dashboards, leads, deals, contacts, organizations, settings, branding, users, and email.
- Use natural Brazilian Portuguese instead of literal word-for-word translations.

## Impact

The `pt_BR` catalog coverage increases from 26.4% to 41.2%, with 733 of 1,781 messages translated on the current `develop` branch.

## Validation

- `bench compile-po-to-mo --app crm --locale pt_BR --force` completed successfully.
- The compiled catalog returns `Painel do CRM`, `Negócios`, and `Personalização da marca` for representative messages.
- Placeholder compatibility checks passed.
- `git diff --check` passed.

## Crowdin note

This repository synchronizes locale files through Crowdin. This is a draft PR so maintainers can review the wording and decide whether to merge the catalog directly or route the translations through Crowdin.
