### PR TITLE
fix: preserve custom favicon in page metadata

### DIFF
--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -144,6 +144,7 @@ import ViewBreadcrumbs from '@/components/ViewBreadcrumbs.vue'
 import LayoutHeader from '@/components/LayoutHeader.vue'
 import Link from '@/components/Controls/Link.vue'
 import { usersStore } from '@/stores/users'
+import { getSettings } from '@/stores/settings'
 import { copy } from '@/utils'
 import { getLastXDays, formatter, formatRange } from '@/utils/dashboard'
 import {
@@ -156,6 +157,7 @@ import {
 import { ref, reactive, computed, provide } from 'vue'
 
 const { users, getUser, isManager, isAdmin } = usersStore()
+const { brand } = getSettings()
 
 const editing = ref(false)
 
@@ -304,6 +306,6 @@ function resetToDefault() {
 }
 
 usePageMeta(() => {
-  return { title: __('CRM Dashboard') }
+  return { title: __('CRM Dashboard'), icon: brand.favicon }
 })
 </script>

--- a/frontend/src/pages/DataImport.vue
+++ b/frontend/src/pages/DataImport.vue
@@ -10,8 +10,10 @@
 import { usePageMeta } from 'frappe-ui'
 import { DataImport } from 'frappe-ui/frappe'
 import { useRoute } from 'vue-router'
+import { getSettings } from '@/stores/settings'
 
 const route = useRoute()
+const { brand } = getSettings()
 
 const doctypeMap = {
   'CRM Lead': {
@@ -47,6 +49,7 @@ const doctypeMap = {
 usePageMeta(() => {
   return {
     title: __('Data Import'),
+    icon: brand.favicon,
   }
 })
 </script>

--- a/frontend/src/pages/PersonaForm.vue
+++ b/frontend/src/pages/PersonaForm.vue
@@ -20,8 +20,10 @@ import { useTelemetry } from 'frappe-ui/frappe'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { PERSONA_DONE_KEY } from '@/router'
+import { getSettings } from '@/stores/settings'
 
 const router = useRouter()
+const { brand } = getSettings()
 const { capture } = useTelemetry()
 const leaving = ref(false)
 const FADE_MS = 300
@@ -129,5 +131,8 @@ const questions = computed(() => [
   },
 ])
 
-usePageMeta(() => ({ title: __('Welcome to Frappe CRM') }))
+usePageMeta(() => ({
+  title: __('Welcome to Frappe CRM'),
+  icon: brand.favicon,
+}))
 </script>


### PR DESCRIPTION
## Summary

- Preserve the configured brand favicon when page metadata changes.
- Apply the existing `FCRM Settings` brand value to Dashboard, Data Import, and Persona Form.

## Root cause

These pages called `usePageMeta` with a title but without an icon. The page metadata utility then restored the static default Frappe favicon, replacing the favicon configured in CRM branding after navigation.

## Impact

The browser tab now keeps the configured CRM favicon while navigating through these pages.

## Validation

- Prettier check passed for all three changed Vue files.
- `yarn test:run` passed with 7 test files and 128 tests.
- `git diff --check` passed.
