### PR TITLE
chore: complete Brazilian Portuguese translations

### DIFF
--- a/crm/locale/pt_BR.po
+++ b/crm/locale/pt_BR.po
@@ -24,7 +24,7 @@ msgstr ""
 
 #: frontend/src/components/Filter.vue:587
 msgid "%John%"
-msgstr ""
+msgstr "%John%"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:66
 msgid "(No Title)"
@@ -32,19 +32,19 @@ msgstr "(Sem título)"
 
 #: frontend/src/components/Filter.vue:577
 msgid "01/01/2022 to 01/31/2022"
-msgstr ""
+msgstr "01/01/2022 a 31/01/2022"
 
 #: frontend/src/components/Telephony/TaskPanel.vue:71
 msgid "01/04/2024 11:30 PM"
-msgstr ""
+msgstr "04/01/2024 23:30"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:39
 msgid "08:00 AM"
-msgstr ""
+msgstr "08:00"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:226
 msgid "08:00 pm"
-msgstr ""
+msgstr "20:00"
 
 #: frontend/src/utils/index.js:204
 msgid "1 hour ago"
@@ -52,7 +52,7 @@ msgstr "há 1 hora"
 
 #: frontend/src/composables/event.js:207
 msgid "1 hr"
-msgstr ""
+msgstr "1 h"
 
 #: frontend/src/utils/index.js:200
 msgid "1 minute ago"
@@ -78,7 +78,7 @@ msgstr "há 1 ano"
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "1-10"
-msgstr ""
+msgstr "1-10"
 
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
@@ -88,7 +88,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "1000+"
-msgstr ""
+msgstr "1000+"
 
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
@@ -98,7 +98,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "11-50"
-msgstr ""
+msgstr "11-50"
 
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
@@ -108,7 +108,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "201-500"
-msgstr ""
+msgstr "201-500"
 
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
@@ -118,7 +118,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "501-1000"
-msgstr ""
+msgstr "501-1000"
 
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Deal'
 #. Option for the 'No. of Employees' (Select) field in DocType 'CRM Lead'
@@ -128,39 +128,39 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "51-200"
-msgstr ""
+msgstr "51-200"
 
 #. Paragraph text in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>META</b>"
-msgstr ""
+msgstr "<b>METADADOS</b>"
 
 #. Paragraph text in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<b>SHORTCUTS</b>"
-msgstr ""
+msgstr "<b>ATALHOS</b>"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:95
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:95
 msgid "<p>Dear {{ lead_name }},</p>\\n\\n<p>This is a reminder for the payment of {{ grand_total }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappé</p>"
-msgstr ""
+msgstr "<p>Olá, {{ lead_name }},</p>\\n\\n<p>Este é um lembrete sobre o pagamento de {{ grand_total }}.</p>\\n\\n<p>Obrigado,</p>\\n<p>Frappé</p>"
 
 #. Header text in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "<span class=\"h5\"><b>PORTAL</b></span>"
-msgstr ""
+msgstr "<span class=\"h5\"><b>PORTAL</b></span>"
 
 #: frontend/src/components/CommunicationArea.vue:80
 msgid "@John, can you please check this?"
-msgstr ""
+msgstr "@John, você pode verificar isso?"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:125
 msgid "A Lead requires either a person's name or an organization's name"
-msgstr ""
+msgstr "Um lead deve ter o nome de uma pessoa ou de uma organização"
 
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.py:49
 msgid "A lead sync source is already enabled for this Facebook Lead Form!"
-msgstr ""
+msgstr "Já existe uma fonte de sincronização de leads ativa para este formulário de leads do Facebook!"
 
 #: crm/templates/emails/helpdesk_invitation.html:5
 msgid "A new account has been created for you at {0}"
@@ -168,11 +168,11 @@ msgstr "Uma nova conta foi criada para você em {0}"
 
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.py:257
 msgid "A valid call log is required."
-msgstr ""
+msgstr "É necessário um registro de chamada válido."
 
 #: frontend/src/components/Settings/Hierarchy/useDragDrop.js:69
 msgid "A {0} cannot report to a {1}"
-msgstr ""
+msgstr "Um {0} não pode se reportar a um {1}"
 
 #. Label of the api_key (Data) field in DocType 'CRM Exotel Settings'
 #. Label of the api_key (Data) field in DocType 'CRM Twilio Settings'
@@ -199,28 +199,28 @@ msgstr "Segredo da API"
 #: crm/fcrm/doctype/crm_exotel_settings/crm_exotel_settings.json
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:53
 msgid "API Token"
-msgstr ""
+msgstr "Token da API"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:500
 #: frontend/src/components/Settings/emailConfig.js:192
 msgid "API key is required"
-msgstr ""
+msgstr "A chave da API é obrigatória"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:503
 msgid "API secret is required"
-msgstr ""
+msgstr "O segredo da API é obrigatório"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:88
 msgid "Accept"
-msgstr ""
+msgstr "Aceitar"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:155
 msgid "Accept Call"
-msgstr ""
+msgstr "Aceitar chamada"
 
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.js:7
 msgid "Accept Invitation"
-msgstr ""
+msgstr "Aceitar convite"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -230,11 +230,11 @@ msgstr "Aceito"
 #. Label of the accepted_at (Datetime) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Accepted At"
-msgstr ""
+msgstr "Aceito em"
 
 #: frontend/src/pages/NotPermitted.vue:7
 msgid "Access Denied"
-msgstr ""
+msgstr "Acesso negado"
 
 #. Label of the access_key (Data) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -244,7 +244,7 @@ msgstr ""
 
 #: crm/api/exchange_rate.py:98 crm/api/exchange_rate.py:114
 msgid "Access Key is required for Service Provider: {0}"
-msgstr ""
+msgstr "A chave de acesso é obrigatória para o provedor de serviços: {0}"
 
 #. Label of the access_token (Small Text) field in DocType 'Facebook Page'
 #. Label of the access_token (Password) field in DocType 'Lead Sync Source'
@@ -257,12 +257,12 @@ msgstr "Token de Acesso"
 
 #: crm/lead_syncing/doctype/lead_sync_source/facebook.py:145
 msgid "Access token is required"
-msgstr ""
+msgstr "O token de acesso é obrigatório"
 
 #. Label of the account_id (Data) field in DocType 'Facebook Page'
 #: crm/lead_syncing/doctype/facebook_page/facebook_page.json
 msgid "Account ID"
-msgstr ""
+msgstr "ID da conta"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:91
 msgid "Account Info & Security"
@@ -279,7 +279,7 @@ msgstr ""
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:59
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:45
 msgid "Account SID"
-msgstr ""
+msgstr "SID da conta"
 
 #: frontend/src/components/Settings/emailConfig.js:178
 msgid "Account name is required"
@@ -304,7 +304,7 @@ msgstr "Atividade"
 #. 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Activity Timeline"
-msgstr ""
+msgstr "Linha do tempo de atividades"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:37
 #: frontend/src/components/Modals/AddExistingUserModal.vue:55
@@ -314,7 +314,7 @@ msgstr "Adicionar"
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:162
 #: frontend/src/components/Settings/Hierarchy/HierarchyRow.vue:85
 msgid "Add ({0})"
-msgstr ""
+msgstr "Adicionar ({0})"
 
 #: frontend/src/components/Settings/EmailAccountList.vue:19
 msgid "Add Account"
@@ -326,11 +326,11 @@ msgstr "Adicionar responsável"
 
 #: frontend/src/components/Calendar/Attendee.vue:122
 msgid "Add Attendee"
-msgstr ""
+msgstr "Adicionar participante"
 
 #: crm/fcrm/doctype/crm_product/crm_product_list.js:3
 msgid "Add CRM Product"
-msgstr ""
+msgstr "Adicionar produto do CRM"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:2
 msgid "Add Chart"
@@ -359,11 +359,11 @@ msgstr ""
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:389
 msgid "Add Description"
-msgstr ""
+msgstr "Adicionar descrição"
 
 #: frontend/src/components/Modals/EventModal.vue:179
 msgid "Add Description."
-msgstr ""
+msgstr "Adicionar descrição."
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:100
 msgid "Add Email"
@@ -379,7 +379,7 @@ msgstr ""
 #: frontend/src/components/Kanban/KanbanSettings.vue:78
 #: frontend/src/components/SidePanelLayoutEditor.vue:97
 msgid "Add Field"
-msgstr ""
+msgstr "Adicionar campo"
 
 #: frontend/src/components/Filter.vue:139
 #: frontend/src/components/ViewControls.vue:107
@@ -388,12 +388,12 @@ msgstr ""
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:430
 msgid "Add Lead or Deal"
-msgstr ""
+msgstr "Adicionar lead ou negócio"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:377
 #: frontend/src/components/Modals/EventModal.vue:166
 msgid "Add Location"
-msgstr ""
+msgstr "Adicionar local"
 
 #: frontend/src/pages/Contact.vue:436
 msgid "Add Mobile Number..."
@@ -401,7 +401,7 @@ msgstr ""
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:20
 msgid "Add Note"
-msgstr ""
+msgstr "Adicionar nota"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:67
 #: frontend/src/components/Calendar/EventNotifications.vue:128
@@ -423,24 +423,24 @@ msgstr "Adicionar Linha"
 
 #: frontend/src/pages/Welcome.vue:24
 msgid "Add Sample Data"
-msgstr ""
+msgstr "Adicionar dados de exemplo"
 
 #: frontend/src/components/FieldLayoutEditor.vue:261
 #: frontend/src/components/SidePanelLayoutEditor.vue:127
 msgid "Add Section"
-msgstr ""
+msgstr "Adicionar seção"
 
 #: frontend/src/components/SortBy.vue:142
 msgid "Add Sort"
-msgstr ""
+msgstr "Adicionar critério de ordenação"
 
 #: frontend/src/components/FieldLayoutEditor.vue:67
 msgid "Add Tab"
-msgstr ""
+msgstr "Adicionar aba"
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:25
 msgid "Add Task"
-msgstr ""
+msgstr "Adicionar tarefa"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:36
 msgid "Add User"
@@ -454,7 +454,7 @@ msgstr ""
 #. 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Add Weekly Holidays"
-msgstr ""
+msgstr "Adicionar feriados semanais"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRulesSection.vue:20
 msgid "Add a Condition"
@@ -467,11 +467,11 @@ msgstr ""
 #: frontend/src/components/Telephony/ExotelCallUI.vue:183
 #: frontend/src/components/Telephony/TwilioCallUI.vue:57
 msgid "Add a Note"
-msgstr ""
+msgstr "Adicionar uma nota"
 
 #: frontend/src/components/Telephony/ExotelCallUI.vue:191
 msgid "Add a Task"
-msgstr ""
+msgstr "Adicionar uma tarefa"
 
 #: frontend/src/components/Settings/LeadSyncing/leadSyncSourceConfig.js:25
 msgid "Add a name for your source"
@@ -479,7 +479,7 @@ msgstr ""
 
 #: frontend/src/components/Telephony/TaskPanel.vue:16
 msgid "Add description..."
-msgstr ""
+msgstr "Adicione uma descrição..."
 
 #: frontend/src/components/Settings/Hierarchy/HierarchyRow.vue:63
 msgid "Add direct reports"
@@ -487,7 +487,7 @@ msgstr ""
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:12
 msgid "Add existing system users to this CRM. Assign them a role to grant access with their current credentials."
-msgstr ""
+msgstr "Adicione usuários existentes do sistema a este CRM. Atribua uma função para conceder acesso com as credenciais atuais."
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRulesList.vue:11
 #: frontend/src/components/Settings/EmailAccountList.vue:51
@@ -499,7 +499,7 @@ msgstr ""
 #. Description of the 'Icon' (Code) field in DocType 'CRM Dropdown Item'
 #: crm/fcrm/doctype/crm_dropdown_item/crm_dropdown_item.json
 msgid "Add svg code or use feather icons e.g 'settings'"
-msgstr ""
+msgstr "Adicione o código SVG ou use ícones Feather, por exemplo, 'settings'"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:219
 msgid "Add time targets around support milestones like first response"
@@ -508,7 +508,7 @@ msgstr ""
 #. Label of the add_to_holidays (Button) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Add to Holidays"
-msgstr ""
+msgstr "Adicionar aos feriados"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:466
 msgid "Add your first comment"
@@ -536,11 +536,11 @@ msgstr "Endereço"
 #: frontend/src/components/Settings/Users.vue:221
 #: frontend/src/components/Settings/Users.vue:224
 msgid "Admin"
-msgstr ""
+msgstr "Administrador"
 
 #: crm/integrations/twilio/twilio_handler.py:144
 msgid "Agent is unavailable to take the call, please call after some time."
-msgstr ""
+msgstr "O agente não está disponível para atender à chamada. Tente novamente mais tarde."
 
 #: frontend/src/components/Notifications.vue:118
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:75
@@ -566,7 +566,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/SlaPriorityList.vue:205
 msgid "All available priorities have already been added"
-msgstr ""
+msgstr "Todas as prioridades disponíveis já foram adicionadas"
 
 #. Label of the amount (Currency) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_products/crm_products.json
@@ -579,16 +579,16 @@ msgstr "Valor Total"
 #. Description of the 'Net Amount' (Currency) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_products/crm_products.json
 msgid "Amount after discount"
-msgstr ""
+msgstr "Valor após o desconto"
 
 #: frontend/src/components/Modals/FieldLayoutDialog.vue:277
 #: frontend/src/data/script.js:78 frontend/src/data/script.js:79
 msgid "An error occurred"
-msgstr ""
+msgstr "Ocorreu um erro"
 
 #: frontend/src/data/document.js:77
 msgid "An error occurred while updating the document"
-msgstr ""
+msgstr "Ocorreu um erro ao atualizar o documento"
 
 #. Description of the 'Favicon' (Attach) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -598,11 +598,11 @@ msgstr "Um arquivo de ícone com extensão .ico. Deve ter 16 x 16 px. Gerado usa
 #. Description of the 'Logo' (Attach) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "An image with 1:1 & 2:1 ratio is preferred"
-msgstr ""
+msgstr "Recomenda-se uma imagem com proporção 1:1 ou 2:1"
 
 #: frontend/src/components/Filter.vue:43 frontend/src/components/Filter.vue:83
 msgid "And"
-msgstr ""
+msgstr "E"
 
 #. Label of the annual_revenue (Currency) field in DocType 'CRM Deal'
 #. Label of the annual_revenue (Currency) field in DocType 'CRM Lead'
@@ -616,15 +616,15 @@ msgstr "Faturamento Anual"
 #: frontend/src/components/Modals/DealModal.vue:193
 #: frontend/src/components/Modals/LeadModal.vue:136
 msgid "Annual Revenue should be a number"
-msgstr ""
+msgstr "A receita anual deve ser um número"
 
 #: frontend/src/pages/PersonaForm.vue:64
 msgid "Another CRM"
-msgstr ""
+msgstr "Outro CRM"
 
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:69
 msgid "Any failed lead syncs will show up here"
-msgstr ""
+msgstr "Falhas na sincronização de leads aparecerão aqui"
 
 #. Label of the app_name (Data) field in DocType 'CRM Twilio Settings'
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.json
@@ -667,36 +667,36 @@ msgstr "Aplicativos"
 
 #: frontend/src/composables/demoData.js:21
 msgid "Are you sure you want to clear demo data? This action cannot be undone."
-msgstr ""
+msgstr "Tem certeza de que deseja limpar os dados de demonstração? Esta ação não pode ser desfeita."
 
 #: frontend/src/components/Activities/AttachmentArea.vue:128
 msgid "Are you sure you want to delete this attachment?"
-msgstr ""
+msgstr "Tem certeza de que deseja excluir este anexo?"
 
 #: frontend/src/pages/MobileContact.vue:274
 msgid "Are you sure you want to delete this contact?"
-msgstr ""
+msgstr "Tem certeza de que deseja excluir este contato?"
 
 #: frontend/src/components/Modals/EventModal.vue:468
 #: frontend/src/pages/Calendar.vue:409
 msgid "Are you sure you want to delete this event?"
-msgstr ""
+msgstr "Tem certeza de que deseja excluir este evento?"
 
 #: frontend/src/pages/MobileOrganization.vue:275
 msgid "Are you sure you want to delete this organization?"
-msgstr ""
+msgstr "Tem certeza de que deseja excluir esta organização?"
 
 #: frontend/src/components/Activities/TaskArea.vue:60
 msgid "Are you sure you want to delete this task?"
-msgstr ""
+msgstr "Tem certeza de que deseja excluir esta tarefa?"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:224
 msgid "Are you sure you want to delete {0} linked item(s)?"
-msgstr ""
+msgstr "Tem certeza de que deseja excluir {0} item(ns) vinculado(s)?"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:912
 msgid "Are you sure you want to discard unsaved changes to this event?"
-msgstr ""
+msgstr "Tem certeza de que deseja descartar as alterações não salvas deste evento?"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:576
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:346
@@ -705,15 +705,15 @@ msgstr ""
 
 #: frontend/src/composables/frappecloud.js:24
 msgid "Are you sure you want to login to your Frappe Cloud dashboard?"
-msgstr ""
+msgstr "Tem certeza de que deseja entrar no painel do Frappe Cloud?"
 
 #: frontend/src/components/FieldLayoutEditor.vue:431
 msgid "Are you sure you want to remove this tab and all its content?"
-msgstr ""
+msgstr "Tem certeza de que deseja remover esta aba e todo o seu conteúdo?"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:9
 msgid "Are you sure you want to reset 'Create Quotation from CRM Deal' Form Script?"
-msgstr ""
+msgstr "Tem certeza de que deseja redefinir o script do formulário 'Criar cotação a partir do negócio do CRM'?"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:236
 msgid "Are you sure you want to set the currency as {0}? This cannot be changed later."
@@ -721,19 +721,19 @@ msgstr ""
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:237
 msgid "Are you sure you want to unlink {0} linked item(s)?"
-msgstr ""
+msgstr "Tem certeza de que deseja desvincular {0} item(ns) vinculado(s)?"
 
 #: crm/api/exchange_rate.py:144
 msgid "Ask your manager to set up the Exchange Rate Provider, as default provider does not support currency conversion for {0} to {1}."
-msgstr ""
+msgstr "Peça ao seu gerente para configurar o provedor de taxas de câmbio, pois o provedor padrão não oferece conversão de {0} para {1}."
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:435
 msgid "Assign Condition is required"
-msgstr ""
+msgstr "A condição de atribuição é obrigatória"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:438
 msgid "Assign Conditions are invalid"
-msgstr ""
+msgstr "As condições de atribuição são inválidas"
 
 #: frontend/src/components/AssignTo.vue:11
 #: frontend/src/components/AssignToBody.vue:5
@@ -744,7 +744,7 @@ msgstr "Atribuir a"
 
 #: frontend/src/components/AssignToBody.vue:67
 msgid "Assign To Me"
-msgstr ""
+msgstr "Atribuir a mim"
 
 #. Label of the assigned_to (Link) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -766,7 +766,7 @@ msgstr "Tarefa"
 
 #: frontend/src/components/ListBulkActions.vue:152
 msgid "Assignment Cleared Successfully"
-msgstr ""
+msgstr "A atribuição foi removida com sucesso"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:145
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:605
@@ -780,7 +780,7 @@ msgstr "Dias de tarefa"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:471
 msgid "Assignment Days are required"
-msgstr ""
+msgstr "Os dias de atribuição são obrigatórios"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -791,23 +791,23 @@ msgstr "Regra de atribuição"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:698
 msgid "Assignment Rule Created"
-msgstr ""
+msgstr "Regra de atribuição criada"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue:123
 msgid "Assignment Rule Deleted"
-msgstr ""
+msgstr "Regra de atribuição excluída"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue:155
 msgid "Assignment Rule Duplicated"
-msgstr ""
+msgstr "Regra de atribuição duplicada"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:780
 msgid "Assignment Rule Updated"
-msgstr ""
+msgstr "Regra de atribuição atualizada"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue:187
 msgid "Assignment Rule {0} Updated"
-msgstr ""
+msgstr "Regra de atribuição {0} atualizada"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRules.vue:7
 #: frontend/src/components/Settings/Settings.vue:193
@@ -824,19 +824,19 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:305
 msgid "Assignment conditions are invalid or corrupt, recreate the conditions."
-msgstr ""
+msgstr "As condições de atribuição são inválidas ou estão corrompidas. Crie-as novamente."
 
 #: frontend/src/components/Controls/GridFieldsEditorModal.vue:188
 msgid "At least one field is required"
-msgstr ""
+msgstr "É necessário pelo menos um campo"
 
 #: frontend/src/components/Settings/Sla/utils.js:116
 msgid "At least one priority is required"
-msgstr ""
+msgstr "É necessária pelo menos uma prioridade"
 
 #: frontend/src/components/Settings/Sla/utils.js:204
 msgid "At least one valid Workday with Workday, Start Time, and End Time is required"
-msgstr ""
+msgstr "É necessário pelo menos um dia útil válido com dia da semana, horário inicial e horário final"
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:2
 #: frontend/src/components/FilesUploader/FilesUploader.vue:67
@@ -851,7 +851,7 @@ msgstr ""
 
 #: frontend/src/components/Controls/AttachControl.vue:14
 msgid "Attach file…"
-msgstr ""
+msgstr "Anexar arquivo…"
 
 #: frontend/src/pages/Deal.vue:601 frontend/src/pages/Lead.vue:453
 #: frontend/src/pages/MobileDeal.vue:473 frontend/src/pages/MobileLead.vue:320
@@ -860,21 +860,21 @@ msgstr "Anexos"
 
 #: frontend/src/components/Modals/EventModal.vue:120
 msgid "Attendees"
-msgstr ""
+msgstr "Participantes"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:869
 msgid "Attending status updated"
-msgstr ""
+msgstr "Status de participação atualizado"
 
 #. Label of the auth_token (Password) field in DocType 'CRM Twilio Settings'
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.json
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:53
 msgid "Auth Token"
-msgstr ""
+msgstr "Token de autenticação"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:213
 msgid "Auto Create Customer"
-msgstr ""
+msgstr "Criar cliente automaticamente"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:49
 msgid "Auto Update Expected Deal Value"
@@ -884,17 +884,17 @@ msgstr ""
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Auto update Expected Deal Value"
-msgstr ""
+msgstr "Atualizar automaticamente o valor esperado do negócio"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRules.vue:11
 msgid "Auto-assign leads/deals to the right sales user based on predefined conditions"
-msgstr ""
+msgstr "Atribui automaticamente leads e negócios ao vendedor correto com base em condições predefinidas"
 
 #. Description of the 'Condition' (Code) field in DocType 'CRM Service Level
 #. Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Auto-generated from the portal view — do not edit directly unless you know what you're doing! "
-msgstr ""
+msgstr "Gerado automaticamente a partir da visualização do portal. Não edite diretamente, a menos que saiba o que está fazendo! "
 
 #. Label of the autocomplete (Autocomplete) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_products/crm_products.json
@@ -906,14 +906,14 @@ msgstr "Preenchimento automático"
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/GeneralSettings.vue:64
 msgid "Automatically sets Communication Status to “Open” for the lead or deal when a new communication is created. Applies only when SLA is enabled"
-msgstr ""
+msgstr "Define automaticamente o status da comunicação como “Aberto” para o lead ou negócio quando uma nova comunicação é criada. Aplica-se somente quando o SLA está ativado"
 
 #. Description of the 'Mark lead/deal as replied on response' (Check) field in
 #. DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/GeneralSettings.vue:42
 msgid "Automatically sets Communication Status to “Replied” for the lead or deal when a response is received. Applies only when SLA is enabled"
-msgstr ""
+msgstr "Define automaticamente o status da comunicação como “Respondido” para o lead ou negócio quando uma resposta é recebida. Aplica-se somente quando o SLA está ativado"
 
 #. Description of the 'Auto update Expected Deal Value' (Check) field in
 #. DocType 'FCRM Settings'
@@ -928,23 +928,23 @@ msgstr ""
 
 #: crm/api/dashboard.py:252
 msgid "Average deal value of non won/lost deals"
-msgstr ""
+msgstr "Valor médio dos negócios que não foram ganhos nem perdidos"
 
 #: crm/api/dashboard.py:419
 msgid "Average deal value of ongoing & won deals"
-msgstr ""
+msgstr "Valor médio dos negócios em andamento e ganhos"
 
 #: crm/api/dashboard.py:365
 msgid "Average deal value of won deals"
-msgstr ""
+msgstr "Valor médio dos negócios ganhos"
 
 #: crm/api/dashboard.py:546
 msgid "Average time taken from deal creation to deal closure"
-msgstr ""
+msgstr "Tempo médio entre a criação e o fechamento do negócio"
 
 #: crm/api/dashboard.py:483
 msgid "Average time taken from lead creation to deal closure"
-msgstr ""
+msgstr "Tempo médio entre a criação do lead e o fechamento do negócio"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:77
 msgid "Avg Deal Value"
@@ -968,23 +968,23 @@ msgstr ""
 
 #: crm/api/dashboard.py:418
 msgid "Avg. deal value"
-msgstr ""
+msgstr "Valor médio dos negócios"
 
 #: crm/api/dashboard.py:251
 msgid "Avg. ongoing deal value"
-msgstr ""
+msgstr "Valor médio dos negócios em andamento"
 
 #: crm/api/dashboard.py:545
 msgid "Avg. time to close a deal"
-msgstr ""
+msgstr "Tempo médio para fechar um negócio"
 
 #: crm/api/dashboard.py:482
 msgid "Avg. time to close a lead"
-msgstr ""
+msgstr "Tempo médio para fechar um lead"
 
 #: crm/api/dashboard.py:364
 msgid "Avg. won deal value"
-msgstr ""
+msgstr "Valor médio dos negócios ganhos"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:22
 #: frontend/src/components/Dashboard/AddChartModal.vue:66
@@ -1009,11 +1009,11 @@ msgstr ""
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:25
 msgid "Back to File Upload"
-msgstr ""
+msgstr "Voltar ao envio de arquivos"
 
 #: frontend/src/components/Questionnaire.vue:94
 msgid "Back to previous question"
-msgstr ""
+msgstr "Voltar à pergunta anterior"
 
 #. Label of the background_sync_frequency (Select) field in DocType 'Lead Sync
 #. Source'
@@ -1025,7 +1025,7 @@ msgstr ""
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Backlog"
-msgstr ""
+msgstr "Pendências"
 
 #: frontend/src/components/Filter.vue:356
 msgid "Between"
@@ -1033,7 +1033,7 @@ msgstr "Entre"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:195
 msgid "Bidirectional sync of existing CRM Products and ERPNext Items. Runs in the background."
-msgstr ""
+msgstr "Sincronização bidirecional de produtos existentes do CRM com itens do ERPNext. É executada em segundo plano."
 
 #: frontend/src/components/Settings/Settings.vue:137
 msgid "Brand"
@@ -1054,7 +1054,7 @@ msgstr ""
 #. Label of the branding_tab (Tab Break) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Branding"
-msgstr ""
+msgstr "Identidade visual"
 
 #: frontend/src/components/Modals/EditValueModal.vue:2
 msgid "Bulk Edit"
@@ -1063,28 +1063,28 @@ msgstr "Edição em Massa"
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Busy"
-msgstr ""
+msgstr "Ocupado"
 
 #: frontend/src/components/Activities/EmailArea.vue:53
 #: frontend/src/components/EmailEditor.vue:52
 #: frontend/src/components/EmailEditor.vue:74
 msgid "CC"
-msgstr ""
+msgstr "CC"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "CRM Call Log"
-msgstr ""
+msgstr "Registro de chamadas do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_communication_status/crm_communication_status.json
 msgid "CRM Communication Status"
-msgstr ""
+msgstr "Status de comunicação do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_contacts/crm_contacts.json
 msgid "CRM Contacts"
-msgstr ""
+msgstr "Contatos do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_dashboard/crm_dashboard.json
@@ -1095,175 +1095,175 @@ msgstr ""
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "CRM Deal"
-msgstr ""
+msgstr "Negócio do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 msgid "CRM Deal Status"
-msgstr ""
+msgstr "Status do negócio do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_dropdown_item/crm_dropdown_item.json
 msgid "CRM Dropdown Item"
-msgstr ""
+msgstr "Opção da lista suspensa do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_exotel_settings/crm_exotel_settings.json
 msgid "CRM Exotel Settings"
-msgstr ""
+msgstr "Configurações do Exotel no CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "CRM Fields Layout"
-msgstr ""
+msgstr "Layout de campos do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 msgid "CRM Form Script"
-msgstr ""
+msgstr "Script de formulário do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_global_settings/crm_global_settings.json
 msgid "CRM Global Settings"
-msgstr ""
+msgstr "Configurações gerais do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_holiday/crm_holiday.json
 msgid "CRM Holiday"
-msgstr ""
+msgstr "Feriado do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "CRM Holiday List"
-msgstr ""
+msgstr "Lista de feriados do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_industry/crm_industry.json
 msgid "CRM Industry"
-msgstr ""
+msgstr "Setor do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "CRM Invitation"
-msgstr ""
+msgstr "Convite do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "CRM Lead"
-msgstr ""
+msgstr "Lead do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead_source/crm_lead_source.json
 msgid "CRM Lead Source"
-msgstr ""
+msgstr "Origem do lead do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "CRM Lead Status"
-msgstr ""
+msgstr "Status do lead do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_lost_reason/crm_lost_reason.json
 msgid "CRM Lost Reason"
-msgstr ""
+msgstr "Motivo de perda do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "CRM Notification"
-msgstr ""
+msgstr "Notificação do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "CRM Organization"
-msgstr ""
+msgstr "Organização do CRM"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "CRM Portal Page"
-msgstr ""
+msgstr "Página do portal do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_product/crm_product.json
 msgid "CRM Product"
-msgstr ""
+msgstr "Produto do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_product_sync_issue/crm_product_sync_issue.json
 msgid "CRM Product Sync Issue"
-msgstr ""
+msgstr "Problema na sincronização de produtos do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_products/crm_products.json
 msgid "CRM Products"
-msgstr ""
+msgstr "Produtos do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_rolling_response_time/crm_rolling_response_time.json
 msgid "CRM Rolling Response Time"
-msgstr ""
+msgstr "Tempo de resposta recorrente do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_sales_hierarchy/crm_sales_hierarchy.json
 msgid "CRM Sales Hierarchy"
-msgstr ""
+msgstr "Hierarquia de vendas do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 msgid "CRM Service Day"
-msgstr ""
+msgstr "Dia de atendimento do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "CRM Service Level Agreement"
-msgstr ""
+msgstr "Acordo de nível de serviço do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
 msgid "CRM Service Level Priority"
-msgstr ""
+msgstr "Prioridade do nível de serviço do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "CRM Status Change Log"
-msgstr ""
+msgstr "Registro de alterações de status do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "CRM Task"
-msgstr ""
+msgstr "Tarefa do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
 msgid "CRM Telephony Agent"
-msgstr ""
+msgstr "Agente de telefonia do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_telephony_phone/crm_telephony_phone.json
 msgid "CRM Telephony Phone"
-msgstr ""
+msgstr "Telefone do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "CRM Territory"
-msgstr ""
+msgstr "Território do CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.json
 msgid "CRM Twilio Settings"
-msgstr ""
+msgstr "Configurações do Twilio no CRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "CRM View Settings"
-msgstr ""
+msgstr "Configurações de visualização do CRM"
 
 #: frontend/src/components/ViewControls.vue:286
 msgid "CSV"
-msgstr ""
+msgstr "CSV"
 
 #: frontend/src/pages/PersonaForm.vue:81
 msgid "CSV imports"
-msgstr ""
+msgstr "Importações de CSV"
 
 #. Label of the calendar_tab (Tab Break) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -1277,7 +1277,7 @@ msgstr ""
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:9
 msgid "Call Details"
-msgstr ""
+msgstr "Detalhes da chamada"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:586
 msgid "Call Log"
@@ -1286,34 +1286,34 @@ msgstr "Registro de Chamadas"
 #. Label of the receiver (Link) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Call Received By"
-msgstr ""
+msgstr "Chamada atendida por"
 
 #: crm/integrations/api.py:158 crm/integrations/twilio/api.py:148
 #: crm/integrations/twilio/api.py:166
 msgid "Call log not found"
-msgstr ""
+msgstr "Registro de chamada não encontrado"
 
 #: frontend/src/components/Telephony/CallUI.vue:9
 msgid "Call using {0}"
-msgstr ""
+msgstr "Ligar usando {0}"
 
 #: frontend/src/components/Modals/EventModal.vue:63
 msgid "Call with John Doe"
-msgstr ""
+msgstr "Chamada com John Doe"
 
 #. Label of the caller (Link) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Caller"
-msgstr ""
+msgstr "Chamador"
 
 #: frontend/src/components/Telephony/CallUI.vue:25
 msgid "Calling Medium"
-msgstr ""
+msgstr "Canal de chamada"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:40
 #: frontend/src/components/Telephony/TwilioCallUI.vue:140
 msgid "Calling..."
-msgstr ""
+msgstr "Ligando..."
 
 #: frontend/src/pages/Deal.vue:586 frontend/src/pages/Lead.vue:438
 #: frontend/src/pages/MobileDeal.vue:457 frontend/src/pages/MobileLead.vue:305
@@ -1326,7 +1326,7 @@ msgstr "Câmera"
 
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.py:28
 msgid "Can't retry sync for this without source!"
-msgstr ""
+msgstr "Não é possível repetir a sincronização sem uma fonte!"
 
 #: frontend/src/components/Activities/CommentArea.vue:41
 #: frontend/src/components/BulkDeleteLinkedDocModal.vue:82
@@ -1352,39 +1352,39 @@ msgstr "Cancelar"
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 #: crm/fcrm/doctype/crm_task/crm_task.json frontend/src/utils/callLog.js:67
 msgid "Canceled"
-msgstr ""
+msgstr "Cancelado"
 
 #: crm/api/user.py:82
 msgid "Cannot assign this role"
-msgstr ""
+msgstr "Não é possível atribuir esta função"
 
 #: frontend/src/components/Settings/Users.vue:123
 msgid "Cannot change role of user with Admin access"
-msgstr ""
+msgstr "Não é possível alterar a função de um usuário com acesso de administrador"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.py:70
 msgid "Cannot delete standard items {0}"
-msgstr ""
+msgstr "Não é possível excluir os itens padrão {0}"
 
 #: crm/fcrm/doctype/crm_product/crm_product.py:81
 msgid "Cannot delete: linked ERPNext Item {0} is referenced by a Quotation. Remove the reference or delete the Item in ERPNext first."
-msgstr ""
+msgstr "Não é possível excluir: o item {0} vinculado ao ERPNext é usado em uma cotação. Remova a referência ou exclua primeiro o item no ERPNext."
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue:170
 msgid "Cannot enable rule without adding users in it"
-msgstr ""
+msgstr "Não é possível ativar a regra sem adicionar usuários"
 
 #: crm/api/__init__.py:109
 msgid "Cannot invite for this role"
-msgstr ""
+msgstr "Não é possível enviar convite para esta função"
 
 #: frontend/src/components/Settings/Hierarchy/useDragDrop.js:73
 msgid "Cannot move a manager under one of their own reports"
-msgstr ""
+msgstr "Não é possível colocar um gerente sob a gestão de um de seus próprios subordinados"
 
 #: crm/integrations/erpnext/utils.py:64
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve manually first."
-msgstr ""
+msgstr "Não é possível renomear: já existe um {0} '{1}' sem vínculo correspondente no outro sistema. Resolva manualmente primeiro."
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:85
 msgid "Capture"
@@ -1392,7 +1392,7 @@ msgstr "Capturar"
 
 #: frontend/src/pages/PersonaForm.vue:122
 msgid "Capture my first lead"
-msgstr ""
+msgstr "Capturar meu primeiro lead"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:591
 msgid "Capturing Leads"
@@ -1460,19 +1460,19 @@ msgstr "Tipo de Gráfico"
 #: frontend/src/components/Modals/ConvertToDealModal.vue:29
 #: frontend/src/components/Modals/ConvertToDealModal.vue:55
 msgid "Choose Existing"
-msgstr ""
+msgstr "Escolher existente"
 
 #: frontend/src/components/Modals/DealModal.vue:44
 msgid "Choose Existing Contact"
-msgstr ""
+msgstr "Escolher contato existente"
 
 #: frontend/src/components/Modals/DealModal.vue:37
 msgid "Choose Existing Organization"
-msgstr ""
+msgstr "Escolher organização existente"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:171
 msgid "Choose how long this SLA policy will be active."
-msgstr ""
+msgstr "Escolha por quanto tempo esta política de SLA ficará ativa."
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:6
 msgid "Choose how you want to use the application by setting your preferences."
@@ -1480,7 +1480,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue:9
 msgid "Choose how {0} are assigned among salespeople."
-msgstr ""
+msgstr "Escolha como atribuir {0} entre os vendedores."
 
 #: frontend/src/components/Settings/EmailAdd.vue:9
 msgid "Choose the Email Service Provider you want to configure."
@@ -1492,11 +1492,11 @@ msgstr "Escolha os dias da semana em que esta regra deve estar ativa."
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:107
 msgid "Choose which leads/deals are affected by this policy."
-msgstr ""
+msgstr "Escolha quais leads e negócios serão afetados por esta política."
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:229
 msgid "Choose which {0} are affected by this un-assignment rule."
-msgstr ""
+msgstr "Escolha quais {0} serão afetados por esta regra de remoção de atribuição."
 
 #: frontend/src/components/Controls/AttachControl.vue:58
 #: frontend/src/components/Controls/GeolocationControl.vue:40
@@ -1507,7 +1507,7 @@ msgstr "Limpar"
 
 #: frontend/src/components/Filter.vue:21 frontend/src/components/Filter.vue:149
 msgid "Clear All Filters"
-msgstr ""
+msgstr "Limpar todos os filtros"
 
 #: frontend/src/components/ListBulkActions.vue:134
 #: frontend/src/components/ListBulkActions.vue:142
@@ -1522,12 +1522,12 @@ msgstr "Limpar Dados de Demonstração"
 
 #: frontend/src/components/SortBy.vue:153
 msgid "Clear Sort"
-msgstr ""
+msgstr "Limpar ordenação"
 
 #. Label of the clear_table (Button) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Clear Table"
-msgstr ""
+msgstr "Limpar tabela"
 
 #: crm/templates/emails/helpdesk_invitation.html:7
 msgid "Click on the link below to complete your registration and set a new password"
@@ -1541,20 +1541,20 @@ msgstr "Fechar"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:39
 msgid "Close Panel"
-msgstr ""
+msgstr "Fechar painel"
 
 #: frontend/src/pages/PersonaForm.vue:126
 msgid "Close my first deal"
-msgstr ""
+msgstr "Fechar meu primeiro negócio"
 
 #. Label of the closed_date (Date) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Closed Date"
-msgstr ""
+msgstr "Data de fechamento"
 
 #: frontend/src/pages/PersonaForm.vue:100
 msgid "Collaborating with my team"
-msgstr ""
+msgstr "Colaborando com minha equipe"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:120
 msgid "Collapse"
@@ -1579,7 +1579,7 @@ msgstr "Coluna"
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: frontend/src/components/Kanban/KanbanSettings.vue:12
 msgid "Column Field"
-msgstr ""
+msgstr "Campo da coluna"
 
 #. Label of the columns (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
@@ -1607,19 +1607,19 @@ msgstr "Comentários"
 
 #: crm/api/dashboard.py:938
 msgid "Common reasons for losing deals"
-msgstr ""
+msgstr "Principais motivos de perda de negócios"
 
 #. Label of the communication_status (Link) field in DocType 'CRM Deal'
 #. Label of the communication_status (Link) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Communication Status"
-msgstr ""
+msgstr "Status da comunicação"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Communication Statuses"
-msgstr ""
+msgstr "Status de comunicação"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:130
 msgid "Company Name"
@@ -1628,11 +1628,11 @@ msgstr "Nome da Empresa"
 #. Label of the erpnext_company (Data) field in DocType 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "Company in ERPNext site"
-msgstr ""
+msgstr "Empresa no site do ERPNext"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:517
 msgid "Company name is required"
-msgstr ""
+msgstr "O nome da empresa é obrigatório"
 
 #: crm/templates/emails/helpdesk_invitation.html:10
 msgid "Complete Registration"
@@ -1647,7 +1647,7 @@ msgstr "Concluído"
 #. Option for the 'Device' (Select) field in DocType 'CRM Telephony Agent'
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
 msgid "Computer"
-msgstr ""
+msgstr "Computador"
 
 #. Label of the condition (Code) field in DocType 'CRM Service Level Agreement'
 #. Label of the condition_json (Code) field in DocType 'CRM Service Level
@@ -1661,7 +1661,7 @@ msgstr "Condição"
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:188
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:272
 msgid "Conditions for this rule were created from"
-msgstr ""
+msgstr "As condições desta regra foram criadas a partir de"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:107
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:163
@@ -1679,7 +1679,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:10
 msgid "Configure default settings for your CRM system, including default currency, date formats, and other system-wide preferences to ensure consistency across your system."
-msgstr ""
+msgstr "Configure as preferências padrão do CRM, incluindo moeda, formatos de data e outras opções gerais para manter a consistência do sistema."
 
 #: frontend/src/components/Settings/GeneralSettings.vue:8
 msgid "Configure general settings for your application"
@@ -1703,11 +1703,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:184
 msgid "Configure your Exotel Telephony Integration Settings here"
-msgstr ""
+msgstr "Configure aqui as opções da integração de telefonia com o Exotel"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:157
 msgid "Configure your Twilio Telephony Integration Settings here"
-msgstr ""
+msgstr "Configure aqui as opções da integração de telefonia com o Twilio"
 
 #: frontend/src/composables/demoData.js:26
 #: frontend/src/composables/frappecloud.js:29
@@ -1730,7 +1730,7 @@ msgstr "Confirmar senha"
 
 #: frontend/src/utils/index.js:822 frontend/src/utils/index.js:825
 msgid "Confirm {0}"
-msgstr ""
+msgstr "Confirmar {0}"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:274
 msgid "Connect ERPNext to Frappe CRM"
@@ -1738,7 +1738,7 @@ msgstr ""
 
 #: frontend/src/pages/Welcome.vue:35
 msgid "Connect your Email"
-msgstr ""
+msgstr "Conectar seu e-mail"
 
 #. Label of the contact (Link) field in DocType 'CRM Contacts'
 #. Label of the contact (Link) field in DocType 'CRM Deal'
@@ -1759,11 +1759,11 @@ msgstr ""
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:290
 msgid "Contact Already Exists"
-msgstr ""
+msgstr "O contato já existe"
 
 #: frontend/src/pages/MobileContact.vue:266
 msgid "Contact Image Updated"
-msgstr ""
+msgstr "Imagem do contato atualizada"
 
 #: frontend/src/pages/Deal.vue:693 frontend/src/pages/MobileDeal.vue:562
 msgid "Contact Removed"
@@ -1771,7 +1771,7 @@ msgstr ""
 
 #: frontend/src/components/Modals/AboutModal.vue:70
 msgid "Contact Support"
-msgstr ""
+msgstr "Entrar em contato com o suporte"
 
 #: frontend/src/pages/Contact.vue:448 frontend/src/pages/Contact.vue:461
 #: frontend/src/pages/Contact.vue:474 frontend/src/pages/Contact.vue:484
@@ -1788,7 +1788,7 @@ msgstr "Fale conosco"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:289
 msgid "Contact already exists with Email: {0}"
-msgstr ""
+msgstr "Já existe um contato com o e-mail: {0}"
 
 #: frontend/src/pages/Contact.vue:289
 msgid "Contact image updated"
@@ -1823,7 +1823,7 @@ msgstr "Tipo de conteúdo"
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:162
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:166
 msgid "Content is required"
-msgstr ""
+msgstr "O conteúdo é obrigatório"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:75
 msgid "Controls how numbers are displayed (e.g., commas, decimal separators)"
@@ -1855,23 +1855,23 @@ msgstr "Convertido"
 
 #: frontend/src/components/ListBulkActions.vue:94
 msgid "Converted Successfully"
-msgstr ""
+msgstr "Convertido com sucesso"
 
 #: frontend/src/utils/index.js:405
 msgid "Copied to Clipboard"
-msgstr ""
+msgstr "Copiado para a área de transferência"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:156
 msgid "Could not create the Frappe CRM custom fields on {0} automatically. If it is running the latest ERPNext, enable <b>Frappe CRM Data Synchronization</b> in its CRM Settings, Otherwise check the Error Log."
-msgstr ""
+msgstr "Não foi possível criar automaticamente os campos personalizados do Frappe CRM em {0}. Se estiver usando a versão mais recente do ERPNext, ative <b>Sincronização de dados do Frappe CRM</b> nas configurações do CRM. Caso contrário, consulte o registro de erros."
 
 #: frontend/src/components/Settings/Hierarchy/useRemoveNode.js:16
 msgid "Could not remove."
-msgstr ""
+msgstr "Não foi possível remover."
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:469
 msgid "Could not update report to"
-msgstr ""
+msgstr "Não foi possível atualizar a relação de subordinação"
 
 #: crm/api/dashboard.py:647 crm/api/dashboard.py:795 crm/api/dashboard.py:852
 #: crm/api/dashboard.py:945
@@ -1899,21 +1899,21 @@ msgstr "Criar"
 
 #: frontend/src/components/Modals/DealModal.vue:8
 msgid "Create Deal"
-msgstr ""
+msgstr "Criar negócio"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:514
 #: frontend/src/pages/Calendar.vue:7
 msgid "Create Event"
-msgstr ""
+msgstr "Criar evento"
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:155
 #: frontend/src/components/Modals/LeadModal.vue:8
 msgid "Create Lead"
-msgstr ""
+msgstr "Criar lead"
 
 #: frontend/src/components/Settings/emailConfig.js:58
 msgid "Create Lead from Incoming Emails"
-msgstr ""
+msgstr "Criar lead a partir de e-mails recebidos"
 
 #: frontend/src/components/Controls/Link.vue:50
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:58
@@ -1924,11 +1924,11 @@ msgstr "Criar novo"
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:66
 msgid "Create New Holiday List"
-msgstr ""
+msgstr "Criar nova lista de feriados"
 
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:20
 msgid "Create New Template"
-msgstr ""
+msgstr "Criar novo modelo"
 
 #: frontend/src/components/Modals/ViewModal.vue:9
 #: frontend/src/components/ViewControls.vue:697
@@ -1937,27 +1937,27 @@ msgstr ""
 
 #: frontend/src/components/Modals/EventModal.vue:12
 msgid "Create an Event"
-msgstr ""
+msgstr "Criar um evento"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:217
 msgid "Create customer in ERPNext when the deal status is changed"
-msgstr ""
+msgstr "Criar um cliente no ERPNext quando o status do negócio for alterado"
 
 #. Label of the create_customer_on_status_change (Check) field in DocType
 #. 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "Create customer on status change"
-msgstr ""
+msgstr "Criar cliente ao alterar o status"
 
 #: crm/fcrm/doctype/crm_product/crm_product.js:12
 #: crm/fcrm/doctype/crm_product/crm_product_list.js:10
 #: frontend/src/composables/document.js:29
 msgid "Create products as Items in ERPNext"
-msgstr ""
+msgstr "Criar produtos como itens no ERPNext"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:435
 msgid "Create quotation button on deal page and auto customer creation on deal status change will be disabled. Are you sure?"
-msgstr ""
+msgstr "O botão para criar cotação na página do negócio e a criação automática de clientes ao alterar o status serão desativados. Tem certeza?"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:371
 msgid "Create your first lead"
@@ -1996,7 +1996,7 @@ msgstr ""
 
 #: crm/api/dashboard.py:896
 msgid "Current pipeline distribution"
-msgstr ""
+msgstr "Distribuição atual do funil"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:621
 msgid "Custom Actions"
@@ -2047,7 +2047,7 @@ msgstr "Diário"
 
 #: crm/api/dashboard.py:639
 msgid "Daily performance of leads, deals, and wins"
-msgstr ""
+msgstr "Desempenho diário de leads, negócios e vendas"
 
 #: frontend/src/components/Settings/ThemeSwitcher.vue:89
 msgid "Dark"
@@ -2080,7 +2080,7 @@ msgstr "Dados"
 #. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Data Fields"
-msgstr ""
+msgstr "Campos de dados"
 
 #: frontend/src/pages/DataImport.vue:49
 msgid "Data Import"
@@ -2129,29 +2129,29 @@ msgstr ""
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 #: frontend/src/components/Settings/ERPNextSettings.vue:241
 msgid "Deal Status"
-msgstr ""
+msgstr "Status do negócio"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Deal Statuses"
-msgstr ""
+msgstr "Status de negócios"
 
 #. Label of the deal_value (Currency) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Deal Value"
-msgstr ""
+msgstr "Valor do negócio"
 
 #: crm/api/dashboard.py:1023
 msgid "Deal generation channel analysis"
-msgstr ""
+msgstr "Análise dos canais de geração de negócios"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:522
 msgid "Deal status is required"
-msgstr ""
+msgstr "O status do negócio é obrigatório"
 
 #: crm/api/dashboard.py:1078 crm/api/dashboard.py:1141
 msgid "Deal value"
-msgstr ""
+msgstr "Valor do negócio"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -2183,32 +2183,32 @@ msgstr ""
 
 #: crm/api/dashboard.py:846
 msgid "Deals by ongoing & won stage"
-msgstr ""
+msgstr "Negócios em andamento e ganhos por etapa"
 
 #: crm/api/dashboard.py:1130
 msgid "Deals by salesperson"
-msgstr ""
+msgstr "Negócios por vendedor"
 
 #: crm/api/dashboard.py:1022
 msgid "Deals by source"
-msgstr ""
+msgstr "Negócios por origem"
 
 #: crm/api/dashboard.py:895
 msgid "Deals by stage"
-msgstr ""
+msgstr "Negócios por etapa"
 
 #: crm/api/dashboard.py:1067
 msgid "Deals by territory"
-msgstr ""
+msgstr "Negócios por território"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:111
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:111
 msgid "Dear {{ lead_name }}, \\n\\nThis is a reminder for the payment of {{ grand_total }}. \\n\\nThanks, \\nFrappé"
-msgstr ""
+msgstr "Olá, {{ lead_name }}. \\n\\nEste é um lembrete sobre o pagamento de {{ grand_total }}. \\n\\nObrigado, \\nFrappé"
 
 #: frontend/src/utils/callLog.js:64
 msgid "Declined"
-msgstr ""
+msgstr "Recusado"
 
 #. Label of the default (Check) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
@@ -2218,17 +2218,17 @@ msgstr "Padrão"
 #. Label of the default_calendar_view (Select) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Default Calendar View"
-msgstr ""
+msgstr "Visualização padrão do calendário"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:41
 msgid "Default Calling Medium for Logged In User"
-msgstr ""
+msgstr "Canal de chamada padrão do usuário conectado"
 
 #. Label of the default_reminder_section (Section Break) field in DocType 'FCRM
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Default Event Notifications"
-msgstr ""
+msgstr "Notificações padrão de eventos"
 
 #: frontend/src/components/Settings/EmailAccountCard.vue:38
 msgid "Default Inbox"
@@ -2242,7 +2242,7 @@ msgstr "Recebimento padrão"
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:38
 msgid "Default Medium"
-msgstr ""
+msgstr "Canal padrão"
 
 #: frontend/src/components/Settings/emailConfig.js:50
 msgid "Default Outgoing"
@@ -2253,7 +2253,7 @@ msgstr "Saída Padrão"
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
 #: frontend/src/components/Settings/Sla/SlaPriorityList.vue:181
 msgid "Default Priority"
-msgstr ""
+msgstr "Prioridade padrão"
 
 #: frontend/src/components/Settings/EmailAccountCard.vue:40
 msgid "Default Sending"
@@ -2265,7 +2265,7 @@ msgstr ""
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:62
 msgid "Default Service Level Agreement already exists for {0}"
-msgstr ""
+msgstr "Já existe um acordo de nível de serviço padrão para {0}"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:34
 msgid "Default View"
@@ -2273,12 +2273,12 @@ msgstr "Visualização Padrão"
 
 #: frontend/src/components/Telephony/CallUI.vue:110
 msgid "Default calling medium set successfully to {0}"
-msgstr ""
+msgstr "Canal de chamada padrão definido como {0}"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:26
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:38
 msgid "Default statuses, custom fields and layouts restored successfully."
-msgstr ""
+msgstr "Status, campos personalizados e layouts padrão restaurados com sucesso."
 
 #: frontend/src/components/Settings/Settings.vue:132
 msgid "Defaults"
@@ -2286,7 +2286,7 @@ msgstr "Valores padrão"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:35
 msgid "Defines the default currency for all records, can be overridden at the field level"
-msgstr ""
+msgstr "Define a moeda padrão de todos os registros. Ela pode ser substituída no nível do campo"
 
 #: frontend/src/components/Activities/AttachmentArea.vue:131
 #: frontend/src/components/Activities/NoteArea.vue:12
@@ -2325,7 +2325,7 @@ msgstr "Excluir"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:34
 msgid "Delete & Restore"
-msgstr ""
+msgstr "Excluir e restaurar"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:69
 msgid "Delete All"
@@ -2334,15 +2334,15 @@ msgstr "Excluir tudo"
 #: frontend/src/components/Activities/AttachmentArea.vue:54
 #: frontend/src/components/Activities/AttachmentArea.vue:127
 msgid "Delete Attachment"
-msgstr ""
+msgstr "Excluir anexo"
 
 #: frontend/src/pages/MobileContact.vue:273
 msgid "Delete Contact"
-msgstr ""
+msgstr "Excluir contato"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:26
 msgid "Delete Event"
-msgstr ""
+msgstr "Excluir evento"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:79
 msgid "Delete Invitation"
@@ -2350,7 +2350,7 @@ msgstr ""
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:223
 msgid "Delete Linked Item"
-msgstr ""
+msgstr "Excluir item vinculado"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:222
 msgid "Delete Only User"
@@ -2358,11 +2358,11 @@ msgstr ""
 
 #: frontend/src/pages/MobileOrganization.vue:274
 msgid "Delete Organization"
-msgstr ""
+msgstr "Excluir organização"
 
 #: frontend/src/components/Activities/TaskArea.vue:59
 msgid "Delete Task"
-msgstr ""
+msgstr "Excluir tarefa"
 
 #: frontend/src/components/ViewControls.vue:1116
 #: frontend/src/components/ViewControls.vue:1124
@@ -2371,27 +2371,27 @@ msgstr ""
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:14
 msgid "Delete or unlink linked documents"
-msgstr ""
+msgstr "Excluir ou desvincular documentos vinculados"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:26
 msgid "Delete or unlink these linked documents before deleting this document"
-msgstr ""
+msgstr "Exclua ou desvincule estes documentos antes de excluir este documento"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:70
 msgid "Delete {0} Item(s)"
-msgstr ""
+msgstr "Excluir {0} item(ns)"
 
 #: frontend/src/components/BulkDeleteLinkedDocModal.vue:28
 msgid "Delete {0} items"
-msgstr ""
+msgstr "Excluir {0} itens"
 
 #: frontend/src/components/Activities/NoteArea.vue:73
 msgid "Deleting note..."
-msgstr ""
+msgstr "Excluindo nota..."
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:58
 msgid "Demo data restored successfully."
-msgstr ""
+msgstr "Dados de demonstração restaurados com sucesso."
 
 #. Label of the description (Text Editor) field in DocType 'CRM Holiday'
 #. Label of the description (Text Editor) field in DocType 'CRM Lost Reason'
@@ -2411,16 +2411,16 @@ msgstr "Descrição"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:426
 msgid "Description is required"
-msgstr ""
+msgstr "A descrição é obrigatória"
 
 #: frontend/src/components/Apps.vue:64
 msgid "Desk"
-msgstr ""
+msgstr "Área de trabalho"
 
 #. Label of the detail (Small Text) field in DocType 'CRM Product Sync Issue'
 #: crm/fcrm/doctype/crm_product_sync_issue/crm_product_sync_issue.json
 msgid "Detail"
-msgstr ""
+msgstr "Detalhe"
 
 #. Label of the details (Tab Break) field in DocType 'CRM Lead'
 #. Label of the details (Text Editor) field in DocType 'CRM Lead Source'
@@ -2437,14 +2437,14 @@ msgstr "Detalhes"
 #. Issue'
 #: crm/fcrm/doctype/crm_product_sync_issue/crm_product_sync_issue.json
 msgid "Detected On"
-msgstr ""
+msgstr "Detectado em"
 
 #. Label of the call_receiving_device (Select) field in DocType 'CRM Telephony
 #. Agent'
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:39
 msgid "Device"
-msgstr ""
+msgstr "Dispositivo"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
 #: frontend/src/components/Settings/ERPNextSettings.vue:32
@@ -2458,11 +2458,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:434
 msgid "Disable ERPNext Integration"
-msgstr ""
+msgstr "Desativar integração com o ERPNext"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:310
 msgid "Disable Sales Hierarchy"
-msgstr ""
+msgstr "Desativar hierarquia de vendas"
 
 #. Label of the disabled (Check) field in DocType 'CRM Product'
 #: crm/fcrm/doctype/crm_product/crm_product.json
@@ -2482,7 +2482,7 @@ msgstr ""
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:911
 msgid "Discard Unsaved Changes?"
-msgstr ""
+msgstr "Descartar alterações não salvas?"
 
 #. Label of the discount_percentage (Percent) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_products/crm_products.json
@@ -2501,7 +2501,7 @@ msgstr "Ocultar"
 #. Label of the dismissed (Check) field in DocType 'CRM Product Sync Issue'
 #: crm/fcrm/doctype/crm_product_sync_issue/crm_product_sync_issue.json
 msgid "Dismissed"
-msgstr ""
+msgstr "Descartado"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:114
 msgid "Display format for dates across the system"
@@ -2514,15 +2514,15 @@ msgstr ""
 #: crm/fcrm/doctype/crm_global_settings/crm_global_settings.json
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "DocType"
-msgstr ""
+msgstr "DocType"
 
 #: crm/api/doc.py:803
 msgid "Doctype is required"
-msgstr ""
+msgstr "O DocType é obrigatório"
 
 #: frontend/src/pages/MobileLead.vue:204
 msgid "Document Not Found"
-msgstr ""
+msgstr "Documento não encontrado"
 
 #. Label of the dt (Link) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
@@ -2535,19 +2535,19 @@ msgstr ""
 
 #: frontend/src/data/document.js:41
 msgid "Document does not exist"
-msgstr ""
+msgstr "O documento não existe"
 
 #: crm/api/activities.py:20 frontend/src/pages/MobileDeal.vue:354
 msgid "Document not found"
-msgstr ""
+msgstr "Documento não encontrado"
 
 #: frontend/src/data/document.js:55
 msgid "Document updated successfully"
-msgstr ""
+msgstr "Documento atualizado com sucesso"
 
 #: frontend/src/components/Modals/AboutModal.vue:60
 msgid "Documentation"
-msgstr ""
+msgstr "Documentação"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -2566,11 +2566,11 @@ msgstr "Baixar"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:24
 msgid "Drag & Drop files here or upload from"
-msgstr ""
+msgstr "Arraste e solte arquivos aqui ou envie de"
 
 #: frontend/src/components/FieldLayoutEditor.vue:253
 msgid "Drag a section or a field here to get started"
-msgstr ""
+msgstr "Arraste uma seção ou um campo para começar"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:60
 msgid "Drop files here"
@@ -2579,7 +2579,7 @@ msgstr "Solte arquivos aqui"
 #. Label of the dropdown_items_tab (Tab Break) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Dropdown items"
-msgstr ""
+msgstr "Opções da lista suspensa"
 
 #. Label of the due_date (Datetime) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -2609,27 +2609,27 @@ msgstr "Duplicar Regra de Atribuição"
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:513
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:675
 msgid "Duplicate Event"
-msgstr ""
+msgstr "Duplicar evento"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:112
 msgid "Duplicate SLA Policy"
-msgstr ""
+msgstr "Duplicar política de SLA"
 
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:10
 msgid "Duplicate Template"
-msgstr ""
+msgstr "Duplicar modelo"
 
 #: frontend/src/components/Modals/ViewModal.vue:8
 msgid "Duplicate View"
-msgstr ""
+msgstr "Duplicar visualização"
 
 #: frontend/src/components/Settings/Sla/utils.js:223
 msgid "Duplicate Workday found: {0}. Each Workday should be unique."
-msgstr ""
+msgstr "Dia útil duplicado: {0}. Cada dia útil deve ser único."
 
 #: frontend/src/components/Modals/EventModal.vue:11
 msgid "Duplicate an Event"
-msgstr ""
+msgstr "Duplicar um evento"
 
 #. Label of the duration (Duration) field in DocType 'CRM Call Log'
 #. Label of the duration (Duration) field in DocType 'CRM Status Change Log'
@@ -2641,12 +2641,12 @@ msgstr "Duração"
 #: frontend/src/components/Layouts/AppSidebar.vue:634
 #: frontend/src/components/Settings/Settings.vue:231
 msgid "ERPNext"
-msgstr ""
+msgstr "ERPNext"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "ERPNext CRM Settings"
-msgstr ""
+msgstr "Configurações do CRM no ERPNext"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:3
 #: frontend/src/components/Settings/ERPNextSettings.vue:9
@@ -2657,38 +2657,38 @@ msgstr "Configurações do ERPNext CRM"
 #. CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "ERPNext Site API's"
-msgstr ""
+msgstr "APIs do site do ERPNext"
 
 #. Label of the erpnext_site_url (Data) field in DocType 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "ERPNext Site URL"
-msgstr ""
+msgstr "URL do site ERPNext"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:161
 msgid "ERPNext custom fields not created"
-msgstr ""
+msgstr "Campos personalizados do ERPNext não foram criados"
 
 #: crm/fcrm/doctype/crm_product/crm_product.py:42
 msgid "ERPNext integration is active. Create an Item in ERPNext and it will appear in CRM Product automatically."
-msgstr ""
+msgstr "A integração com o ERPNext está ativa. Crie um item no ERPNext e ele aparecerá automaticamente como produto do CRM."
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:220
 msgid "ERPNext integration must be enabled on the same site"
-msgstr ""
+msgstr "A integração com o ERPNext deve estar ativada no mesmo site"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:70
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:87
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:523
 msgid "ERPNext is not installed in the current site"
-msgstr ""
+msgstr "O ERPNext não está instalado no site atual"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:71
 msgid "ERPNext is not installed on this site either install it or enter the URL of your ERPNext site to connect"
-msgstr ""
+msgstr "O ERPNext não está instalado neste site. Instale-o ou informe a URL do seu site ERPNext para estabelecer a conexão."
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:27
 msgid "ERPNext is not integrated with the CRM"
-msgstr ""
+msgstr "O ERPNext não está integrado ao CRM"
 
 #: frontend/src/components/Activities/CommentArea.vue:94
 #: frontend/src/components/FieldLayout/Field.vue:110
@@ -2705,11 +2705,11 @@ msgstr "Editar"
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:40
 msgid "Edit Call Log"
-msgstr ""
+msgstr "Editar registro de chamada"
 
 #: frontend/src/components/Modals/DataFieldsModal.vue:7
 msgid "Edit Data Fields Layout"
-msgstr ""
+msgstr "Editar layout dos campos de dados"
 
 #: frontend/src/components/Settings/EmailEdit.vue:6
 msgid "Edit Email"
@@ -2717,11 +2717,11 @@ msgstr ""
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:19
 msgid "Edit Event"
-msgstr ""
+msgstr "Editar evento"
 
 #: frontend/src/components/Modals/SidePanelModal.vue:7
 msgid "Edit Field Layout"
-msgstr ""
+msgstr "Editar layout de campo"
 
 #: frontend/src/components/Activities/DataFields.vue:17
 #: frontend/src/components/Controls/GridRowModal.vue:14
@@ -2732,59 +2732,59 @@ msgstr ""
 #: frontend/src/components/Modals/LeadModal.vue:16
 #: frontend/src/components/Modals/OrganizationModal.vue:16
 msgid "Edit Fields Layout"
-msgstr ""
+msgstr "Editar layout de campos"
 
 #: frontend/src/components/Controls/Grid.vue:57
 msgid "Edit Grid Fields"
-msgstr ""
+msgstr "Editar campos da grade"
 
 #: frontend/src/components/Controls/GridFieldsEditorModal.vue:7
 msgid "Edit Grid Fields Layout"
-msgstr ""
+msgstr "Editar layout dos campos da grade"
 
 #: frontend/src/components/Controls/GridRowFieldsModal.vue:7
 msgid "Edit Grid Row Fields Layout"
-msgstr ""
+msgstr "Editar layout dos campos da linha da grade"
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:20
 msgid "Edit Note"
-msgstr ""
+msgstr "Editar nota"
 
 #: frontend/src/components/Modals/QuickEntryModal.vue:7
 msgid "Edit Quick Entry Layout"
-msgstr ""
+msgstr "Editar layout de entrada rápida"
 
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:2
 msgid "Edit Response & Resolution"
-msgstr ""
+msgstr "Editar resposta e resolução"
 
 #: frontend/src/components/Controls/Grid.vue:414
 msgid "Edit Row"
-msgstr ""
+msgstr "Editar linha"
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:25
 msgid "Edit Task"
-msgstr ""
+msgstr "Editar tarefa"
 
 #: frontend/src/components/Modals/ViewModal.vue:6
 msgid "Edit View"
-msgstr ""
+msgstr "Editar visualização"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:4
 msgid "Edit Workday"
-msgstr ""
+msgstr "Editar dia útil"
 
 #: frontend/src/components/Modals/EventModal.vue:9
 msgid "Edit an Event"
-msgstr ""
+msgstr "Editar um evento"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:673
 msgid "Editing Event"
-msgstr ""
+msgstr "Editando evento"
 
 #: frontend/src/components/Controls/GridRowModal.vue:8
 msgid "Editing Row {0}"
-msgstr ""
+msgstr "Editando linha {0}"
 
 #. Label of the email (Data) field in DocType 'CRM Contacts'
 #. Label of the email (Data) field in DocType 'CRM Invitation'
@@ -2826,7 +2826,7 @@ msgstr ""
 
 #: frontend/src/components/Calendar/Attendee.vue:278
 msgid "Email Already Exists"
-msgstr ""
+msgstr "O e-mail já existe"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:608
 msgid "Email Communication"
@@ -2834,7 +2834,7 @@ msgstr ""
 
 #: frontend/src/components/EmailEditor.vue:222
 msgid "Email From Lead"
-msgstr ""
+msgstr "E-mail enviado pelo lead"
 
 #: frontend/src/components/Settings/emailConfig.js:19
 msgid "Email ID"
@@ -2847,7 +2847,7 @@ msgstr ""
 #. Label of the email_sent_at (Datetime) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Email Sent At"
-msgstr ""
+msgstr "E-mail enviado em"
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:8
 msgid "Email Settings"
@@ -2864,7 +2864,7 @@ msgstr ""
 
 #: frontend/src/components/Controls/EmailMultiSelect.vue:256
 msgid "Email already exists"
-msgstr ""
+msgstr "O e-mail já existe"
 
 #: frontend/src/components/CommunicationArea.vue:259
 msgid "Email sent"
@@ -2890,11 +2890,11 @@ msgstr "Vazio"
 
 #: frontend/src/components/Filter.vue:126
 msgid "Empty - Choose a field to filter by"
-msgstr ""
+msgstr "Vazio. Escolha um campo para filtrar"
 
 #: frontend/src/components/SortBy.vue:130
 msgid "Empty - Choose a field to sort by"
-msgstr ""
+msgstr "Vazio. Escolha um campo para ordenar"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.js:30
 #: frontend/src/components/Settings/ERPNextSettings.vue:287
@@ -2906,7 +2906,7 @@ msgstr "Ativar"
 
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:112
 msgid "Enable Exotel integration to make and receive calls directly from your CRM"
-msgstr ""
+msgstr "Ative a integração com o Exotel para fazer e receber chamadas diretamente pelo CRM"
 
 #. Label of the enable_forecasting (Check) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -2924,25 +2924,25 @@ msgstr "Ativar envio"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:62
 msgid "Enable Sales Hierarchy"
-msgstr ""
+msgstr "Ativar hierarquia de vendas"
 
 #. Label of the enable_sales_hierarchy (Check) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Enable Sales Hierarchy Permissions"
-msgstr ""
+msgstr "Ativar permissões da hierarquia de vendas"
 
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:119
 msgid "Enable Twilio integration to make and receive calls directly from your CRM"
-msgstr ""
+msgstr "Ative a integração com o Twilio para fazer e receber chamadas diretamente pelo CRM"
 
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:90
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:97
 msgid "Enable call recording for incoming and outgoing calls"
-msgstr ""
+msgstr "Ativar gravação de chamadas recebidas e realizadas"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:278
 msgid "Enable the integration to create quotations and auto create customers in ERPNext."
-msgstr ""
+msgstr "Ative a integração para criar cotações e clientes automaticamente no ERPNext."
 
 #. Label of the enabled (Check) field in DocType 'CRM Exotel Settings'
 #. Label of the enabled (Check) field in DocType 'CRM Form Script'
@@ -2995,7 +2995,7 @@ msgstr ""
 
 #: frontend/src/composables/event.js:250
 msgid "End Time Should Be After Start Time"
-msgstr ""
+msgstr "O horário final deve ser posterior ao horário inicial"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:189
 msgid "End Time is required"
@@ -3003,11 +3003,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:204
 msgid "End Time must be after Start Time"
-msgstr ""
+msgstr "O horário final deve ser posterior ao horário inicial"
 
 #: frontend/src/components/Settings/Sla/utils.js:262
 msgid "End Time must be after Start Time for: {0}"
-msgstr ""
+msgstr "O horário final deve ser posterior ao horário inicial para: {0}"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:160
 msgid "Enter Access Key"
@@ -3015,7 +3015,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:91
 msgid "Enter Access Token"
-msgstr ""
+msgstr "Insira o token de acesso"
 
 #: frontend/src/components/Settings/BrandSettings.vue:41
 msgid "Enter Brand Name"
@@ -3023,19 +3023,19 @@ msgstr ""
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:109
 msgid "Enter Exotel Number"
-msgstr ""
+msgstr "Insira o número do Exotel"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:134
 msgid "Enter Personal Mobile No."
-msgstr ""
+msgstr "Insira o número de celular pessoal"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:74
 msgid "Enter Source Name"
-msgstr ""
+msgstr "Insira o nome da origem"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:84
 msgid "Enter Twilio Number"
-msgstr ""
+msgstr "Insira o número do Twilio"
 
 #: frontend/src/components/Filter.vue:605
 msgid "Enter Value"
@@ -3043,15 +3043,15 @@ msgstr "Digite o Valor"
 
 #: frontend/src/components/Settings/LeadSyncing/leadSyncSourceConfig.js:31
 msgid "Enter your Facebook Access Token"
-msgstr ""
+msgstr "Insira seu token de acesso do Facebook"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:124
 msgid "Enter your personal mobile number used by Exotel to make calls"
-msgstr ""
+msgstr "Insira o número de celular pessoal usado pelo Exotel para fazer chamadas"
 
 #: frontend/src/components/FieldLayout/Field.vue:565
 msgid "Enter {0}"
-msgstr ""
+msgstr "Insira {0}"
 
 #: frontend/src/components/Filter.vue:67 frontend/src/components/Filter.vue:100
 #: frontend/src/components/Filter.vue:273
@@ -3066,35 +3066,35 @@ msgstr "Igual"
 
 #: frontend/src/pages/MobileLead.vue:205
 msgid "Error Occurred"
-msgstr ""
+msgstr "Ocorreu um erro"
 
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:139
 msgid "Error Syncing Lead"
-msgstr ""
+msgstr "Erro ao sincronizar lead"
 
 #: frontend/src/components/Modals/ConvertToDealModal.vue:173
 msgid "Error converting to deal: {0}"
-msgstr ""
+msgstr "Erro ao converter em negócio: {0}"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:290
 msgid "Error creating Lead Sync Source"
-msgstr ""
+msgstr "Erro ao criar a fonte de sincronização de leads"
 
 #: frontend/src/components/Modals/CallLogDetailModal.vue:358
 msgid "Error creating lead: {0}"
-msgstr ""
+msgstr "Erro ao criar lead: {0}"
 
 #: frontend/src/pages/MobileDeal.vue:355
 msgid "Error occurred"
-msgstr ""
+msgstr "Ocorreu um erro"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:384
 msgid "Error syncing leads"
-msgstr ""
+msgstr "Erro ao sincronizar leads"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:271
 msgid "Error updating Lead Sync Source"
-msgstr ""
+msgstr "Erro ao atualizar a fonte de sincronização de leads"
 
 #: frontend/src/pages/Deal.vue:766 frontend/src/pages/Lead.vue:498
 #: frontend/src/pages/MobileDeal.vue:619 frontend/src/pages/MobileLead.vue:360
@@ -3103,11 +3103,11 @@ msgstr ""
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:672
 msgid "Event Details"
-msgstr ""
+msgstr "Detalhes do evento"
 
 #: frontend/src/components/Modals/EventModal.vue:426
 msgid "Event ID is required"
-msgstr ""
+msgstr "O ID do evento é obrigatório"
 
 #. Label of the event_notifications (Table) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -3117,15 +3117,15 @@ msgstr ""
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:285
 msgid "Event Title"
-msgstr ""
+msgstr "Título do evento"
 
 #: frontend/src/pages/Calendar.vue:339
 msgid "Event created successfully"
-msgstr ""
+msgstr "Evento criado com sucesso"
 
 #: frontend/src/pages/Calendar.vue:418
 msgid "Event deleted successfully"
-msgstr ""
+msgstr "Evento excluído com sucesso"
 
 #: frontend/src/components/Notifications.vue:119
 #: frontend/src/pages/Deal.vue:581 frontend/src/pages/Lead.vue:433
@@ -3136,19 +3136,19 @@ msgstr "Eventos"
 #. Sync Source'
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 msgid "Every 10 Minutes"
-msgstr ""
+msgstr "A cada 10 minutos"
 
 #. Option for the 'Background Sync Frequency' (Select) field in DocType 'Lead
 #. Sync Source'
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 msgid "Every 15 Minutes"
-msgstr ""
+msgstr "A cada 15 minutos"
 
 #. Option for the 'Background Sync Frequency' (Select) field in DocType 'Lead
 #. Sync Source'
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 msgid "Every 5 Minutes"
-msgstr ""
+msgstr "A cada 5 minutos"
 
 #. Option for the 'Timeline Timestamp Format' (Select) field in DocType 'FCRM
 #. Settings'
@@ -3160,14 +3160,14 @@ msgstr ""
 #: frontend/src/components/ViewControls.vue:282
 #: frontend/src/components/ViewControls.vue:290
 msgid "Excel"
-msgstr ""
+msgstr "Excel"
 
 #. Label of the exchange_rate (Float) field in DocType 'CRM Deal'
 #. Label of the exchange_rate (Float) field in DocType 'CRM Organization'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "Exchange Rate"
-msgstr ""
+msgstr "Taxa de câmbio"
 
 #. Label of the exchange_rate_provider_section (Section Break) field in DocType
 #. 'FCRM Settings'
@@ -3185,33 +3185,33 @@ msgstr ""
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:52
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:180
 msgid "Exotel"
-msgstr ""
+msgstr "Exotel"
 
 #: crm/integrations/exotel/handler.py:113
 msgid "Exotel Exception"
-msgstr ""
+msgstr "Exceção do Exotel"
 
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:108
 msgid "Exotel Integration Disabled"
-msgstr ""
+msgstr "Integração com o Exotel desativada"
 
 #. Label of the exotel_number (Data) field in DocType 'CRM Telephony Agent'
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:99
 msgid "Exotel Number"
-msgstr ""
+msgstr "Número do Exotel"
 
 #: crm/integrations/exotel/handler.py:84
 msgid "Exotel Number Missing"
-msgstr ""
+msgstr "Número do Exotel não informado"
 
 #: crm/integrations/exotel/handler.py:88
 msgid "Exotel Number {0} is not valid"
-msgstr ""
+msgstr "O número do Exotel {0} não é válido"
 
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:8
 msgid "Exotel Settings"
-msgstr ""
+msgstr "Configurações do Exotel"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:120
 msgid "Expand"
@@ -3220,20 +3220,20 @@ msgstr "Expandir"
 #. Label of the expected_closure_date (Date) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Expected Closure Date"
-msgstr ""
+msgstr "Data prevista de fechamento"
 
 #. Label of the expected_deal_value (Currency) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Expected Deal Value"
-msgstr ""
+msgstr "Valor esperado do negócio"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:253
 msgid "Expected closure date is required."
-msgstr ""
+msgstr "A data prevista de fechamento é obrigatória."
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:251
 msgid "Expected deal value is required."
-msgstr ""
+msgstr "O valor esperado do negócio é obrigatório."
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -3256,56 +3256,56 @@ msgstr ""
 #. Name of a DocType
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
 msgid "FCRM Note"
-msgstr ""
+msgstr "Nota do FCRM"
 
 #. Name of a DocType
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "FCRM Settings"
-msgstr ""
+msgstr "Configurações do FCRM"
 
 #: frontend/src/components/EmailEditor.vue:25
 msgid "FROM"
-msgstr ""
+msgstr "DE"
 
 #. Option for the 'Type' (Select) field in DocType 'Lead Sync Source'
 #. Label of the facebook_section (Section Break) field in DocType 'Lead Sync
 #. Source'
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 msgid "Facebook"
-msgstr ""
+msgstr "Facebook"
 
 #. Label of the facebook_form_id (Data) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Facebook Form ID"
-msgstr ""
+msgstr "ID do formulário do Facebook"
 
 #. Name of a DocType
 #. Label of the facebook_lead_form (Link) field in DocType 'Lead Sync Source'
 #: crm/lead_syncing/doctype/facebook_lead_form/facebook_lead_form.json
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 msgid "Facebook Lead Form"
-msgstr ""
+msgstr "Formulário de leads do Facebook"
 
 #. Name of a DocType
 #: crm/lead_syncing/doctype/facebook_lead_form_question/facebook_lead_form_question.json
 msgid "Facebook Lead Form Question"
-msgstr ""
+msgstr "Pergunta do formulário de leads do Facebook"
 
 #. Label of the facebook_lead_id (Data) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Facebook Lead ID"
-msgstr ""
+msgstr "ID do lead no Facebook"
 
 #. Name of a DocType
 #. Label of the facebook_page (Link) field in DocType 'Lead Sync Source'
 #: crm/lead_syncing/doctype/facebook_page/facebook_page.json
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 msgid "Facebook Page"
-msgstr ""
+msgstr "Página do Facebook"
 
 #: frontend/src/pages/PersonaForm.vue:74
 msgid "Facebook/Instagram Ads"
-msgstr ""
+msgstr "Anúncios do Facebook/Instagram"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
@@ -3323,63 +3323,63 @@ msgstr "Falhou"
 #. Name of a DocType
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.json
 msgid "Failed Lead Sync Log"
-msgstr ""
+msgstr "Registro de falha na sincronização de leads"
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:111
 msgid "Failed to Add Users"
-msgstr ""
+msgstr "Não foi possível adicionar os usuários"
 
 #: frontend/src/components/Activities/WhatsAppArea.vue:247
 msgid "Failed to add reaction to the message"
-msgstr ""
+msgstr "Não foi possível adicionar uma reação à mensagem"
 
 #: crm/integrations/twilio/api.py:154
 msgid "Failed to capture Twilio recording"
-msgstr ""
+msgstr "Não foi possível capturar a gravação do Twilio"
 
 #: frontend/src/components/Settings/EmailAdd.vue:149
 msgid "Failed to create Email Account, Invalid credentials"
-msgstr ""
+msgstr "Não foi possível criar a conta de e-mail: credenciais inválidas"
 
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:180
 msgid "Failed to create template"
-msgstr ""
+msgstr "Não foi possível criar o modelo"
 
 #: frontend/src/components/Activities/CommentArea.vue:144
 msgid "Failed to delete comment"
-msgstr ""
+msgstr "Não foi possível excluir o comentário"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue:178
 msgid "Failed to delete lead sync source"
-msgstr ""
+msgstr "Não foi possível excluir a fonte de sincronização de leads"
 
 #: frontend/src/components/Activities/NoteArea.vue:75
 msgid "Failed to delete note"
-msgstr ""
+msgstr "Não foi possível excluir a nota"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:217
 msgid "Failed to delete template"
-msgstr ""
+msgstr "Não foi possível excluir o modelo"
 
 #: crm/api/exchange_rate.py:155
 msgid "Failed to fetch exchange rate from {0} to {1} on {2}. Please check your internet connection or try again later."
-msgstr ""
+msgstr "Não foi possível obter a taxa de câmbio de {0} para {1} em {2}. Verifique sua conexão com a internet ou tente novamente mais tarde."
 
 #: frontend/src/components/Modals/FieldLayoutDialog.vue:172
 msgid "Failed to load fields layout"
-msgstr ""
+msgstr "Não foi possível carregar o layout dos campos"
 
 #: frontend/src/data/script.js:150
 msgid "Failed to load file-based form controller: {0}"
-msgstr ""
+msgstr "Não foi possível carregar o controlador de formulário baseado em arquivo: {0}"
 
 #: frontend/src/data/script.js:168
 msgid "Failed to load form controller: {0}"
-msgstr ""
+msgstr "Não foi possível carregar o controlador do formulário: {0}"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:239
 msgid "Failed to rename template"
-msgstr ""
+msgstr "Não foi possível renomear o modelo"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:169
 #: frontend/src/components/Settings/ERPNextSettings.vue:342
@@ -3388,43 +3388,43 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:265
 msgid "Failed to save workday: {0}"
-msgstr ""
+msgstr "Não foi possível salvar o dia útil: {0}"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:144
 msgid "Failed to send WhatsApp message"
-msgstr ""
+msgstr "Não foi possível enviar a mensagem do WhatsApp"
 
 #: frontend/src/components/Activities/Activities.vue:604
 msgid "Failed to send WhatsApp template"
-msgstr ""
+msgstr "Não foi possível enviar o modelo do WhatsApp"
 
 #: frontend/src/components/CommunicationArea.vue:276
 msgid "Failed to send comment!"
-msgstr ""
+msgstr "Não foi possível enviar o comentário!"
 
 #: frontend/src/components/CommunicationArea.vue:260
 msgid "Failed to send email!"
-msgstr ""
+msgstr "Não foi possível enviar o e-mail!"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:333
 msgid "Failed to start sync"
-msgstr ""
+msgstr "Não foi possível iniciar a sincronização"
 
 #: frontend/src/components/Settings/EmailEdit.vue:216
 msgid "Failed to update Email Account, Invalid credentials"
-msgstr ""
+msgstr "Não foi possível atualizar a conta de e-mail: credenciais inválidas"
 
 #: crm/integrations/twilio/api.py:181
 msgid "Failed to update Twilio call status"
-msgstr ""
+msgstr "Não foi possível atualizar o status da chamada do Twilio"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:874
 msgid "Failed to update attending status"
-msgstr ""
+msgstr "Não foi possível atualizar o status de participação"
 
 #: frontend/src/components/Activities/CommentArea.vue:130
 msgid "Failed to update comment"
-msgstr ""
+msgstr "Não foi possível atualizar o comentário"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:106
 msgid "Failed to update password"
@@ -3432,16 +3432,16 @@ msgstr "Falha ao atualizar a senha"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:290
 msgid "Failed to update setting"
-msgstr ""
+msgstr "Não foi possível atualizar a configuração"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue:163
 msgid "Failed to update source"
-msgstr ""
+msgstr "Não foi possível atualizar a fonte"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:205
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:202
 msgid "Failed to update template"
-msgstr ""
+msgstr "Não foi possível atualizar o modelo"
 
 #. Option for the 'Type' (Select) field in DocType 'Failed Lead Sync Log'
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.json
@@ -3450,7 +3450,7 @@ msgstr "Falha"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:204
 msgid "Failure Logs"
-msgstr ""
+msgstr "Registros de falha"
 
 #. Label of the favicon (Attach) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -3466,7 +3466,7 @@ msgstr "Campo"
 #: frontend/src/components/Controls/GridFieldsEditorModal.vue:19
 #: frontend/src/components/Kanban/KanbanSettings.vue:47
 msgid "Fields Order"
-msgstr ""
+msgstr "Ordem dos campos"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:334
 msgid "File \"{0}\" was skipped because of invalid file type"
@@ -3474,11 +3474,11 @@ msgstr "O arquivo \"{0}\" foi ignorado devido a um tipo de arquivo inválido"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:355
 msgid "File \"{0}\" was skipped because only {1} uploads are allowed"
-msgstr ""
+msgstr "O arquivo \"{0}\" foi ignorado porque são permitidos apenas {1} envios"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:360
 msgid "File \"{0}\" was skipped because only {1} uploads are allowed for DocType \"{2}\""
-msgstr ""
+msgstr "O arquivo \"{0}\" foi ignorado porque são permitidos apenas {1} envios para o DocType \"{2}\""
 
 #: frontend/src/components/Filter.vue:6
 msgid "Filter"
@@ -3506,27 +3506,27 @@ msgstr "Nome"
 
 #: frontend/src/components/Modals/LeadModal.vue:129
 msgid "First Name is mandatory"
-msgstr ""
+msgstr "O nome é obrigatório"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'CRM Deal'
 #. Label of the first_responded_on (Datetime) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "First Responded On"
-msgstr ""
+msgstr "Primeira resposta enviada em"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Deal'
 #. Option for the 'SLA Status' (Select) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "First Response Due"
-msgstr ""
+msgstr "Prazo para a primeira resposta"
 
 #. Label of the first_response_time (Duration) field in DocType 'CRM Service
 #. Level Priority'
 #: crm/fcrm/doctype/crm_service_level_priority/crm_service_level_priority.json
 msgid "First Response TIme"
-msgstr ""
+msgstr "Tempo da primeira resposta"
 
 #. Label of the first_response_time (Duration) field in DocType 'CRM Deal'
 #. Label of the first_response_time (Duration) field in DocType 'CRM Lead'
@@ -3548,7 +3548,7 @@ msgstr "Precisão decimal"
 
 #: frontend/src/pages/PersonaForm.vue:91
 msgid "Following up consistently"
-msgstr ""
+msgstr "Manter o acompanhamento em dia"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:48
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:83
@@ -3558,7 +3558,7 @@ msgstr "Para"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:163
 msgid "For all-day events, <b>set a time</b> to send reminders before the event starts"
-msgstr ""
+msgstr "Para eventos de dia inteiro, <b>defina um horário</b> para enviar lembretes antes do início do evento"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:91
 msgid "Forecasted Revenue"
@@ -3566,7 +3566,7 @@ msgstr ""
 
 #: crm/api/dashboard.py:718
 msgid "Forecasted revenue"
-msgstr ""
+msgstr "Receita prevista"
 
 #. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
@@ -3576,16 +3576,16 @@ msgstr "Formulário"
 #. Label of the form_name (Data) field in DocType 'Facebook Lead Form'
 #: crm/lead_syncing/doctype/facebook_lead_form/facebook_lead_form.json
 msgid "Form Name"
-msgstr ""
+msgstr "Nome do formulário"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:18
 msgid "Form Script updated successfully"
-msgstr ""
+msgstr "Script do formulário atualizado com sucesso"
 
 #. Name of a Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Frappe CRM"
-msgstr ""
+msgstr "Frappe CRM"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:638
 msgid "Frappe CRM mobile"
@@ -3617,12 +3617,12 @@ msgstr "A partir da data"
 #. Label of the from (Data) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "From Number"
-msgstr ""
+msgstr "Número de origem"
 
 #. Label of the from_type (Data) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "From Type"
-msgstr ""
+msgstr "Tipo de origem"
 
 #. Label of the from_user (Link) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -3637,7 +3637,7 @@ msgstr "Do Usuário"
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/doctype/crm_rolling_response_time/crm_rolling_response_time.json
 msgid "Fulfilled"
-msgstr ""
+msgstr "Cumprido"
 
 #. Label of the full_name (Data) field in DocType 'CRM Contacts'
 #. Label of the lead_name (Data) field in DocType 'CRM Lead'
@@ -3654,11 +3654,11 @@ msgstr ""
 
 #: crm/api/dashboard.py:787
 msgid "Funnel conversion"
-msgstr ""
+msgstr "Conversão no funil"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:299
 msgid "GMT+5:30"
-msgstr ""
+msgstr "GMT+5:30"
 
 #. Label of the gender (Link) field in DocType 'CRM Contacts'
 #. Label of the gender (Link) field in DocType 'CRM Deal'
@@ -3679,11 +3679,11 @@ msgstr ""
 
 #: crm/api/dashboard.py:1068
 msgid "Geographic distribution of deals and revenue"
-msgstr ""
+msgstr "Distribuição geográfica dos negócios e da receita"
 
 #: frontend/src/components/Modals/AboutModal.vue:55
 msgid "GitHub Repository"
-msgstr ""
+msgstr "Repositório no GitHub"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:582
 msgid "Go Back"
@@ -3691,7 +3691,7 @@ msgstr "Voltar"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:158
 msgid "Go to Invite Page"
-msgstr ""
+msgstr "Ir para a página de convites"
 
 #: frontend/src/pages/Deal.vue:104 frontend/src/pages/Lead.vue:151
 msgid "Go to Website"
@@ -3699,24 +3699,24 @@ msgstr ""
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:524
 msgid "Going?"
-msgstr ""
+msgstr "Vai participar?"
 
 #: frontend/src/pages/PersonaForm.vue:75
 msgid "Google Ads"
-msgstr ""
+msgstr "Google Ads"
 
 #: frontend/src/components/Filter.vue:366
 msgid "Greater than"
-msgstr ""
+msgstr "Maior que"
 
 #: frontend/src/components/Filter.vue:368
 msgid "Greater than or equal to"
-msgstr ""
+msgstr "Maior ou igual a"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Grid Row"
-msgstr ""
+msgstr "Linha da grade"
 
 #. Label of the group_by_tab (Tab Break) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
@@ -3728,7 +3728,7 @@ msgstr "Agrupar por"
 #. Label of the group_by_field (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Group By Field"
-msgstr ""
+msgstr "Campo para agrupamento"
 
 #: frontend/src/components/GroupBy.vue:8
 msgid "Group By: "
@@ -3736,7 +3736,7 @@ msgstr "Agrupar Por: "
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:63
 msgid "Hang Up"
-msgstr ""
+msgstr "Encerrar chamada"
 
 #: crm/templates/emails/helpdesk_invitation.html:2
 msgid "Hello"
@@ -3748,7 +3748,7 @@ msgstr "Ajuda"
 
 #: frontend/src/components/CommunicationArea.vue:56
 msgid "Hi John, \\n\\nCan you please provide more details on this..."
-msgstr ""
+msgstr "Olá, João, \\n\\nVocê poderia fornecer mais detalhes sobre isso..."
 
 #. Label of the hidden (Check) field in DocType 'CRM Dropdown Item'
 #: crm/fcrm/doctype/crm_dropdown_item/crm_dropdown_item.json
@@ -3769,7 +3769,7 @@ msgstr "Ocultar rótulo"
 
 #: frontend/src/components/Controls/Password.vue:19
 msgid "Hide Password"
-msgstr ""
+msgstr "Ocultar senha"
 
 #: frontend/src/components/Controls/GridRowFieldsModal.vue:20
 #: frontend/src/components/Modals/DataFieldsModal.vue:20
@@ -3780,7 +3780,7 @@ msgstr "Ocultar pré-visualização"
 
 #: frontend/src/components/Activities/CallArea.vue:66
 msgid "Hide Recording"
-msgstr ""
+msgstr "Ocultar gravação"
 
 #. Option for the 'Priority' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -3796,14 +3796,14 @@ msgstr "Lista de Feriados"
 #. Label of the holiday_list_name (Data) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Holiday List Name"
-msgstr ""
+msgstr "Nome da lista de feriados"
 
 #. Label of the holidays_section (Section Break) field in DocType 'CRM Holiday
 #. List'
 #. Label of the holidays (Table) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Holidays"
-msgstr ""
+msgstr "Feriados"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:572
 #: frontend/src/components/Settings/HomeActions.vue:7
@@ -3819,31 +3819,31 @@ msgstr "A cada hora"
 
 #: frontend/src/pages/PersonaForm.vue:56
 msgid "How are you managing your sales today?"
-msgstr ""
+msgstr "Como você gerencia suas vendas atualmente?"
 
 #: frontend/src/pages/PersonaForm.vue:70
 msgid "How do new leads usually come to you?"
-msgstr ""
+msgstr "Como os novos leads costumam chegar até você?"
 
 #: frontend/src/pages/PersonaForm.vue:108
 msgid "How many people will use Frappe CRM?"
-msgstr ""
+msgstr "Quantas pessoas usarão o Frappe CRM?"
 
 #. Description of the 'Timeline Timestamp Format' (Select) field in DocType
 #. 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "How timestamps are shown in the activity timeline for all users"
-msgstr ""
+msgstr "Como datas e horários são exibidos na linha do tempo de atividades para todos os usuários"
 
 #: frontend/src/pages/PersonaForm.vue:60
 msgid "HubSpot"
-msgstr ""
+msgstr "HubSpot"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:199
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:283
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:151
 msgid "I understand, Add Conditions"
-msgstr ""
+msgstr "Entendi, quero adicionar condições"
 
 #. Label of the id (Data) field in DocType 'CRM Call Log'
 #. Label of the id (Data) field in DocType 'Facebook Lead Form'
@@ -3855,7 +3855,7 @@ msgstr ""
 #: crm/lead_syncing/doctype/facebook_page/facebook_page.json
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:112
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. Label of the icon (Code) field in DocType 'CRM Dropdown Item'
 #. Label of the icon (Data) field in DocType 'CRM View Settings'
@@ -3866,11 +3866,11 @@ msgstr "Ícone"
 
 #: frontend/src/components/Settings/emailConfig.js:61
 msgid "If enabled, a lead will be automatically created when an incoming email is received from an unknown contact."
-msgstr ""
+msgstr "Se ativado, um lead será criado automaticamente ao receber um e-mail de um contato desconhecido."
 
 #: frontend/src/components/Settings/emailConfig.js:53
 msgid "If enabled, all outgoing emails will be sent from this account. Note: Only one account can be default outgoing."
-msgstr ""
+msgstr "Se ativado, todos os e-mails enviados sairão desta conta. Observação: apenas uma conta pode ser definida como padrão para envio."
 
 #: frontend/src/components/Settings/emailConfig.js:45
 msgid "If enabled, all replies to your company (eg: replies@yourcompany.com) will come to this account. Note: Only one account can be default incoming."
@@ -3878,11 +3878,11 @@ msgstr "Se ativado, todas as respostas para sua empresa (por exemplo: replies@yo
 
 #: frontend/src/components/Settings/emailConfig.js:31
 msgid "If enabled, emails will be pulled from this account."
-msgstr ""
+msgstr "Se ativado, os e-mails serão importados desta conta."
 
 #: frontend/src/components/Settings/emailConfig.js:37
 msgid "If enabled, outgoing emails can be sent from this account."
-msgstr ""
+msgstr "Se ativado, esta conta poderá ser usada para enviar e-mails."
 
 #. Label of the image (Attach Image) field in DocType 'CRM Lead'
 #. Label of the image (Attach Image) field in DocType 'CRM Product'
@@ -3897,7 +3897,7 @@ msgstr "Importar"
 
 #: frontend/src/pages/PersonaForm.vue:121
 msgid "Import my existing data"
-msgstr ""
+msgstr "Importar meus dados existentes"
 
 #: frontend/src/components/Filter.vue:277
 #: frontend/src/components/Filter.vue:298
@@ -3916,11 +3916,11 @@ msgstr "Em Andamento"
 
 #: frontend/src/components/SLASection.vue:73
 msgid "In less than a minute"
-msgstr ""
+msgstr "Em menos de um minuto"
 
 #: frontend/src/components/Activities/CallArea.vue:31
 msgid "Inbound Call"
-msgstr ""
+msgstr "Chamada recebida"
 
 #: frontend/src/components/Settings/EmailAccountCard.vue:42
 msgid "Inbox"
@@ -3933,16 +3933,16 @@ msgstr "Recebida"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:41
 msgid "Incoming call..."
-msgstr ""
+msgstr "Recebendo chamada..."
 
 #: crm/api/user.py:32
 msgid "Incorrect current password. Please try again."
-msgstr ""
+msgstr "A senha atual está incorreta. Tente novamente."
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Industries"
-msgstr ""
+msgstr "Setores"
 
 #. Label of the industry (Link) field in DocType 'CRM Deal'
 #. Label of the industry (Data) field in DocType 'CRM Industry'
@@ -3963,16 +3963,16 @@ msgstr "Iniciada"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:36
 msgid "Initiating call..."
-msgstr ""
+msgstr "Iniciando chamada..."
 
 #: frontend/src/components/EmailEditor.vue:171
 msgid "Insert Email Template"
-msgstr ""
+msgstr "Inserir modelo de e-mail"
 
 #: frontend/src/components/CommentBox.vue:49
 #: frontend/src/components/EmailEditor.vue:147
 msgid "Insert Emoji"
-msgstr ""
+msgstr "Inserir emoji"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:628
 msgid "Integration"
@@ -3980,7 +3980,7 @@ msgstr ""
 
 #: crm/integrations/exotel/handler.py:72
 msgid "Integration Not Enabled"
-msgstr ""
+msgstr "Integração não ativada"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:144
 msgid "Integrations"
@@ -3998,97 +3998,97 @@ msgstr "Introdução"
 
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.py:57
 msgid "Invalid Account SID or Auth Token."
-msgstr ""
+msgstr "O SID da conta ou o token de autenticação é inválido."
 
 #: frontend/src/components/Modals/ContactModal.vue:110
 msgid "Invalid Email Address"
-msgstr ""
+msgstr "Endereço de e-mail inválido"
 
 #: frontend/src/stores/session.js:22
 msgid "Invalid Email or Password"
-msgstr ""
+msgstr "E-mail ou senha inválidos"
 
 #: crm/integrations/exotel/handler.py:88
 msgid "Invalid Exotel Number"
-msgstr ""
+msgstr "Número do Exotel inválido"
 
 #: frontend/src/components/Controls/GeolocationControl.vue:122
 msgid "Invalid GeoJSON"
-msgstr ""
+msgstr "GeoJSON inválido"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:495
 msgid "Invalid Site URL"
-msgstr ""
+msgstr "URL do site inválida"
 
 #: frontend/src/composables/event.js:247
 msgid "Invalid Start Or End Time"
-msgstr ""
+msgstr "Horário de início ou término inválido"
 
 #: crm/integrations/twilio/api.py:19
 msgid "Invalid Twilio account"
-msgstr ""
+msgstr "Conta do Twilio inválida"
 
 #: crm/integrations/twilio/api.py:24
 msgid "Invalid Twilio application"
-msgstr ""
+msgstr "Aplicativo do Twilio inválido"
 
 #: frontend/src/utils/index.js:304
 msgid "Invalid Website URL"
-msgstr ""
+msgstr "URL do site inválida"
 
 #: crm/lead_syncing/doctype/lead_sync_source/facebook.py:149
 msgid "Invalid access token provided for Facebook."
-msgstr ""
+msgstr "O token de acesso fornecido para o Facebook é inválido."
 
 #: crm/api/dashboard.py:88
 msgid "Invalid chart name"
-msgstr ""
+msgstr "Nome do gráfico inválido"
 
 #: crm/fcrm/doctype/crm_exotel_settings/crm_exotel_settings.py:42
 msgid "Invalid credentials"
-msgstr ""
+msgstr "Credenciais inválidas"
 
 #: frontend/src/components/Settings/emailConfig.js:185
 msgid "Invalid email ID"
-msgstr ""
+msgstr "Endereço de e-mail inválido"
 
 #: frontend/src/components/Modals/DealModal.vue:205
 #: frontend/src/components/Modals/LeadModal.vue:148
 msgid "Invalid email address"
-msgstr ""
+msgstr "Endereço de e-mail inválido"
 
 #: crm/api/contact.py:81 crm/api/contact.py:109
 msgid "Invalid field"
-msgstr ""
+msgstr "Campo inválido"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:390
 msgid "Invalid fields, check if all are filled in and values are correct."
-msgstr ""
+msgstr "Há campos inválidos. Verifique se todos estão preenchidos e se os valores estão corretos."
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:631
 msgid "Invalid fields: {0}"
-msgstr ""
+msgstr "Campos inválidos: {0}"
 
 #: frontend/src/components/Controls/DurationInput.vue:94
 msgid "Invalid format. Try: 1 hour 30 minutes, 2 hours, 45 seconds, 1:30:45, 90s"
-msgstr ""
+msgstr "Formato inválido. Tente: 1 hora e 30 minutos, 2 horas, 45 segundos, 1:30:45, 90s"
 
 #: frontend/src/components/Controls/DurationInput.vue:97
 msgid "Invalid format. Try: 1h 30m 45s, 1:30:45, 90s"
-msgstr ""
+msgstr "Formato inválido. Tente: 1h 30m 45s, 1:30:45, 90s"
 
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.py:269
 msgid "Invalid lead details supplied."
-msgstr ""
+msgstr "Os dados fornecidos para o lead são inválidos."
 
 #: crm/api/__init__.py:81 crm/api/__init__.py:85
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.py:61
 msgid "Invalid or expired key"
-msgstr ""
+msgstr "Chave inválida ou expirada"
 
 #: frontend/src/pages/InvalidPage.vue:6
 msgid "Invalid page or not permitted to access"
-msgstr ""
+msgstr "Página inválida ou acesso não permitido"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:187
 msgid "Invitations sent successfully"
@@ -4097,11 +4097,11 @@ msgstr ""
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:80
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:151
 msgid "Invite Agent"
-msgstr ""
+msgstr "Convidar agente"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:53
 msgid "Invite As"
-msgstr ""
+msgstr "Convidar como"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:32
 msgid "Invite By Email"
@@ -4121,7 +4121,7 @@ msgstr ""
 
 #: frontend/src/pages/PersonaForm.vue:125
 msgid "Invite my team"
-msgstr ""
+msgstr "Convidar minha equipe"
 
 #: frontend/src/components/Settings/InviteUserPage.vue:10
 msgid "Invite users to access CRM. Specify their roles to control access and permissions"
@@ -4134,7 +4134,7 @@ msgstr ""
 #. Label of the invited_by (Link) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
 msgid "Invited By"
-msgstr ""
+msgstr "Convidado por"
 
 #: frontend/src/components/Filter.vue:279
 #: frontend/src/components/Filter.vue:288
@@ -4183,26 +4183,26 @@ msgstr "É padrão"
 
 #: frontend/src/components/ListViews/EmptyState.vue:43
 msgid "It appears that there are currently no {0} available. You can create more {0} by using the Create button."
-msgstr ""
+msgstr "Não há nenhum {0} disponível no momento. Use o botão Criar para adicionar mais {0}."
 
 #. Description of the 'Enable Forecasting' (Check) field in DocType 'FCRM
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "It will make deal's \"Expected Closure Date\" & \"Expected Deal Value\" mandatory to get accurate forecasting insights"
-msgstr ""
+msgstr "Isso tornará a \"Data prevista de fechamento\" e o \"Valor esperado do negócio\" obrigatórios para gerar previsões mais precisas"
 
 #: crm/api/doc.py:806
 msgid "Items are required"
-msgstr ""
+msgstr "Os itens são obrigatórios"
 
 #: crm/api/doc.py:810
 msgid "Items must be a list"
-msgstr ""
+msgstr "Os itens devem estar em uma lista"
 
 #. Label of the json (JSON) field in DocType 'CRM Global Settings'
 #: crm/fcrm/doctype/crm_global_settings/crm_global_settings.json
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #. Label of the job_title (Data) field in DocType 'CRM Deal'
 #. Label of the job_title (Data) field in DocType 'CRM Lead'
@@ -4217,36 +4217,36 @@ msgstr "Cargo"
 #: frontend/src/components/Telephony/TaskPanel.vue:46
 #: frontend/src/pages/Calendar.vue:113
 msgid "John Doe"
-msgstr ""
+msgstr "João da Silva"
 
 #: frontend/src/components/Filter.vue:582
 msgid "John, Jane, Doe"
-msgstr ""
+msgstr "João, Maria, Silva"
 
 #: frontend/src/pages/PersonaForm.vue:127
 msgid "Just exploring"
-msgstr ""
+msgstr "Só estou conhecendo"
 
 #: frontend/src/pages/PersonaForm.vue:110
 msgid "Just me"
-msgstr ""
+msgstr "Apenas eu"
 
 #. Label of the kanban_tab (Tab Break) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 #: frontend/src/components/ViewControls.vue:392
 #: frontend/src/components/ViewControls.vue:608 frontend/src/utils/view.js:20
 msgid "Kanban"
-msgstr ""
+msgstr "Kanban"
 
 #. Label of the kanban_columns (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Kanban Columns"
-msgstr ""
+msgstr "Colunas do Kanban"
 
 #. Label of the kanban_fields (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Kanban Fields"
-msgstr ""
+msgstr "Campos do Kanban"
 
 #: frontend/src/components/Kanban/KanbanSettings.vue:8
 msgid "Kanban Settings"
@@ -4254,11 +4254,11 @@ msgstr "Configurações do Kanban"
 
 #: frontend/src/components/Kanban/KanbanSettings.vue:3
 msgid "Kanban settings"
-msgstr ""
+msgstr "Configurações do Kanban"
 
 #: frontend/src/pages/PersonaForm.vue:93
 msgid "Keeping my pipeline organized"
-msgstr ""
+msgstr "Manter meu pipeline organizado"
 
 #. Label of the key (Data) field in DocType 'CRM Invitation'
 #. Label of the key (Data) field in DocType 'Facebook Lead Form Question'
@@ -4270,7 +4270,7 @@ msgstr "Chave"
 #. Label of the kind (Select) field in DocType 'CRM Product Sync Issue'
 #: crm/fcrm/doctype/crm_product_sync_issue/crm_product_sync_issue.json
 msgid "Kind"
-msgstr ""
+msgstr "Tipo"
 
 #. Label of the label (Data) field in DocType 'CRM Dropdown Item'
 #. Label of the label (Data) field in DocType 'CRM View Settings'
@@ -4300,7 +4300,7 @@ msgstr "Últimos 30 dias"
 
 #: frontend/src/components/Filter.vue:661
 msgid "Last 6 Months"
-msgstr ""
+msgstr "Últimos 6 meses"
 
 #: frontend/src/pages/Dashboard.vue:210
 msgid "Last 60 Days"
@@ -4340,20 +4340,20 @@ msgstr "Último trimestre"
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Last Responded On"
-msgstr ""
+msgstr "Última resposta enviada em"
 
 #. Label of the last_response_time (Duration) field in DocType 'CRM Deal'
 #. Label of the last_response_time (Duration) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Last Response Time"
-msgstr ""
+msgstr "Tempo da última resposta"
 
 #. Label of the last_status_change_log (Link) field in DocType 'CRM Status
 #. Change Log'
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "Last Status Change Log"
-msgstr ""
+msgstr "Registro da última alteração de status"
 
 #. Label of the last_synced_at (Datetime) field in DocType 'Lead Sync Source'
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
@@ -4403,17 +4403,17 @@ msgstr "Lead"
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.json
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:40
 msgid "Lead Data"
-msgstr ""
+msgstr "Dados do lead"
 
 #. Label of the lead_details_tab (Tab Break) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Lead Details"
-msgstr ""
+msgstr "Detalhes do lead"
 
 #. Label of the lead_name (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Lead Name"
-msgstr ""
+msgstr "Nome do lead"
 
 #. Label of the lead_owner (Link) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -4422,7 +4422,7 @@ msgstr "Proprietário do Lead"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:142
 msgid "Lead Owner cannot be same as the Lead Email Address"
-msgstr ""
+msgstr "O responsável pelo lead não pode ter o mesmo endereço de e-mail do lead"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -4433,16 +4433,16 @@ msgstr ""
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Lead Statuses"
-msgstr ""
+msgstr "Status de leads"
 
 #. Name of a DocType
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.json
 msgid "Lead Sync Source"
-msgstr ""
+msgstr "Fonte de sincronização de leads"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:285
 msgid "Lead Sync Source created successfully"
-msgstr ""
+msgstr "Fonte de sincronização de leads criada com sucesso"
 
 #: frontend/src/components/Settings/Settings.vue:237
 msgid "Lead Syncing"
@@ -4450,27 +4450,27 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:311
 msgid "Lead and deal visibility will no longer be restricted by the reporting tree. Are you sure?"
-msgstr ""
+msgstr "A visibilidade de leads e negócios não será mais limitada pela hierarquia de responsáveis. Deseja continuar?"
 
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.py:287
 msgid "Lead from call {0}"
-msgstr ""
+msgstr "Lead da chamada {0}"
 
 #: crm/api/dashboard.py:985
 msgid "Lead generation channel analysis"
-msgstr ""
+msgstr "Análise dos canais de geração de leads"
 
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.js:8
 msgid "Lead sync initiated."
-msgstr ""
+msgstr "Sincronização de leads iniciada."
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue:175
 msgid "Lead sync source deleted successfully"
-msgstr ""
+msgstr "Fonte de sincronização de leads excluída com sucesso"
 
 #: crm/api/dashboard.py:788
 msgid "Lead to deal conversion pipeline"
-msgstr ""
+msgstr "Funil de conversão de leads em negócios"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -4485,7 +4485,7 @@ msgstr ""
 
 #: crm/api/dashboard.py:984
 msgid "Leads by source"
-msgstr ""
+msgstr "Leads por origem"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:158
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:238
@@ -4505,11 +4505,11 @@ msgstr "Esquerda"
 
 #: frontend/src/components/Filter.vue:367
 msgid "Less than"
-msgstr ""
+msgstr "Menor que"
 
 #: frontend/src/components/Filter.vue:369
 msgid "Less than or equal to"
-msgstr ""
+msgstr "Menor ou igual a"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:47
 msgid "Library"
@@ -4529,11 +4529,11 @@ msgstr "Semelhante"
 
 #: frontend/src/components/FilesUploader/FilesUploaderArea.vue:51
 msgid "Link"
-msgstr ""
+msgstr "Link"
 
 #: crm/fcrm/doctype/crm_product/reconcile_job.py:100
 msgid "Linked Item {0} no longer exists"
-msgstr ""
+msgstr "O item vinculado {0} não existe mais"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:404
 msgid "Linked With"
@@ -4542,7 +4542,7 @@ msgstr "Relacionado com"
 #. Label of the links (Table) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Links"
-msgstr ""
+msgstr "Links"
 
 #. Option for the 'Apply To' (Select) field in DocType 'CRM Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'CRM View Settings'
@@ -4555,13 +4555,13 @@ msgstr "Lista"
 
 #: frontend/src/components/Activities/CallArea.vue:66
 msgid "Listen"
-msgstr ""
+msgstr "Ouvir"
 
 #. Label of the load_default_columns (Check) field in DocType 'CRM View
 #. Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Load Default Columns"
-msgstr ""
+msgstr "Carregar colunas padrão"
 
 #: frontend/src/components/Kanban/KanbanView.vue:144
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:142
@@ -4590,25 +4590,25 @@ msgstr "Registro"
 
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:23
 msgid "Log ID"
-msgstr ""
+msgstr "ID do registro"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:136
 #: frontend/src/components/Activities/ActivityHeader.vue:179
 msgid "Log a Call"
-msgstr ""
+msgstr "Registrar uma chamada"
 
 #: frontend/src/composables/frappecloud.js:23
 msgid "Login to Frappe Cloud?"
-msgstr ""
+msgstr "Entrar no Frappe Cloud?"
 
 #: frontend/src/pages/NotPermitted.vue:21
 msgid "Login with Different Account"
-msgstr ""
+msgstr "Entrar com outra conta"
 
 #. Label of the brand_logo (Attach) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Type' (Select) field in DocType 'CRM Lead Status'
@@ -4626,7 +4626,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Lost Details"
-msgstr ""
+msgstr "Detalhes da perda"
 
 #. Label of the lost_notes (Text) field in DocType 'CRM Deal'
 #. Label of the lost_notes (Text) field in DocType 'CRM Lead'
@@ -4634,11 +4634,11 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: frontend/src/components/Modals/LostReasonModal.vue:28
 msgid "Lost Notes"
-msgstr ""
+msgstr "Observações sobre a perda"
 
 #: frontend/src/components/Modals/LostReasonModal.vue:84
 msgid "Lost Notes are required when Lost Reason is \"Other\""
-msgstr ""
+msgstr "As observações sobre a perda são obrigatórias quando o motivo da perda for \"Outro\""
 
 #. Label of the lost_reason (Link) field in DocType 'CRM Deal'
 #. Label of the lost_reason (Link) field in DocType 'CRM Lead'
@@ -4653,11 +4653,11 @@ msgstr "Motivo da Perda"
 
 #: frontend/src/components/Modals/LostReasonModal.vue:80
 msgid "Lost Reason is required"
-msgstr ""
+msgstr "O motivo da perda é obrigatório"
 
 #: crm/api/dashboard.py:937
 msgid "Lost deal reasons"
-msgstr ""
+msgstr "Motivos de perda de negócios"
 
 #. Option for the 'Priority' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
@@ -4689,7 +4689,7 @@ msgstr ""
 
 #: frontend/src/components/Activities/AttachmentArea.vue:98
 msgid "Make attachment {0}"
-msgstr ""
+msgstr "Tornar o anexo {0}"
 
 #: frontend/src/components/Activities/AttachmentArea.vue:107
 msgid "Make {0}"
@@ -4697,7 +4697,7 @@ msgstr "Criar {0}"
 
 #: frontend/src/components/Telephony/CallUI.vue:32
 msgid "Make {0} as default calling medium"
-msgstr ""
+msgstr "Definir {0} como canal de chamada padrão"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:35
 msgid "Makes \"Expected Closure Date\" and \"Expected Deal Value\" mandatory for deal value forecasting"
@@ -4709,7 +4709,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:4
 msgid "Manage ERPNext integration settings"
-msgstr ""
+msgstr "Gerenciar as configurações de integração com o ERPNext"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:100
 msgid "Manage your account emails and email signature for communication."
@@ -4717,7 +4717,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/EmailAccountList.vue:11
 msgid "Manage your email accounts to send and receive emails directly from CRM. You can add multiple accounts and set one as default for incoming and outgoing emails."
-msgstr ""
+msgstr "Gerencie suas contas de e-mail para enviar e receber mensagens diretamente pelo CRM. Você pode adicionar várias contas e definir uma como padrão para recebimento e envio."
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:36
 msgid "Manage your email signature"
@@ -4729,7 +4729,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:4
 msgid "Manage your service level agreement policies"
-msgstr ""
+msgstr "Gerencie suas políticas de SLA"
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:93
 #: frontend/src/components/Settings/InviteUserPage.vue:163
@@ -4743,32 +4743,32 @@ msgstr ""
 
 #: frontend/src/pages/PersonaForm.vue:97
 msgid "Managing contacts and companies"
-msgstr ""
+msgstr "Gerenciar contatos e organizações"
 
 #: frontend/src/components/Modals/DoctypeModal.vue:122
 #: frontend/src/data/document.js:68
 msgid "Mandatory field error: {0}"
-msgstr ""
+msgstr "Erro em campo obrigatório: {0}"
 
 #: crm/lead_syncing/doctype/facebook_lead_form/facebook_lead_form.py:48
 msgid "Mandatory field(s) {0} must be mapped"
-msgstr ""
+msgstr "Os campos obrigatórios {0} precisam ser mapeados"
 
 #: frontend/src/components/Modals/FieldLayoutDialog.vue:207
 #: frontend/src/data/document.js:226 frontend/src/data/document.js:228
 msgid "Mandatory fields required: {0}"
-msgstr ""
+msgstr "Campos obrigatórios: {0}"
 
 #. Option for the 'Telephony Medium' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Manual"
-msgstr ""
+msgstr "Manual"
 
 #. Label of the mapped_to_crm_field (Autocomplete) field in DocType 'Facebook
 #. Lead Form Question'
 #: crm/lead_syncing/doctype/facebook_lead_form_question/facebook_lead_form_question.json
 msgid "Mapped to CRM Field"
-msgstr ""
+msgstr "Mapeado para o campo do CRM"
 
 #: frontend/src/components/Notifications.vue:22
 #: frontend/src/pages/MobileNotification.vue:13
@@ -4781,7 +4781,7 @@ msgstr "Marcar tudo como lido"
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/GeneralSettings.vue:38
 msgid "Mark lead/deal as replied on response"
-msgstr ""
+msgstr "Marcar o lead ou o negócio como respondido ao receber uma resposta"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:577
 msgid "Masters"
@@ -4790,11 +4790,11 @@ msgstr "Cadastros"
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:313
 #: frontend/src/components/Modals/EventModal.vue:86
 msgid "May 1, 2025"
-msgstr ""
+msgstr "1º de maio de 2025"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:539
 msgid "Maybe"
-msgstr ""
+msgstr "Talvez"
 
 #. Label of the medium (Data) field in DocType 'CRM Call Log'
 #. Option for the 'Priority' (Select) field in DocType 'CRM Task'
@@ -4824,11 +4824,11 @@ msgstr "Nome do meio"
 
 #: frontend/src/components/Telephony/ExotelCallUI.vue:126
 msgid "Minimize"
-msgstr ""
+msgstr "Minimizar"
 
 #: frontend/src/utils/callLog.js:69
 msgid "Missed Call"
-msgstr ""
+msgstr "Chamada perdida"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:628
 msgid "Missing mandatory fields: {0}"
@@ -4854,7 +4854,7 @@ msgstr "Telefone Celular."
 #: frontend/src/components/Modals/DealModal.vue:201
 #: frontend/src/components/Modals/LeadModal.vue:144
 msgid "Mobile No. should be a number"
-msgstr ""
+msgstr "O número de celular deve ser numérico"
 
 #: frontend/src/components/Telephony/CallUI.vue:20
 #: frontend/src/pages/Contact.vue:431
@@ -4863,7 +4863,7 @@ msgstr "Número de Celular"
 
 #: crm/integrations/exotel/handler.py:92
 msgid "Mobile Number Missing"
-msgstr ""
+msgstr "Número de celular não informado"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
@@ -4893,43 +4893,43 @@ msgstr ""
 
 #: frontend/src/pages/PersonaForm.vue:113
 msgid "More than 20"
-msgstr ""
+msgstr "Mais de 20"
 
 #: frontend/src/components/FieldLayoutEditor.vue:617
 msgid "Move Last Column to Next Section"
-msgstr ""
+msgstr "Mover a última coluna para a próxima seção"
 
 #: frontend/src/components/FieldLayoutEditor.vue:657
 msgid "Move Last Column to Next Tab"
-msgstr ""
+msgstr "Mover a última coluna para a próxima aba"
 
 #: frontend/src/components/FieldLayoutEditor.vue:627
 msgid "Move Last Column to Previous Section"
-msgstr ""
+msgstr "Mover a última coluna para a seção anterior"
 
 #: frontend/src/components/FieldLayoutEditor.vue:637
 msgid "Move Last Column to Previous Tab"
-msgstr ""
+msgstr "Mover a última coluna para a aba anterior"
 
 #: frontend/src/components/FieldLayoutEditor.vue:546
 msgid "Move to Next Tab"
-msgstr ""
+msgstr "Mover para a próxima aba"
 
 #: frontend/src/components/FieldLayoutEditor.vue:532
 msgid "Move to Previous Tab"
-msgstr ""
+msgstr "Mover para a aba anterior"
 
 #: frontend/src/components/Settings/Hierarchy/HierarchyRow.vue:160
 msgid "Move to top level"
-msgstr ""
+msgstr "Mover para o nível superior"
 
 #: frontend/src/components/Settings/Hierarchy/useDragDrop.js:100
 msgid "Move under {0}"
-msgstr ""
+msgstr "Mover para dentro de {0}"
 
 #: frontend/src/components/Modals/ViewModal.vue:30
 msgid "My Open Deals"
-msgstr ""
+msgstr "Meus negócios em aberto"
 
 #. Label of the title (Data) field in DocType 'CRM Dashboard'
 #. Label of the name1 (Data) field in DocType 'CRM Dropdown Item'
@@ -4968,7 +4968,7 @@ msgstr "Série de Atrib. de Nomes"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:98
 msgid "Nested Conditions"
-msgstr ""
+msgstr "Condições aninhadas"
 
 #. Label of the net_amount (Currency) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_products/crm_products.json
@@ -4993,7 +4993,7 @@ msgstr "Novo"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:12
 msgid "New Assignment Rule"
-msgstr ""
+msgstr "Nova regra de atribuição"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue:53
 msgid "New Assignment Rule Name"
@@ -5001,7 +5001,7 @@ msgstr "Novo nome da regra de atribuição"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:19
 msgid "New Comment"
-msgstr ""
+msgstr "Novo comentário"
 
 #: frontend/src/components/Modals/ContactModal.vue:8
 msgid "New Contact"
@@ -5017,11 +5017,11 @@ msgstr "Novo evento"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:9
 msgid "New Lead Sync Source"
-msgstr ""
+msgstr "Nova fonte de sincronização de leads"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:66
 msgid "New Message"
-msgstr ""
+msgstr "Nova mensagem"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:41
 #: frontend/src/pages/Deals.vue:509 frontend/src/pages/Leads.vue:543
@@ -5030,7 +5030,7 @@ msgstr "Nova Anotação"
 
 #: frontend/src/components/Modals/OrganizationModal.vue:8
 msgid "New Organization"
-msgstr ""
+msgstr "Nova organização"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:19
 msgid "New Password"
@@ -5038,20 +5038,20 @@ msgstr "Nova Senha"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:8
 msgid "New SLA Policy"
-msgstr ""
+msgstr "Nova política de SLA"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:118
 msgid "New SLA Policy Name"
-msgstr ""
+msgstr "Nome da nova política de SLA"
 
 #: frontend/src/components/SidePanelLayoutEditor.vue:131
 msgid "New Section"
-msgstr ""
+msgstr "Nova seção"
 
 #: frontend/src/components/FieldLayoutEditor.vue:359
 #: frontend/src/components/FieldLayoutEditor.vue:372
 msgid "New Tab"
-msgstr ""
+msgstr "Nova aba"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:48
 #: frontend/src/pages/Deals.vue:514 frontend/src/pages/Leads.vue:548
@@ -5060,23 +5060,23 @@ msgstr "Nova Tarefa"
 
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:10
 msgid "New Template"
-msgstr ""
+msgstr "Novo modelo"
 
 #: frontend/src/components/Modals/ConvertToDealModal.vue:67
 msgid "New contact will be created based on the person's details"
-msgstr ""
+msgstr "Um novo contato será criado com base nos dados da pessoa"
 
 #: frontend/src/components/Modals/ConvertToDealModal.vue:42
 msgid "New organization will be created based on the data in details section"
-msgstr ""
+msgstr "Uma nova organização será criada com base nos dados da seção de detalhes"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:123
 msgid "New password cannot be the same as current password"
-msgstr ""
+msgstr "A nova senha não pode ser igual à senha atual"
 
 #: crm/api/user.py:25
 msgid "New password cannot be the same as current password. Please choose a different password."
-msgstr ""
+msgstr "A nova senha não pode ser igual à senha atual. Escolha uma senha diferente."
 
 #: frontend/src/components/Modals/CreateDocumentModal.vue:84
 msgid "New {0}"
@@ -5091,32 +5091,32 @@ msgstr ""
 
 #: frontend/src/components/Filter.vue:709
 msgid "Next 6 Months"
-msgstr ""
+msgstr "Próximos 6 meses"
 
 #: frontend/src/components/Filter.vue:701
 msgid "Next Month"
-msgstr ""
+msgstr "Próximo mês"
 
 #: frontend/src/components/Filter.vue:705
 msgid "Next Quarter"
-msgstr ""
+msgstr "Próximo trimestre"
 
 #. Label of the next_step (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Next Step"
-msgstr ""
+msgstr "Próxima etapa"
 
 #: frontend/src/components/Filter.vue:697
 msgid "Next Week"
-msgstr ""
+msgstr "Próxima semana"
 
 #: frontend/src/components/Filter.vue:713
 msgid "Next Year"
-msgstr ""
+msgstr "Próximo ano"
 
 #: frontend/src/components/Questionnaire.vue:95
 msgid "Next question"
-msgstr ""
+msgstr "Próxima pergunta"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:535
 msgid "No"
@@ -5125,7 +5125,7 @@ msgstr "Não"
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "No Answer"
-msgstr ""
+msgstr "Sem resposta"
 
 #: frontend/src/components/Modals/SidePanelModal.vue:51
 #: frontend/src/pages/Deal.vue:281 frontend/src/pages/MobileDeal.vue:209
@@ -5142,11 +5142,11 @@ msgstr ""
 
 #: frontend/src/components/Activities/EventArea.vue:73
 msgid "No Events Scheduled"
-msgstr ""
+msgstr "Nenhum evento agendado"
 
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:68
 msgid "No Failure Logs Found"
-msgstr ""
+msgstr "Nenhum registro de falha encontrado"
 
 #: frontend/src/components/FieldLayoutEditor.vue:123
 msgid "No Label"
@@ -5158,7 +5158,7 @@ msgstr ""
 
 #: frontend/src/pages/MobileNotification.vue:65
 msgid "No New Notifications"
-msgstr ""
+msgstr "Nenhuma notificação nova"
 
 #: frontend/src/pages/Deal.vue:727
 msgid "No Primary Contact Set"
@@ -5166,7 +5166,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/SlaPriorityList.vue:86
 msgid "No Priorities in the list"
-msgstr ""
+msgstr "Nenhuma prioridade na lista"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:72
 msgid "No Results Found"
@@ -5175,7 +5175,7 @@ msgstr ""
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:56
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:57
 msgid "No Templates Found"
-msgstr ""
+msgstr "Nenhum modelo encontrado"
 
 #: frontend/src/components/Kanban/KanbanView.vue:103
 #: frontend/src/pages/Deals.vue:105 frontend/src/pages/Leads.vue:121
@@ -5185,7 +5185,7 @@ msgstr ""
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:39
 msgid "No Users Found"
-msgstr ""
+msgstr "Nenhum usuário encontrado"
 
 #: frontend/src/pages/MobileOrganization.vue:296
 #: frontend/src/pages/Organization.vue:333
@@ -5194,7 +5194,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:156
 msgid "No Workdays in the List"
-msgstr ""
+msgstr "Nenhum dia útil na lista"
 
 #: frontend/src/components/Settings/EmailEdit.vue:153
 #: frontend/src/components/Settings/Hierarchy/useDragDrop.js:63
@@ -5203,15 +5203,15 @@ msgstr "Nenhuma alteração realizada"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:323
 msgid "No companies found in the given site"
-msgstr ""
+msgstr "Nenhuma empresa encontrada no site informado"
 
 #: frontend/src/components/Activities/EventArea.vue:75
 msgid "No events coming up. Create a new one to keep things on track."
-msgstr ""
+msgstr "Não há eventos programados. Crie um novo para manter tudo em dia."
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:57
 msgid "No holiday list found"
-msgstr ""
+msgstr "Nenhuma lista de feriados encontrada"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:107
 msgid "No matching users"
@@ -5221,7 +5221,7 @@ msgstr ""
 #: frontend/src/components/Controls/EmailMultiSelect.vue:133
 #: frontend/src/components/frappe-ui/Autocomplete.vue:119
 msgid "No results found"
-msgstr ""
+msgstr "Nenhum resultado encontrado"
 
 #: frontend/src/components/Settings/Hierarchy/UserMultiSelect.vue:64
 msgid "No users found"
@@ -5229,7 +5229,7 @@ msgstr "Nenhum usuário encontrado"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:108
 msgid "No users in hierarchy"
-msgstr ""
+msgstr "Nenhum usuário na hierarquia"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:112
 msgid "No users match the current filter."
@@ -5238,11 +5238,11 @@ msgstr ""
 #: frontend/src/components/ListViews/EmptyState.vue:37
 #: frontend/src/pages/MobileOrganization.vue:145
 msgid "No {0} Found"
-msgstr ""
+msgstr "Nenhum registro de {0} encontrado"
 
 #: frontend/src/components/PrimaryDropdown.vue:33
 msgid "No {0} available"
-msgstr ""
+msgstr "Nenhum registro de {0} disponível"
 
 #: frontend/src/pages/MobileContact.vue:153
 msgid "No {0} found"
@@ -5250,7 +5250,7 @@ msgstr "Nenhum {0} encontrado"
 
 #: frontend/src/components/Controls/Grid.vue:27
 msgid "No."
-msgstr ""
+msgstr "Nº"
 
 #. Label of the no_of_employees (Select) field in DocType 'CRM Deal'
 #. Label of the no_of_employees (Select) field in DocType 'CRM Lead'
@@ -5263,7 +5263,7 @@ msgstr "Número de Funcionários"
 
 #: frontend/src/components/Activities/AudioPlayer.vue:148
 msgid "Normal"
-msgstr ""
+msgstr "Normal"
 
 #: crm/utils/__init__.py:134
 msgid "Not Allowed"
@@ -5288,23 +5288,23 @@ msgstr "Não Salvo"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:148
 msgid "Not Synced"
-msgstr ""
+msgstr "Não sincronizado"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:355
 msgid "Not allowed to add contact to Deal"
-msgstr ""
+msgstr "Você não tem permissão para adicionar um contato ao negócio"
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:497
 msgid "Not allowed to convert Lead to Deal"
-msgstr ""
+msgstr "Você não tem permissão para converter o lead em negócio"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:366
 msgid "Not allowed to remove contact from Deal"
-msgstr ""
+msgstr "Você não tem permissão para remover o contato do negócio"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:377
 msgid "Not allowed to set primary contact for Deal"
-msgstr ""
+msgstr "Você não tem permissão para definir o contato principal do negócio"
 
 #: frontend/src/components/Filter.vue:274
 #: frontend/src/components/Filter.vue:295
@@ -5313,11 +5313,11 @@ msgstr ""
 #: frontend/src/components/Filter.vue:350
 #: frontend/src/components/Filter.vue:365
 msgid "Not equals"
-msgstr ""
+msgstr "Diferente de"
 
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.py:32
 msgid "Not implemented yet!"
-msgstr ""
+msgstr "Ainda não implementado!"
 
 #: frontend/src/components/Filter.vue:278
 #: frontend/src/components/Filter.vue:299
@@ -5325,7 +5325,7 @@ msgstr ""
 #: frontend/src/components/Filter.vue:327
 #: frontend/src/components/Filter.vue:341
 msgid "Not in"
-msgstr ""
+msgstr "Não está em"
 
 #: frontend/src/components/Filter.vue:276
 #: frontend/src/components/Filter.vue:287
@@ -5333,7 +5333,7 @@ msgstr ""
 #: frontend/src/components/Filter.vue:325
 #: frontend/src/components/Filter.vue:339
 msgid "Not like"
-msgstr ""
+msgstr "Não corresponde a"
 
 #: crm/api/activities.py:25 crm/api/activities.py:179 crm/api/contact.py:34
 #: crm/api/contact.py:70 crm/api/contact.py:91
@@ -5345,15 +5345,15 @@ msgstr "Não permitido"
 
 #: crm/api/whatsapp.py:27
 msgid "Not permitted to access reference document {0} {1}."
-msgstr ""
+msgstr "Você não tem permissão para acessar o documento de referência {0} {1}."
 
 #: crm/api/whatsapp.py:274 crm/api/whatsapp.py:326
 msgid "Not permitted to access the referenced WhatsApp message."
-msgstr ""
+msgstr "Você não tem permissão para acessar a mensagem do WhatsApp referenciada."
 
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py:197
 msgid "Not permitted to modify fields layout"
-msgstr ""
+msgstr "Você não tem permissão para alterar o layout dos campos"
 
 #. Label of the note (Link) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
@@ -5364,7 +5364,7 @@ msgstr "Nota"
 
 #: frontend/src/components/Activities/NoteArea.vue:74
 msgid "Note deleted"
-msgstr ""
+msgstr "Nota excluída"
 
 #: frontend/src/pages/Deal.vue:596 frontend/src/pages/Lead.vue:448
 #: frontend/src/pages/MobileDeal.vue:468 frontend/src/pages/MobileLead.vue:315
@@ -5389,19 +5389,19 @@ msgstr "Notificação"
 #. Label of the notification_text (Text) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Notification Text"
-msgstr ""
+msgstr "Texto da notificação"
 
 #. Label of the notification_type_doc (Dynamic Link) field in DocType 'CRM
 #. Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Notification Type Doc"
-msgstr ""
+msgstr "Documento do tipo de notificação"
 
 #. Label of the notification_type_doctype (Link) field in DocType 'CRM
 #. Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
 msgid "Notification Type Doctype"
-msgstr ""
+msgstr "DocType do tipo de notificação"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:13
 #: frontend/src/components/Mobile/MobileSidebar.vue:23
@@ -5427,11 +5427,11 @@ msgstr "Formato de número"
 
 #: crm/api/dashboard.py:1075 crm/api/dashboard.py:1138
 msgid "Number of deals"
-msgstr ""
+msgstr "Número de negócios"
 
 #: crm/api/dashboard.py:1131
 msgid "Number of deals and total value per salesperson"
-msgstr ""
+msgstr "Número de negócios e valor total por vendedor"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:95
 msgid "Number of decimal places for non-currency numeric fields"
@@ -5448,14 +5448,14 @@ msgstr "Condição antiga"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:124
 msgid "Old Conditions"
-msgstr ""
+msgstr "Condições anteriores"
 
 #. Label of the old_parent (Link) field in DocType 'CRM Sales Hierarchy'
 #. Label of the old_parent (Link) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_sales_hierarchy/crm_sales_hierarchy.json
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Old Parent"
-msgstr ""
+msgstr "Item pai anterior"
 
 #. Option for the 'Timeline Sort Order' (Select) field in DocType 'FCRM
 #. Settings'
@@ -5477,7 +5477,7 @@ msgstr "Em Espera"
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "Ongoing"
-msgstr ""
+msgstr "Em andamento"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:73
 msgid "Ongoing Deals"
@@ -5485,23 +5485,23 @@ msgstr ""
 
 #: crm/api/dashboard.py:189
 msgid "Ongoing deals"
-msgstr ""
+msgstr "Negócios em andamento"
 
 #: crm/api/user.py:62 crm/api/user.py:95
 msgid "Only System Managers can assign the Sales Manager role"
-msgstr ""
+msgstr "Somente gerentes do sistema podem atribuir a função Gerente de Vendas"
 
 #: crm/api/user.py:59 crm/api/user.py:89
 msgid "Only System Managers can assign the System Manager role"
-msgstr ""
+msgstr "Somente gerentes do sistema podem atribuir a função Gerente do Sistema"
 
 #: crm/api/user.py:92 crm/api/user.py:137
 msgid "Only System Managers can modify other System Managers"
-msgstr ""
+msgstr "Somente gerentes do sistema podem alterar outros gerentes do sistema"
 
 #: frontend/src/utils/index.js:484
 msgid "Only image files are allowed"
-msgstr ""
+msgstr "Apenas arquivos de imagem são permitidos"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:135
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.py:68
@@ -5510,7 +5510,7 @@ msgstr "Apenas um {0} pode ser definido como primário."
 
 #: crm/api/whatsapp.py:16
 msgid "Only sales users can access WhatsApp features."
-msgstr ""
+msgstr "Somente usuários de vendas podem acessar os recursos do WhatsApp."
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Type' (Select) field in DocType 'CRM Lead Status'
@@ -5521,7 +5521,7 @@ msgstr "Aberto"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:88
 msgid "Open Nested Conditions"
-msgstr ""
+msgstr "Abrir condições aninhadas"
 
 #: frontend/src/pages/Organization.vue:97
 msgid "Open Website"
@@ -5530,7 +5530,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.js:6
 #: crm/fcrm/doctype/crm_lead/crm_lead.js:6
 msgid "Open in Portal"
-msgstr ""
+msgstr "Abrir no portal"
 
 #. Label of the open_in_new_window (Check) field in DocType 'CRM Dropdown Item'
 #: crm/fcrm/doctype/crm_dropdown_item/crm_dropdown_item.json
@@ -5555,7 +5555,7 @@ msgstr "Opções"
 
 #: frontend/src/pages/Welcome.vue:40
 msgid "Or create leads manually"
-msgstr ""
+msgstr "Ou crie leads manualmente"
 
 #. Label of the order_by_tab (Tab Break) field in DocType 'CRM View Settings'
 #. Label of the order_by (Code) field in DocType 'CRM View Settings'
@@ -5565,13 +5565,13 @@ msgstr "Ordenar Por"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:111
 msgid "Order of activities, emails, comments and calls in the timeline"
-msgstr ""
+msgstr "Ordem das atividades, e-mails, comentários e chamadas na linha do tempo"
 
 #. Description of the 'Timeline Sort Order' (Select) field in DocType 'FCRM
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Order of activities, emails, comments and calls in the timeline for all users"
-msgstr ""
+msgstr "Ordem das atividades, e-mails, comentários e chamadas na linha do tempo para todos os usuários"
 
 #. Label of the organization (Link) field in DocType 'CRM Deal'
 #. Label of the organization_tab (Tab Break) field in DocType 'CRM Deal'
@@ -5593,7 +5593,7 @@ msgstr "Organização"
 #. 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Organization Details"
-msgstr ""
+msgstr "Dados da organização"
 
 #. Label of the organization_logo (Attach Image) field in DocType 'CRM
 #. Organization'
@@ -5611,7 +5611,7 @@ msgstr "Nome da Organização"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py:503
 msgid "Organization or a primary Contact is required to create a customer"
-msgstr ""
+msgstr "É necessário informar uma organização ou um contato principal para criar um cliente"
 
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
@@ -5622,11 +5622,11 @@ msgstr ""
 
 #: frontend/src/pages/PersonaForm.vue:124
 msgid "Organize my contacts"
-msgstr ""
+msgstr "Organizar meus contatos"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:151
 msgid "Organizer"
-msgstr ""
+msgstr "Organizador"
 
 #: frontend/src/pages/PersonaForm.vue:65 frontend/src/pages/PersonaForm.vue:82
 #: frontend/src/pages/PersonaForm.vue:103
@@ -5640,7 +5640,7 @@ msgstr ""
 #. Label of the organization_tab (Tab Break) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Others"
-msgstr ""
+msgstr "Outros"
 
 #: frontend/src/components/Activities/CallArea.vue:31
 msgid "Outbound Call"
@@ -5658,7 +5658,7 @@ msgstr "Proprietário"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:146
 msgid "Owner: {0}"
-msgstr ""
+msgstr "Responsável: {0}"
 
 #. Label of the page (Link) field in DocType 'Facebook Lead Form'
 #: crm/lead_syncing/doctype/facebook_lead_form/facebook_lead_form.json
@@ -5673,7 +5673,7 @@ msgstr "Nome da Página"
 #. Label of the parent_crm_territory (Link) field in DocType 'CRM Territory'
 #: crm/fcrm/doctype/crm_territory/crm_territory.json
 msgid "Parent CRM Territory"
-msgstr ""
+msgstr "Território superior do CRM"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:114
 #: frontend/src/components/Settings/emailConfig.js:71
@@ -5682,11 +5682,11 @@ msgstr "Senha"
 
 #: crm/api/user.py:46
 msgid "Password Updated Successfully"
-msgstr ""
+msgstr "Senha atualizada com sucesso"
 
 #: crm/api/live_demo.py:24 crm/api/live_demo.py:32
 msgid "Password cannot be reset by Demo User {}"
-msgstr ""
+msgstr "O usuário de demonstração {} não pode redefinir a senha"
 
 #: frontend/src/components/Settings/emailConfig.js:188
 msgid "Password is required"
@@ -5694,19 +5694,19 @@ msgstr ""
 
 #: crm/api/user.py:43
 msgid "Password is too weak. {0}"
-msgstr ""
+msgstr "A senha é muito fraca. {0}"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:130
 msgid "Password must be at least 8 characters"
-msgstr ""
+msgstr "A senha deve ter pelo menos 8 caracteres"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:133
 msgid "Password must contain lowercase, uppercase, number, and symbol"
-msgstr ""
+msgstr "A senha deve conter letra minúscula, letra maiúscula, número e símbolo"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:98
 msgid "Password updated successfully"
-msgstr ""
+msgstr "Senha atualizada com sucesso"
 
 #: frontend/src/components/Modals/ChangePasswordModal.vue:143
 msgid "Passwords do not match"
@@ -5715,21 +5715,21 @@ msgstr "As senhas não coincidem"
 #: frontend/src/components/Modals/ChangePasswordModal.vue:47
 #: frontend/src/components/Modals/ChangePasswordModal.vue:149
 msgid "Passwords match"
-msgstr ""
+msgstr "As senhas coincidem"
 
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:10
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:38
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:38
 msgid "Payment Reminder"
-msgstr ""
+msgstr "Lembrete de pagamento"
 
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:69
 msgid "Payment Reminder from Frappé - (#{{ name }})"
-msgstr ""
+msgstr "Lembrete de pagamento da Frappé (#{{ name }})"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:69
 msgid "Payment reminder from Frappé - (#{{ name }})"
-msgstr ""
+msgstr "Lembrete de pagamento da Frappé (#{{ name }})"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -5746,19 +5746,19 @@ msgstr "Período"
 
 #: frontend/src/components/SalesHierarchyBanner.vue:9
 msgid "Permissions update"
-msgstr ""
+msgstr "Atualização de permissões"
 
 #. Label of the person_section (Section Break) field in DocType 'CRM Deal'
 #. Label of the person_tab (Tab Break) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Person"
-msgstr ""
+msgstr "Pessoa"
 
 #. Label of the persona_captured (Check) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Persona Captured"
-msgstr ""
+msgstr "Persona registrada"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:120
 msgid "Personal Mobile No."
@@ -5782,7 +5782,7 @@ msgstr "Números de telefone"
 
 #: frontend/src/pages/PersonaForm.vue:78
 msgid "Phone calls"
-msgstr ""
+msgstr "Chamadas telefônicas"
 
 #: frontend/src/components/ViewControls.vue:1097
 msgid "Pin View"
@@ -5791,7 +5791,7 @@ msgstr ""
 #. Label of the pinned (Check) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Pinned"
-msgstr ""
+msgstr "Fixado"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:601
 msgid "Pinned View"
@@ -5803,15 +5803,15 @@ msgstr ""
 
 #: frontend/src/pages/PersonaForm.vue:63
 msgid "Pipedrive"
-msgstr ""
+msgstr "Pipedrive"
 
 #: frontend/src/components/Activities/AudioPlayer.vue:176
 msgid "Playback Speed"
-msgstr ""
+msgstr "Velocidade de reprodução"
 
 #: crm/lead_syncing/doctype/lead_sync_source/facebook.py:169
 msgid "Please check your access token"
-msgstr ""
+msgstr "Verifique seu token de acesso"
 
 #: crm/integrations/twilio/twilio_handler.py:119
 msgid "Please enable twilio settings before making a call."
@@ -5819,7 +5819,7 @@ msgstr "Ative as configurações do twilio antes de fazer uma chamada."
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:155
 msgid "Please enter a valid URL"
-msgstr ""
+msgstr "Informe uma URL válida"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:239
 msgid "Please fix the errors in the form"
@@ -5827,7 +5827,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:88
 msgid "Please select a Priority"
-msgstr ""
+msgstr "Selecione uma prioridade"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:213
 msgid "Please select a currency before saving."
@@ -5835,7 +5835,7 @@ msgstr ""
 
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.py:67
 msgid "Please select a lead gen form before syncing!"
-msgstr ""
+msgstr "Selecione um formulário de geração de leads antes de sincronizar!"
 
 #: frontend/src/components/Modals/ConvertToDealModal.vue:133
 msgid "Please select an existing contact"
@@ -5847,7 +5847,7 @@ msgstr "Selecione uma organização existente"
 
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.py:55
 msgid "Please select weekly off day"
-msgstr ""
+msgstr "Selecione o dia de folga semanal"
 
 #: frontend/src/pages/Lead.vue:134
 msgid "Please set a mobile number to make calls"
@@ -5863,27 +5863,27 @@ msgstr ""
 
 #: crm/integrations/exotel/handler.py:72
 msgid "Please setup Exotel intergration"
-msgstr ""
+msgstr "Configure a integração com o Exotel"
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:261
 msgid "Please specify a reason for losing the deal."
-msgstr ""
+msgstr "Informe o motivo da perda do negócio."
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:150
 msgid "Please specify a reason for losing the lead."
-msgstr ""
+msgstr "Informe o motivo da perda do lead."
 
 #: crm/fcrm/doctype/crm_deal/crm_deal.py:263
 msgid "Please specify the reason for losing the deal."
-msgstr ""
+msgstr "Informe o motivo da perda do negócio."
 
 #: crm/fcrm/doctype/crm_lead/crm_lead.py:152
 msgid "Please specify the reason for losing the lead."
-msgstr ""
+msgstr "Informe o motivo da perda do lead."
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:62
 msgid "Policy Name"
-msgstr ""
+msgstr "Nome da política"
 
 #. Label of the position (Int) field in DocType 'CRM Deal Status'
 #. Label of the position (Int) field in DocType 'CRM Lead Status'
@@ -5912,27 +5912,27 @@ msgstr ""
 #. Label of the email (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Primary email"
-msgstr ""
+msgstr "E-mail principal"
 
 #. Label of the mobile_no (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Primary mobile no"
-msgstr ""
+msgstr "Celular principal"
 
 #. Label of the phone (Data) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "Primary phone"
-msgstr ""
+msgstr "Telefone principal"
 
 #. Label of the priorities (Table) field in DocType 'CRM Service Level
 #. Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Priorities"
-msgstr ""
+msgstr "Prioridades"
 
 #: frontend/src/components/Settings/Sla/utils.js:145
 msgid "Priorities must be unique"
-msgstr ""
+msgstr "As prioridades não podem se repetir"
 
 #. Label of the priority (Link) field in DocType 'CRM Service Level Priority'
 #. Label of the priority (Select) field in DocType 'CRM Task'
@@ -5947,11 +5947,11 @@ msgstr "Prioridade"
 
 #: frontend/src/components/Settings/Sla/utils.js:125
 msgid "Priority {0}: Priority Name is required"
-msgstr ""
+msgstr "Prioridade {0}: o nome da prioridade é obrigatório"
 
 #: frontend/src/components/Settings/Sla/utils.js:133
 msgid "Priority {0}: Response Time is required"
-msgstr ""
+msgstr "Prioridade {0}: o tempo de resposta é obrigatório"
 
 #. Label of the private (Check) field in DocType 'CRM Dashboard'
 #: crm/fcrm/doctype/crm_dashboard/crm_dashboard.json
@@ -5964,42 +5964,42 @@ msgstr "Privado"
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:488
 #: frontend/src/components/Modals/EventModal.vue:152
 msgid "Private or Public"
-msgstr ""
+msgstr "Privado ou público"
 
 #. Label of the probability (Percent) field in DocType 'CRM Deal'
 #. Label of the probability (Percent) field in DocType 'CRM Deal Status'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 msgid "Probability"
-msgstr ""
+msgstr "Probabilidade"
 
 #. Label of the product (Link) field in DocType 'CRM Product Sync Issue'
 #. Label of the product_code (Link) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_product_sync_issue/crm_product_sync_issue.json
 #: crm/fcrm/doctype/crm_products/crm_products.json
 msgid "Product"
-msgstr ""
+msgstr "Produto"
 
 #. Label of the product_code (Data) field in DocType 'CRM Product'
 #: crm/fcrm/doctype/crm_product/crm_product.json
 msgid "Product Code"
-msgstr ""
+msgstr "Código do produto"
 
 #. Label of the product_name (Data) field in DocType 'CRM Product'
 #. Label of the product_name (Data) field in DocType 'CRM Products'
 #: crm/fcrm/doctype/crm_product/crm_product.json
 #: crm/fcrm/doctype/crm_products/crm_products.json
 msgid "Product Name"
-msgstr ""
+msgstr "Nome do produto"
 
 #. Label of the sync_issues (Table) field in DocType 'ERPNext CRM Settings'
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
 msgid "Product Sync Issues"
-msgstr ""
+msgstr "Problemas na sincronização de produtos"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:330
 msgid "Product sync started. Items will appear shortly."
-msgstr ""
+msgstr "Sincronização de produtos iniciada. Os itens aparecerão em breve."
 
 #. Label of the products_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the products (Table) field in DocType 'CRM Deal'
@@ -6022,7 +6022,7 @@ msgstr ""
 
 #: crm/api/dashboard.py:719
 msgid "Projected vs actual revenue based on deal probability"
-msgstr ""
+msgstr "Receita projetada em comparação com a receita realizada, com base na probabilidade dos negócios"
 
 #. Label of the public (Check) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
@@ -6047,7 +6047,7 @@ msgstr "Quantidade"
 #. Label of the questions (Table) field in DocType 'Facebook Lead Form'
 #: crm/lead_syncing/doctype/facebook_lead_form/facebook_lead_form.json
 msgid "Questions"
-msgstr ""
+msgstr "Perguntas"
 
 #. Option for the 'Status' (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
@@ -6067,7 +6067,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'CRM Global Settings'
 #: crm/fcrm/doctype/crm_global_settings/crm_global_settings.json
 msgid "Quick Filters"
-msgstr ""
+msgstr "Filtros rápidos"
 
 #: frontend/src/components/ViewControls.vue:741
 msgid "Quick filters updated successfully"
@@ -6093,21 +6093,21 @@ msgstr "Motivo"
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:86
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:93
 msgid "Record Calls"
-msgstr ""
+msgstr "Gravar chamadas"
 
 #. Label of the record_call (Check) field in DocType 'CRM Exotel Settings'
 #: crm/fcrm/doctype/crm_exotel_settings/crm_exotel_settings.json
 msgid "Record Outgoing Calls"
-msgstr ""
+msgstr "Gravar chamadas realizadas"
 
 #. Label of the recording_url (Small Text) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Recording URL"
-msgstr ""
+msgstr "URL da gravação"
 
 #: crm/integrations/api.py:163
 msgid "Recording URL not found"
-msgstr ""
+msgstr "URL da gravação não encontrada"
 
 #. Label of the reference_name (Dynamic Link) field in DocType 'CRM
 #. Notification'
@@ -6117,7 +6117,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_task/crm_task.json
 #: crm/fcrm/doctype/fcrm_note/fcrm_note.json
 msgid "Reference Doc"
-msgstr ""
+msgstr "Documento de referência"
 
 #. Label of the reference_doctype (Link) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -6141,15 +6141,15 @@ msgstr "Nome de Referência"
 
 #: crm/api/whatsapp.py:21
 msgid "Reference document {0} {1} does not exist."
-msgstr ""
+msgstr "O documento de referência {0} {1} não existe."
 
 #: crm/api/whatsapp.py:270 crm/api/whatsapp.py:322
 msgid "Referenced WhatsApp message does not exist."
-msgstr ""
+msgstr "A mensagem do WhatsApp referenciada não existe."
 
 #: frontend/src/pages/PersonaForm.vue:79
 msgid "Referrals"
-msgstr ""
+msgstr "Indicações"
 
 #: frontend/src/components/ViewControls.vue:26
 #: frontend/src/components/ViewControls.vue:159
@@ -6159,19 +6159,19 @@ msgstr "Atualizar"
 
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:78
 msgid "Refresh Apps"
-msgstr ""
+msgstr "Atualizar aplicativos"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:157
 msgid "Refresh Companies"
-msgstr ""
+msgstr "Atualizar empresas"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:97
 msgid "Reject"
-msgstr ""
+msgstr "Recusar"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:163
 msgid "Reject Call"
-msgstr ""
+msgstr "Recusar chamada"
 
 #. Option for the 'Timeline Timestamp Format' (Select) field in DocType 'FCRM
 #. Settings'
@@ -6183,11 +6183,11 @@ msgstr ""
 
 #: frontend/src/components/Kanban/KanbanView.vue:169
 msgid "Reload Columns"
-msgstr ""
+msgstr "Recarregar colunas"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:67
 msgid "Reminders will be sent <b>before the event starts</b>, based on the configured time"
-msgstr ""
+msgstr "Os lembretes serão enviados <b>antes do início do evento</b>, conforme o horário configurado"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:175
 #: frontend/src/components/Controls/ImageUploader.vue:21
@@ -6202,11 +6202,11 @@ msgstr "Remover"
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:17
 msgid "Remove All"
-msgstr ""
+msgstr "Remover tudo"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:183
 msgid "Remove Group"
-msgstr ""
+msgstr "Remover grupo"
 
 #: frontend/src/pages/Contact.vue:53 frontend/src/pages/Lead.vue:98
 #: frontend/src/pages/MobileContact.vue:43
@@ -6218,11 +6218,11 @@ msgstr ""
 #: frontend/src/components/FieldLayoutEditor.vue:577
 #: frontend/src/components/FieldLayoutEditor.vue:583
 msgid "Remove Last Column"
-msgstr ""
+msgstr "Remover última coluna"
 
 #: frontend/src/components/FieldLayoutEditor.vue:607
 msgid "Remove Last Column (move fields to previous)"
-msgstr ""
+msgstr "Remover última coluna (mover campos para a anterior)"
 
 #: frontend/src/components/Settings/Profile/ProfileSettings.vue:161
 msgid "Remove Photo"
@@ -6236,30 +6236,30 @@ msgstr "Remover seção"
 #: frontend/src/components/FieldLayoutEditor.vue:422
 #: frontend/src/components/FieldLayoutEditor.vue:430
 msgid "Remove Tab"
-msgstr ""
+msgstr "Remover aba"
 
 #: crm/api/user.py:111
 msgid "Remove this user from the sales hierarchy before changing their role to Sales User"
-msgstr ""
+msgstr "Remova este usuário da hierarquia de vendas antes de alterar sua função para Vendedor"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:195
 msgid "Remove {0} from the hierarchy. What should happen to their direct reports?"
-msgstr ""
+msgstr "Remover {0} da hierarquia. O que deve acontecer com seus subordinados diretos?"
 
 #: frontend/src/components/Settings/Hierarchy/useRemoveNode.js:13
 msgid "Removed from hierarchy."
-msgstr ""
+msgstr "Removido da hierarquia."
 
 #. Label of the auto_reopen_on_new_communication (Check) field in DocType 'FCRM
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/GeneralSettings.vue:60
 msgid "Reopen lead/deal on new communication"
-msgstr ""
+msgstr "Reabrir lead ou negócio ao receber nova comunicação"
 
 #: frontend/src/pages/PersonaForm.vue:102
 msgid "Replacing my current CRM"
-msgstr ""
+msgstr "Substituir meu CRM atual"
 
 #: frontend/src/components/Activities/EmailArea.vue:30
 #: frontend/src/components/CommunicationArea.vue:9
@@ -6272,21 +6272,21 @@ msgstr "Todos os Registros"
 
 #: frontend/src/components/Modals/AboutModal.vue:65
 msgid "Report an Issue"
-msgstr ""
+msgstr "Relatar um problema"
 
 #: frontend/src/pages/PersonaForm.vue:101
 msgid "Reporting & forecasting"
-msgstr ""
+msgstr "Relatórios e previsões"
 
 #. Label of the reports_to (Link) field in DocType 'CRM Sales Hierarchy'
 #: crm/fcrm/doctype/crm_sales_hierarchy/crm_sales_hierarchy.json
 msgid "Reports To"
-msgstr ""
+msgstr "Superior hierárquico"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Required Fields"
-msgstr ""
+msgstr "Campos obrigatórios"
 
 #: frontend/src/components/Controls/GridFieldsEditorModal.vue:83
 #: frontend/src/components/Controls/GridRowFieldsModal.vue:30
@@ -6302,7 +6302,7 @@ msgstr "Redefinir alterações"
 
 #: crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.js:7
 msgid "Reset ERPNext Form Script"
-msgstr ""
+msgstr "Redefinir script de formulário do ERPNext"
 
 #: frontend/src/components/ColumnSettings.vue:86
 #: frontend/src/pages/Dashboard.vue:28
@@ -6313,21 +6313,21 @@ msgstr ""
 #. Time'
 #: crm/fcrm/doctype/crm_rolling_response_time/crm_rolling_response_time.json
 msgid "Responded On"
-msgstr ""
+msgstr "Respondido em"
 
 #. Label of the section_break_ufaf (Section Break) field in DocType 'CRM
 #. Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:215
 msgid "Response & Follow Up"
-msgstr ""
+msgstr "Resposta e acompanhamento"
 
 #. Label of the response_by (Datetime) field in DocType 'CRM Deal'
 #. Label of the response_by (Datetime) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Response By"
-msgstr ""
+msgstr "Responder até"
 
 #. Label of the response_details_section (Section Break) field in DocType 'CRM
 #. Deal'
@@ -6336,24 +6336,24 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Response Details"
-msgstr ""
+msgstr "Detalhes da resposta"
 
 #. Label of the response_time (Duration) field in DocType 'CRM Rolling Response
 #. Time'
 #: crm/fcrm/doctype/crm_rolling_response_time/crm_rolling_response_time.json
 msgid "Response Time"
-msgstr ""
+msgstr "Tempo de resposta"
 
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:94
 msgid "Response Time is required"
-msgstr ""
+msgstr "O tempo de resposta é obrigatório"
 
 #. Description of the 'Rolling Responses' (Check) field in DocType 'CRM Service
 #. Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:93
 msgid "Restart the SLA each time the customer replies (status changes to Open) and fulfill it when marked as Replied"
-msgstr ""
+msgstr "Reiniciar o SLA sempre que o cliente responder (o status muda para Aberto) e considerá-lo cumprido quando for marcado como Respondido"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:22
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:54
@@ -6364,40 +6364,40 @@ msgstr "Restaurar"
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:21
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Restore Defaults"
-msgstr ""
+msgstr "Restaurar padrões"
 
 #. Label of the restore_demo_data (Button) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:53
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Restore Demo Data"
-msgstr ""
+msgstr "Restaurar dados de demonstração"
 
 #. Description of the 'Enable Sales Hierarchy Permissions' (Check) field in
 #. DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Restrict Lead and Deal visibility based on the Sales Hierarchy tree. Managers can see all records owned by or assigned to their reports."
-msgstr ""
+msgstr "Restringir a visibilidade de leads e negócios com base na hierarquia de vendas. Os gerentes podem ver todos os registros pertencentes ou atribuídos aos seus subordinados."
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:20
 msgid "Restrict visibility of Leads and Deals based on a reporting tree."
-msgstr ""
+msgstr "Restringir a visibilidade de leads e negócios com base na hierarquia de subordinação."
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:65
 msgid "Restrict visibility using a reporting tree"
-msgstr ""
+msgstr "Restringir a visibilidade usando a hierarquia de subordinação"
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:45
 msgid "Retake"
-msgstr ""
+msgstr "Tirar novamente"
 
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.js:6
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:16
 msgid "Retry Sync"
-msgstr ""
+msgstr "Tentar sincronizar novamente"
 
 #: crm/api/dashboard.py:727
 msgid "Revenue"
-msgstr ""
+msgstr "Receita"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:81
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:81
@@ -6420,7 +6420,7 @@ msgstr "Toque"
 #: frontend/src/components/Telephony/TwilioCallUI.vue:38
 #: frontend/src/components/Telephony/TwilioCallUI.vue:140
 msgid "Ringing..."
-msgstr ""
+msgstr "Chamando..."
 
 #. Label of the role (Select) field in DocType 'CRM Invitation'
 #: crm/fcrm/doctype/crm_invitation/crm_invitation.json
@@ -6433,7 +6433,7 @@ msgstr "Função"
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Rolling Response Due"
-msgstr ""
+msgstr "Prazo de resposta recorrente"
 
 #. Label of the rolling_responses (Table) field in DocType 'CRM Deal'
 #. Label of the rolling_responses (Table) field in DocType 'CRM Lead'
@@ -6444,7 +6444,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:89
 msgid "Rolling Responses"
-msgstr ""
+msgstr "Respostas recorrentes"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Dropdown Item'
 #. Label of the route (Data) field in DocType 'CRM Dropdown Item'
@@ -6455,12 +6455,12 @@ msgstr "Rota"
 #. Label of the route_name (Data) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Route Name"
-msgstr ""
+msgstr "Nome da rota"
 
 #. Label of the rows (Code) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "Rows"
-msgstr ""
+msgstr "Linhas"
 
 #. Label of the sla_tab (Tab Break) field in DocType 'CRM Deal'
 #. Label of the sla (Link) field in DocType 'CRM Deal'
@@ -6471,64 +6471,64 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "SLA"
-msgstr ""
+msgstr "SLA"
 
 #. Label of the sla_creation (Datetime) field in DocType 'CRM Deal'
 #. Label of the sla_creation (Datetime) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "SLA Creation"
-msgstr ""
+msgstr "Criação de SLA"
 
 #. Label of the sla_name (Data) field in DocType 'CRM Service Level Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "SLA Name"
-msgstr ""
+msgstr "Nome do SLA"
 
 #: frontend/src/components/Settings/Settings.vue:198
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:3
 msgid "SLA Policies"
-msgstr ""
+msgstr "Políticas de SLA"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:428
 msgid "SLA Policy Created"
-msgstr ""
+msgstr "Política de SLA criada"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:242
 msgid "SLA Policy Deleted"
-msgstr ""
+msgstr "Política de SLA excluída"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:218
 msgid "SLA Policy Duplicated"
-msgstr ""
+msgstr "Política de SLA duplicada"
 
 #: frontend/src/components/Settings/Sla/utils.js:106
 msgid "SLA Policy Name is required"
-msgstr ""
+msgstr "O nome da política de SLA é obrigatório"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:264
 msgid "SLA Policy Status Updated"
-msgstr ""
+msgstr "Status da política de SLA atualizado"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:498
 msgid "SLA Policy Updated"
-msgstr ""
+msgstr "Política de SLA atualizada"
 
 #. Label of the sla_status (Select) field in DocType 'CRM Deal'
 #. Label of the sla_status (Select) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "SLA Status"
-msgstr ""
+msgstr "Status do SLA"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:254
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:372
 msgid "SLA set as default cannot be disabled"
-msgstr ""
+msgstr "O SLA padrão não pode ser desativado"
 
 #: frontend/src/components/EmailEditor.vue:102
 msgid "SUBJECT"
-msgstr ""
+msgstr "ASSUNTO"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:7
 #: frontend/src/components/Settings/Settings.vue:165
@@ -6537,11 +6537,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:323
 msgid "Sales Hierarchy disabled"
-msgstr ""
+msgstr "Hierarquia de vendas desativada"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:334
 msgid "Sales Hierarchy enabled"
-msgstr ""
+msgstr "Hierarquia de vendas ativada"
 
 #. Name of a role
 #. Option for the 'Role' (Select) field in DocType 'CRM Invitation'
@@ -6628,15 +6628,15 @@ msgstr "Usuário de Vendas"
 
 #: crm/api/dashboard.py:638
 msgid "Sales trend"
-msgstr ""
+msgstr "Tendência de vendas"
 
 #: frontend/src/pages/PersonaForm.vue:61
 msgid "Salesforce"
-msgstr ""
+msgstr "Salesforce"
 
 #: crm/api/dashboard.py:1133
 msgid "Salesperson"
-msgstr ""
+msgstr "Vendedor"
 
 #. Label of the salutation (Link) field in DocType 'CRM Deal'
 #. Label of the salutation (Link) field in DocType 'CRM Lead'
@@ -6690,17 +6690,17 @@ msgstr ""
 
 #: frontend/src/components/Telephony/TaskPanel.vue:8
 msgid "Schedule a task..."
-msgstr ""
+msgstr "Agendar uma tarefa..."
 
 #: frontend/src/components/Activities/ActivityHeader.vue:36
 #: frontend/src/components/Activities/ActivityHeader.vue:131
 msgid "Schedule an Event"
-msgstr ""
+msgstr "Agendar um evento"
 
 #. Label of the script (Code) field in DocType 'CRM Form Script'
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.json
 msgid "Script"
-msgstr ""
+msgstr "Script"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:23
 #: frontend/src/components/Settings/Sla/SlaPolicyList.vue:21
@@ -6710,7 +6710,7 @@ msgstr "Pesquisa"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:60
 msgid "Search Template"
-msgstr ""
+msgstr "Pesquisar modelo"
 
 #: frontend/src/components/Settings/Users.vue:69
 msgid "Search User"
@@ -6727,7 +6727,7 @@ msgstr "Seção"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:232
 msgid "See All Participants"
-msgstr ""
+msgstr "Ver todos os participantes"
 
 #: frontend/src/components/SidePanelLayout.vue:154
 msgid "Select"
@@ -6743,15 +6743,15 @@ msgstr "Selecionar moeda"
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:20
 msgid "Select Holiday List"
-msgstr ""
+msgstr "Selecionar lista de feriados"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:54
 msgid "Select Medium"
-msgstr ""
+msgstr "Selecionar canal"
 
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:10
 msgid "Select Priority"
-msgstr ""
+msgstr "Selecionar prioridade"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:119
 msgid "Select Provider"
@@ -6763,12 +6763,12 @@ msgstr ""
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:57
 msgid "Select Source Type"
-msgstr ""
+msgstr "Selecionar tipo de origem"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:31
 #: frontend/src/components/Calendar/EventNotifications.vue:99
 msgid "Select Type"
-msgstr ""
+msgstr "Selecionar tipo"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:54
 msgid "Select View"
@@ -6776,43 +6776,43 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:15
 msgid "Select Workday"
-msgstr ""
+msgstr "Selecionar dia útil"
 
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:71
 msgid "Select a Twilio App for your CRM"
-msgstr ""
+msgstr "Selecione um aplicativo Twilio para o seu CRM"
 
 #: frontend/src/components/Filter.vue:599
 msgid "Select a Value"
-msgstr ""
+msgstr "Selecionar um valor"
 
 #: frontend/src/components/Questionnaire.vue:93
 msgid "Select all that apply"
-msgstr ""
+msgstr "Selecione todas as opções aplicáveis"
 
 #: frontend/src/components/Filter.vue:601
 msgid "Select an Option"
-msgstr ""
+msgstr "Selecionar uma opção"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue:84
 msgid "Select the assignees for {0}."
-msgstr ""
+msgstr "Selecione os responsáveis por {0}."
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:245
 msgid "Select the deal status to trigger the auto customer creation in ERPNext"
-msgstr ""
+msgstr "Selecione o status do negócio que acionará a criação automática do cliente no ERPNext"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:38
 msgid "Select the default view for your calendar. This will be the initial view when you open the calendar"
-msgstr ""
+msgstr "Selecione a visualização padrão do calendário. Ela será exibida inicialmente ao abrir o calendário"
 
 #: frontend/src/components/Settings/DefaultsSettings.vue:131
 msgid "Select whether to display time with or without seconds"
-msgstr ""
+msgstr "Escolha se o horário deve ser exibido com ou sem segundos"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:133
 msgid "Select your ERPNext company to connect with"
-msgstr ""
+msgstr "Selecione a empresa do ERPNext à qual deseja se conectar"
 
 #: frontend/src/components/FieldLayout/Field.vue:563
 msgid "Select {0}"
@@ -6832,7 +6832,7 @@ msgstr "Enviar convites para"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:61
 msgid "Send Template"
-msgstr ""
+msgstr "Enviar modelo"
 
 #: frontend/src/pages/Deal.vue:92 frontend/src/pages/Lead.vue:140
 msgid "Send an Email"
@@ -6844,11 +6844,11 @@ msgstr ""
 
 #: frontend/src/components/CommunicationArea.vue:274
 msgid "Sending comment..."
-msgstr ""
+msgstr "Enviando comentário..."
 
 #: frontend/src/components/CommunicationArea.vue:258
 msgid "Sending email..."
-msgstr ""
+msgstr "Enviando e-mail..."
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Dropdown Item'
 #: crm/fcrm/doctype/crm_dropdown_item/crm_dropdown_item.json
@@ -6867,7 +6867,7 @@ msgstr "Acordo de Nível de Serviço"
 #. Label of the service_provider (Select) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Service Provider"
-msgstr ""
+msgstr "Provedor de serviço"
 
 #: frontend/src/components/Filter.vue:589
 msgid "Set"
@@ -6879,7 +6879,7 @@ msgstr ""
 
 #: frontend/src/components/PrimaryDropdownItem.vue:27
 msgid "Set As Primary"
-msgstr ""
+msgstr "Definir como principal"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:235
 msgid "Set Currency"
@@ -6887,7 +6887,7 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/EditResponseResolutionModal.vue:29
 msgid "Set Default Priority"
-msgstr ""
+msgstr "Definir prioridade padrão"
 
 #: frontend/src/pages/Lead.vue:119
 msgid "Set First Name"
@@ -6895,15 +6895,15 @@ msgstr ""
 
 #: frontend/src/components/Controls/GeolocationControl.vue:50
 msgid "Set Location"
-msgstr ""
+msgstr "Definir localização"
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:60
 msgid "Set all as private"
-msgstr ""
+msgstr "Definir todos como privados"
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:53
 msgid "Set all as public"
-msgstr ""
+msgstr "Definir todos como públicos"
 
 #: frontend/src/pages/Deal.vue:78
 msgid "Set an Organization"
@@ -6915,25 +6915,25 @@ msgstr ""
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:113
 msgid "Set as default SLA"
-msgstr ""
+msgstr "Definir como SLA padrão"
 
 #: frontend/src/components/Controls/GeolocationControl.vue:14
 msgid "Set location…"
-msgstr ""
+msgstr "Definir localização…"
 
 #. Description of the 'Persona Captured' (Check) field in DocType 'FCRM
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Set once the first admin completes the onboarding persona questionnaire"
-msgstr ""
+msgstr "Definido assim que o primeiro administrador conclui o questionário de perfil da configuração inicial"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:102
 msgid "Set the Exotel number to be used for outgoing calls."
-msgstr ""
+msgstr "Defina o número do Exotel que será usado nas chamadas de saída."
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:77
 msgid "Set the Twilio number to be used for outgoing calls."
-msgstr ""
+msgstr "Defina o número do Twilio que será usado nas chamadas de saída."
 
 #: frontend/src/components/Settings/BrandSettings.vue:33
 msgid "Set the name of your brand. Appears in the left sidebar."
@@ -6941,11 +6941,11 @@ msgstr ""
 
 #: frontend/src/pages/PersonaForm.vue:123
 msgid "Set up my sales pipeline"
-msgstr ""
+msgstr "Configurar meu funil de vendas"
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:9
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one"
-msgstr ""
+msgstr "Configure os dias e horários de trabalho e os feriados selecionando uma jornada predefinida ou criando uma nova"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:563
 msgid "Setting Up"
@@ -6953,11 +6953,11 @@ msgstr ""
 
 #: frontend/src/components/Settings/GeneralSettings.vue:153
 msgid "Setting disabled successfully"
-msgstr ""
+msgstr "Configuração desativada com sucesso"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:152
 msgid "Setting enabled successfully"
-msgstr ""
+msgstr "Configuração ativada com sucesso"
 
 #: frontend/src/components/Settings/emailConfig.js:158
 msgid "Setting up Frappe Mail requires you to have an API key and API Secret of your email account. Read more"
@@ -6965,31 +6965,31 @@ msgstr "Para configurar o Frappe Mail, você precisa ter uma chave de API e um s
 
 #: frontend/src/components/Settings/emailConfig.js:104
 msgid "Setting up GMail requires you to enable two factor authentication and app specific passwords. Read more"
-msgstr ""
+msgstr "Para configurar o Gmail, é necessário ativar a autenticação em duas etapas e as senhas de app. Saiba mais"
 
 #: frontend/src/components/Settings/emailConfig.js:113
 msgid "Setting up Outlook requires you to enable two factor authentication and app specific passwords. Read more"
-msgstr ""
+msgstr "Para configurar o Outlook, é necessário ativar a autenticação em duas etapas e as senhas de app. Saiba mais"
 
 #: frontend/src/components/Settings/emailConfig.js:122
 msgid "Setting up Sendgrid requires you to enable two factor authentication and app specific passwords. Read more"
-msgstr ""
+msgstr "Para configurar o SendGrid, é necessário ativar a autenticação em duas etapas e as senhas de app. Saiba mais"
 
 #: frontend/src/components/Settings/emailConfig.js:131
 msgid "Setting up Sparkpost requires you to enable two factor authentication and app specific passwords. Read more"
-msgstr ""
+msgstr "Para configurar o SparkPost, é necessário ativar a autenticação em duas etapas e as senhas de app. Saiba mais"
 
 #: frontend/src/components/Settings/emailConfig.js:140
 msgid "Setting up Yahoo requires you to enable two factor authentication and app specific passwords. Read more"
-msgstr ""
+msgstr "Para configurar o Yahoo, é necessário ativar a autenticação em duas etapas e as senhas de app. Saiba mais"
 
 #: frontend/src/components/Settings/emailConfig.js:149
 msgid "Setting up Yandex requires you to enable two factor authentication and app specific passwords. Read more"
-msgstr ""
+msgstr "Para configurar o Yandex, é necessário ativar a autenticação em duas etapas e as senhas de app. Saiba mais"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:161
 msgid "Setting updated successfully"
-msgstr ""
+msgstr "Configuração atualizada com sucesso"
 
 #. Label of the defaults_tab (Tab Break) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -7011,7 +7011,7 @@ msgstr ""
 
 #: crm/api/exchange_rate.py:149
 msgid "Setup the Exchange Rate Provider other than 'Frankfurter' in settings, as default provider does not support currency conversion for {0} to {1}."
-msgstr ""
+msgstr "Configure nas configurações um provedor de câmbio diferente do Frankfurter, pois o provedor padrão não oferece conversão de {0} para {1}."
 
 #: frontend/src/components/Layouts/AppSidebar.vue:360
 msgid "Setup your password"
@@ -7023,19 +7023,19 @@ msgstr "Mostrar"
 
 #: frontend/src/components/FieldLayoutEditor.vue:475
 msgid "Show Border"
-msgstr ""
+msgstr "Mostrar borda"
 
 #: frontend/src/components/FieldLayoutEditor.vue:470
 msgid "Show Label"
-msgstr ""
+msgstr "Mostrar rótulo"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:240
 msgid "Show Less"
-msgstr ""
+msgstr "Mostrar menos"
 
 #: frontend/src/components/Controls/Password.vue:19
 msgid "Show Password"
-msgstr ""
+msgstr "Mostrar senha"
 
 #: frontend/src/components/Controls/GridRowFieldsModal.vue:20
 #: frontend/src/components/Modals/DataFieldsModal.vue:20
@@ -7051,7 +7051,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'CRM Fields Layout'
 #: crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.json
 msgid "Side Panel"
-msgstr ""
+msgstr "Painel lateral"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Global Settings'
 #: crm/fcrm/doctype/crm_global_settings/crm_global_settings.json
@@ -7066,55 +7066,55 @@ msgstr "Assinatura"
 #. Agreement'
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.json
 msgid "Simple Python Expression, Example: doc.status == 'Open' and doc.lead_source == 'Ads'"
-msgstr ""
+msgstr "Expressão simples em Python. Exemplo: doc.status == 'Open' and doc.lead_source == 'Ads'"
 
 #: frontend/src/components/AssignTo.vue:83
 msgid "Since you removed {0} from the assignee, the {0} has also been removed."
-msgstr ""
+msgstr "Como você removeu o {0} dos responsáveis, o campo {0} também foi limpo."
 
 #: frontend/src/components/AssignTo.vue:76
 msgid "Since you removed {0} from the assignee, the {0} has been changed to the next available assignee {1}."
-msgstr ""
+msgstr "Como você removeu o {0} dos responsáveis, o campo {0} foi atualizado para o próximo responsável disponível: {1}."
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:66
 msgid "Site URL"
-msgstr ""
+msgstr "URL do site"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:490
 msgid "Site URL is required"
-msgstr ""
+msgstr "A URL do site é obrigatória"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:473
 msgid "Site connection validated"
-msgstr ""
+msgstr "Conexão com o site validada"
 
 #: frontend/src/components/Questionnaire.vue:97
 msgid "Skip for now"
-msgstr ""
+msgstr "Pular por enquanto"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:438
 msgid "Some error occurred while creating SLA Policy"
-msgstr ""
+msgstr "Ocorreu um erro ao criar a política de SLA"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:484
 msgid "Some error occurred while renaming SLA policy"
-msgstr ""
+msgstr "Ocorreu um erro ao renomear a política de SLA"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:766
 msgid "Some error occurred while renaming assignment rule"
-msgstr ""
+msgstr "Ocorreu um erro ao renomear a regra de atribuição"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:475
 msgid "Some error occurred while updating SLA policy"
-msgstr ""
+msgstr "Ocorreu um erro ao atualizar a política de SLA"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:751
 msgid "Some error occurred while updating assignment rule"
-msgstr ""
+msgstr "Ocorreu um erro ao atualizar a regra de atribuição"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:508
 msgid "Some users could not be added"
-msgstr ""
+msgstr "Não foi possível adicionar alguns usuários"
 
 #: frontend/src/components/Settings/Users.vue:274
 #: frontend/src/components/Settings/Users.vue:287
@@ -7128,7 +7128,7 @@ msgstr ""
 #: frontend/src/components/SortBy.vue:10 frontend/src/components/SortBy.vue:24
 #: frontend/src/components/SortBy.vue:226
 msgid "Sort"
-msgstr ""
+msgstr "Ordenar"
 
 #. Label of the source (Link) field in DocType 'CRM Deal'
 #. Label of the source (Link) field in DocType 'CRM Lead'
@@ -7153,11 +7153,11 @@ msgstr "Tipo de Origem"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue:159
 msgid "Source disabled successfully"
-msgstr ""
+msgstr "Origem desativada com sucesso"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue:158
 msgid "Source enabled successfully"
-msgstr ""
+msgstr "Origem ativada com sucesso"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:64
 #: frontend/src/components/Dashboard/DashboardItem.vue:21
@@ -7166,20 +7166,20 @@ msgstr "Espaçador"
 
 #: frontend/src/pages/PersonaForm.vue:59
 msgid "Spreadsheets"
-msgstr ""
+msgstr "Planilhas"
 
 #: crm/api/dashboard.py:790 crm/api/dashboard.py:848
 msgid "Stage"
-msgstr ""
+msgstr "Etapa"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.js:15
 msgid "Standard Form Scripts can not be modified, duplicate the Form Script instead."
-msgstr ""
+msgstr "Scripts de formulário padrão não podem ser modificados. Duplique o script de formulário para editá-lo."
 
 #. Label of the standard_rate (Currency) field in DocType 'CRM Product'
 #: crm/fcrm/doctype/crm_product/crm_product.json
 msgid "Standard Selling Rate"
-msgstr ""
+msgstr "Preço de venda padrão"
 
 #: frontend/src/components/ViewControls.vue:642
 msgid "Standard Views"
@@ -7187,7 +7187,7 @@ msgstr ""
 
 #: frontend/src/composables/event.js:242
 msgid "Start & End Time Are Required"
-msgstr ""
+msgstr "Os horários de início e término são obrigatórios"
 
 #. Label of the start_date (Date) field in DocType 'CRM Service Level
 #. Agreement'
@@ -7200,7 +7200,7 @@ msgstr "Data de início"
 
 #: frontend/src/components/Settings/Sla/utils.js:160
 msgid "Start Date cannot be after end date"
-msgstr ""
+msgstr "A data de início não pode ser posterior à data de término"
 
 #. Label of the start_time (Datetime) field in DocType 'CRM Call Log'
 #. Label of the start_time (Time) field in DocType 'CRM Service Day'
@@ -7216,11 +7216,11 @@ msgstr "Horário de Início"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:186
 msgid "Start Time is required"
-msgstr ""
+msgstr "O horário de início é obrigatório"
 
 #: frontend/src/pages/Welcome.vue:21
 msgid "Start with sample 10 leads"
-msgstr ""
+msgstr "Começar com 10 leads de demonstração"
 
 #. Label of the status (Select) field in DocType 'CRM Call Log'
 #. Label of the status (Data) field in DocType 'CRM Communication Status'
@@ -7251,16 +7251,16 @@ msgstr "Situação"
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Status Change Log"
-msgstr ""
+msgstr "Registro de alterações de status"
 
 #: frontend/src/components/Modals/DealModal.vue:209
 #: frontend/src/components/Modals/LeadModal.vue:152
 msgid "Status is required"
-msgstr ""
+msgstr "O status é obrigatório"
 
 #: frontend/src/components/Questionnaire.vue:91
 msgid "Step {0} of {1}"
-msgstr ""
+msgstr "Etapa {0} de {1}"
 
 #. Label of the subdomain (Data) field in DocType 'CRM Exotel Settings'
 #: crm/fcrm/doctype/crm_exotel_settings/crm_exotel_settings.json
@@ -7280,7 +7280,7 @@ msgstr "O assunto é obrigatório"
 
 #: frontend/src/components/Modals/EmailTemplateSelectorModal.vue:35
 msgid "Subject: {0}"
-msgstr ""
+msgstr "Assunto: {0}"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
@@ -7291,7 +7291,7 @@ msgstr "Domingo"
 
 #: frontend/src/components/Settings/emailConfig.js:16
 msgid "Support / Sales"
-msgstr ""
+msgstr "Suporte / Vendas"
 
 #: frontend/src/components/FilesUploader/FilesUploader.vue:40
 msgid "Switch Camera"
@@ -7303,34 +7303,34 @@ msgstr ""
 
 #: frontend/src/components/Settings/Profile/UserEmailSettings.vue:55
 msgid "Switch between outgoing email accounts when sending emails"
-msgstr ""
+msgstr "Alternar entre contas de e-mail de saída ao enviar e-mails"
 
 #: crm/lead_syncing/doctype/lead_sync_source/lead_sync_source.js:6
 #: frontend/src/components/Settings/ERPNextSettings.vue:206
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:23
 msgid "Sync Now"
-msgstr ""
+msgstr "Sincronizar agora"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:191
 msgid "Sync Products with ERPNext"
-msgstr ""
+msgstr "Sincronizar produtos com o ERPNext"
 
 #: frontend/src/components/Settings/LeadSyncing/FailureLogs.vue:132
 msgid "Sync Successful!"
-msgstr ""
+msgstr "Sincronização concluída!"
 
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.js:16
 msgid "Sync Successful, CRM Lead: {0}!"
-msgstr ""
+msgstr "Sincronização concluída. Lead do CRM: {0}!"
 
 #: frontend/src/pages/Welcome.vue:32
 msgid "Sync your Contacts, Email and Calendars"
-msgstr ""
+msgstr "Sincronize seus contatos, e-mails e calendários"
 
 #. Option for the 'Type' (Select) field in DocType 'Failed Lead Sync Log'
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.json
 msgid "Synced"
-msgstr ""
+msgstr "Sincronizado"
 
 #. Label of the syncing_tab (Tab Break) field in DocType 'CRM Lead'
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -7339,7 +7339,7 @@ msgstr "Sincronizando"
 
 #: frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue:380
 msgid "Syncing started in background"
-msgstr ""
+msgstr "Sincronização iniciada em segundo plano"
 
 #: frontend/src/components/Settings/ThemeSwitcher.vue:162
 msgid "System"
@@ -7393,11 +7393,11 @@ msgstr "Gerente do sistema"
 
 #: frontend/src/components/EmailEditor.vue:39
 msgid "TO"
-msgstr ""
+msgstr "PARA"
 
 #: frontend/src/components/Telephony/ExotelCallUI.vue:148
 msgid "Take a note..."
-msgstr ""
+msgstr "Escreva uma nota..."
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -7418,7 +7418,7 @@ msgstr ""
 #. Label of the telephony_medium (Select) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "Telephony Medium"
-msgstr ""
+msgstr "Canal de telefonia"
 
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:9
 msgid "Telephony Settings"
@@ -7426,31 +7426,31 @@ msgstr ""
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:214
 msgid "Template Deleted Successfully"
-msgstr ""
+msgstr "Modelo excluído com sucesso"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:82
 msgid "Template Name"
-msgstr ""
+msgstr "Nome do modelo"
 
 #: frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue:175
 msgid "Template created successfully"
-msgstr ""
+msgstr "Modelo criado com sucesso"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:197
 msgid "Template disabled successfully"
-msgstr ""
+msgstr "Modelo desativado com sucesso"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue:196
 msgid "Template enabled successfully"
-msgstr ""
+msgstr "Modelo ativado com sucesso"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:236
 msgid "Template renamed successfully"
-msgstr ""
+msgstr "Modelo renomeado com sucesso"
 
 #: frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue:201
 msgid "Template updated successfully"
-msgstr ""
+msgstr "Modelo atualizado com sucesso"
 
 #: frontend/src/components/Settings/Settings.vue:183
 msgid "Templates"
@@ -7459,7 +7459,7 @@ msgstr "Modelos"
 #. Label of a shortcut in the Frappe CRM Workspace
 #: crm/fcrm/workspace/frappe_crm/frappe_crm.json
 msgid "Territories"
-msgstr ""
+msgstr "Territórios"
 
 #. Label of the territory (Link) field in DocType 'CRM Deal'
 #. Label of the territory (Link) field in DocType 'CRM Lead'
@@ -7486,7 +7486,7 @@ msgstr "Obrigado"
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.py:72
 msgid "The Condition '{0}' is invalid: {1}"
-msgstr ""
+msgstr "A condição ‘{0}’ é inválida: {1}"
 
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.py:64
 msgid "The holiday on {0} is not between From Date and To Date"
@@ -7495,13 +7495,13 @@ msgstr "O feriado em {0} não é entre de Data e To Date"
 #. Description of the 'Exchange Rate' (Float) field in DocType 'CRM Deal'
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 msgid "The rate used to convert the deal’s currency to your crm's base currency (set in CRM Settings). It is set once when the currency is first added and doesn't change automatically."
-msgstr ""
+msgstr "A taxa usada para converter a moeda do negócio para a moeda base configurada nas configurações do CRM é registrada quando a moeda é adicionada pela primeira vez e não muda automaticamente."
 
 #. Description of the 'Exchange Rate' (Float) field in DocType 'CRM
 #. Organization'
 #: crm/fcrm/doctype/crm_organization/crm_organization.json
 msgid "The rate used to convert the organization’s currency to your crm's base currency (set in CRM Settings). It is set once when the currency is first added and doesn't change automatically."
-msgstr ""
+msgstr "A taxa usada para converter a moeda da organização para a moeda base configurada nas configurações do CRM é registrada quando a moeda é adicionada pela primeira vez e não muda automaticamente."
 
 #: frontend/src/components/Settings/PreferencesSettings.vue:23
 msgid "Theme"
@@ -7509,35 +7509,35 @@ msgstr "Tema"
 
 #: crm/fcrm/doctype/crm_service_level_agreement/crm_service_level_agreement.js:29
 msgid "There can only be one default priority in Priorities table"
-msgstr ""
+msgstr "Só pode haver uma prioridade padrão na tabela de prioridades"
 
 #: frontend/src/components/Filter.vue:685
 msgid "This Month"
-msgstr ""
+msgstr "Este mês"
 
 #: frontend/src/components/Filter.vue:689
 msgid "This Quarter"
-msgstr ""
+msgstr "Este trimestre"
 
 #: frontend/src/components/Filter.vue:681
 msgid "This Week"
-msgstr ""
+msgstr "Esta semana"
 
 #: frontend/src/components/Filter.vue:693
 msgid "This Year"
-msgstr ""
+msgstr "Este ano"
 
 #: frontend/src/components/FieldLayoutEditor.vue:584
 msgid "This column contains fields. Are you sure you want to remove it?"
-msgstr ""
+msgstr "Esta coluna contém campos. Tem certeza de que deseja removê-la?"
 
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:177
 msgid "This field is required"
-msgstr ""
+msgstr "Este campo é obrigatório"
 
 #: frontend/src/pages/PersonaForm.vue:58
 msgid "This is my first CRM"
-msgstr ""
+msgstr "Este é o meu primeiro CRM"
 
 #: crm/www/crm.py:31
 msgid "This method is only meant for developer mode"
@@ -7545,27 +7545,27 @@ msgstr "Esse método é destinado apenas ao modo de desenvolvedor"
 
 #: frontend/src/components/FieldLayoutEditor.vue:489
 msgid "This section contains fields. Are you sure you want to remove it?"
-msgstr ""
+msgstr "Esta seção contém campos. Tem certeza de que deseja removê-la?"
 
 #: frontend/src/components/SidePanelLayoutEditor.vue:116
 msgid "This section is not editable"
-msgstr ""
+msgstr "Esta seção não pode ser editada"
 
 #: frontend/src/components/BulkDeleteLinkedDocModal.vue:60
 msgid "This will delete selected items and items linked to it, are you sure?"
-msgstr ""
+msgstr "Os itens selecionados e os itens vinculados a eles serão excluídos. Deseja continuar?"
 
 #: frontend/src/components/BulkDeleteLinkedDocModal.vue:63
 msgid "This will delete selected items and unlink linked items to it, are you sure?"
-msgstr ""
+msgstr "Os itens selecionados serão excluídos e os itens vinculados serão desvinculados. Deseja continuar?"
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:17
 msgid "This will restore (if not exist) all the default statuses, custom fields and layouts. Delete & Restore will delete default layouts and then restore them."
-msgstr ""
+msgstr "Isso restaurará, caso não existam, todos os status, campos personalizados e layouts padrão. A opção Excluir e restaurar excluirá os layouts padrão e depois os restaurará."
 
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.js:67
 msgid "This will restore the demo data. Are you sure you want to continue?"
-msgstr ""
+msgstr "Isso restaurará os dados de demonstração. Deseja continuar?"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
@@ -7582,19 +7582,19 @@ msgstr "Formato de Hora"
 #. DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Time before the event when a reminder notification will be sent by default. This will be applied to all events unless a custom notification is set for a specific event."
-msgstr ""
+msgstr "Tempo padrão antes do evento para o envio de uma notificação de lembrete. Essa configuração será aplicada a todos os eventos, exceto quando houver uma notificação personalizada para um evento específico."
 
 #. Label of the crm_timeline_sort_order (Select) field in DocType 'FCRM
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Timeline Sort Order"
-msgstr ""
+msgstr "Ordem da linha do tempo"
 
 #. Label of the crm_timeline_timestamp_format (Select) field in DocType 'FCRM
 #. Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Timeline Timestamp Format"
-msgstr ""
+msgstr "Formato de data e hora da linha do tempo"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:107
 msgid "Timeline sort order"
@@ -7629,7 +7629,7 @@ msgstr "Campo de Título"
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:823
 #: frontend/src/components/Modals/EventModal.vue:376
 msgid "Title is required"
-msgstr ""
+msgstr "O título é obrigatório"
 
 #. Label of the to (Data) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
@@ -7651,12 +7651,12 @@ msgstr "Até o momento não pode ser antes a partir da data"
 #. Label of the to (Data) field in DocType 'CRM Call Log'
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.json
 msgid "To Number"
-msgstr ""
+msgstr "Número de destino"
 
 #. Label of the to_type (Data) field in DocType 'CRM Status Change Log'
 #: crm/fcrm/doctype/crm_status_change_log/crm_status_change_log.json
 msgid "To Type"
-msgstr ""
+msgstr "Tipo de destino"
 
 #. Label of the to_user (Link) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -7674,19 +7674,19 @@ msgstr "Hoje"
 #. Option for the 'Status' (Select) field in DocType 'CRM Task'
 #: crm/fcrm/doctype/crm_task/crm_task.json
 msgid "Todo"
-msgstr ""
+msgstr "A fazer"
 
 #: frontend/src/components/Modals/SidePanelModal.vue:59
 msgid "Toggle on for Preview"
-msgstr ""
+msgstr "Ative para ver a prévia"
 
 #: frontend/src/components/Filter.vue:677
 msgid "Tomorrow"
-msgstr ""
+msgstr "Amanhã"
 
 #: crm/api/user.py:21
 msgid "Too many failed attempts. Please try again after some time."
-msgstr ""
+msgstr "Muitas tentativas sem sucesso. Tente novamente mais tarde."
 
 #. Label of the total (Currency) field in DocType 'CRM Deal'
 #. Label of the total (Currency) field in DocType 'CRM Lead'
@@ -7698,7 +7698,7 @@ msgstr "Total"
 #. Label of the total_holidays (Int) field in DocType 'CRM Holiday List'
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Total Holidays"
-msgstr ""
+msgstr "Total de feriados"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:72
 msgid "Total Leads"
@@ -7709,23 +7709,23 @@ msgstr ""
 #: crm/fcrm/doctype/crm_deal/crm_deal.json
 #: crm/fcrm/doctype/crm_lead/crm_lead.json
 msgid "Total after discount"
-msgstr ""
+msgstr "Total após o desconto"
 
 #: crm/api/dashboard.py:130
 msgid "Total leads"
-msgstr ""
+msgstr "Total de leads"
 
 #: crm/api/dashboard.py:131
 msgid "Total number of leads"
-msgstr ""
+msgstr "Número total de leads"
 
 #: crm/api/dashboard.py:190
 msgid "Total number of non won/lost deals"
-msgstr ""
+msgstr "Número total de negócios que não foram ganhos nem perdidos"
 
 #: crm/api/dashboard.py:307
 msgid "Total number of won deals based on its closure date"
-msgstr ""
+msgstr "Número total de negócios ganhos com base na data de fechamento"
 
 #. Label of the traceback (Code) field in DocType 'Failed Lead Sync Log'
 #: crm/lead_syncing/doctype/failed_lead_sync_log/failed_lead_sync_log.json
@@ -7742,12 +7742,12 @@ msgstr "Terça-feira"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:156
 msgid "Turn into a Group"
-msgstr ""
+msgstr "Transformar em grupo"
 
 #. Label of the twiml_sid (Data) field in DocType 'CRM Twilio Settings'
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.json
 msgid "TwiML SID"
-msgstr ""
+msgstr "SID do TwiML"
 
 #. Option for the 'Telephony Medium' (Select) field in DocType 'CRM Call Log'
 #. Option for the 'Default Medium' (Select) field in DocType 'CRM Telephony
@@ -7758,39 +7758,39 @@ msgstr ""
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:51
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:153
 msgid "Twilio"
-msgstr ""
+msgstr "Twilio"
 
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.py:85
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.py:86
 msgid "Twilio API credential creation error."
-msgstr ""
+msgstr "Erro ao criar credenciais da API do Twilio."
 
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:68
 msgid "Twilio App Name"
-msgstr ""
+msgstr "Nome do aplicativo Twilio"
 
 #. Label of the twilio_apps (Data) field in DocType 'CRM Twilio Settings'
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.json
 msgid "Twilio Apps"
-msgstr ""
+msgstr "Aplicativos Twilio"
 
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:115
 msgid "Twilio Integration Disabled"
-msgstr ""
+msgstr "Integração com o Twilio desativada"
 
 #. Label of the twilio_number (Data) field in DocType 'CRM Telephony Agent'
 #: crm/fcrm/doctype/crm_telephony_agent/crm_telephony_agent.json
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:74
 msgid "Twilio Number"
-msgstr ""
+msgstr "Número do Twilio"
 
 #: frontend/src/components/Settings/Telephony/TwilioSettings.vue:8
 msgid "Twilio Settings"
-msgstr ""
+msgstr "Configurações do Twilio"
 
 #: crm/integrations/twilio/api.py:15
 msgid "Twilio configuration is missing"
-msgstr ""
+msgstr "A configuração do Twilio não foi encontrada"
 
 #. Label of the type (Select) field in DocType 'CRM Call Log'
 #. Label of the type (Select) field in DocType 'CRM Deal Status'
@@ -7820,36 +7820,36 @@ msgstr "Tipo"
 
 #: frontend/src/components/Calendar/Attendee.vue:216
 msgid "Type an email address to add attendee"
-msgstr ""
+msgstr "Digite um endereço de e-mail para adicionar o participante"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:101
 msgid "Type your message here..."
-msgstr ""
+msgstr "Digite sua mensagem aqui..."
 
 #: crm/fcrm/doctype/crm_twilio_settings/crm_twilio_settings.py:117
 msgid "Unable to connect to Twilio account to fetch applications."
-msgstr ""
+msgstr "Não foi possível conectar-se à conta do Twilio para buscar os aplicativos."
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:454
 msgid "Unassign Conditions are invalid"
-msgstr ""
+msgstr "As condições de remoção de atribuição são inválidas"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:224
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:607
 msgid "Unassignment Condition"
-msgstr ""
+msgstr "Condição para remover atribuição"
 
 #: crm/integrations/exotel/handler.py:169
 msgid "Unauthorized request"
-msgstr ""
+msgstr "Solicitação não autorizada"
 
 #: frontend/src/components/FieldLayoutEditor.vue:465
 msgid "Uncollapsible"
-msgstr ""
+msgstr "Impedir recolhimento"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:166
 msgid "Ungroup Conditions"
-msgstr ""
+msgstr "Condições para desfazer agrupamento"
 
 #: frontend/src/components/Telephony/TwilioCallUI.vue:24
 #: frontend/src/components/Telephony/TwilioCallUI.vue:123
@@ -7858,35 +7858,35 @@ msgstr "Desconhecido"
 
 #: crm/integrations/api.py:19
 msgid "Unknown telephony medium: {0}"
-msgstr ""
+msgstr "Canal de telefonia desconhecido: {0}"
 
 #: frontend/src/components/BulkDeleteLinkedDocModal.vue:124
 msgid "Unlink"
-msgstr ""
+msgstr "Desvincular"
 
 #: frontend/src/components/BulkDeleteLinkedDocModal.vue:74
 msgid "Unlink & Delete"
-msgstr ""
+msgstr "Desvincular e excluir"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:214
 msgid "Unlink & Delete {0} Users"
-msgstr ""
+msgstr "Desvincular e excluir {0} usuários"
 
 #: frontend/src/components/BulkDeleteLinkedDocModal.vue:35
 msgid "Unlink & Delete {0} items"
-msgstr ""
+msgstr "Desvincular e excluir {0} itens"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:81
 msgid "Unlink All"
-msgstr ""
+msgstr "Desvincular todos"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:236
 msgid "Unlink Linked Item"
-msgstr ""
+msgstr "Desvincular item vinculado"
 
 #: frontend/src/components/DeleteLinkedDocModal.vue:82
 msgid "Unlink {0} Item(s)"
-msgstr ""
+msgstr "Desvincular {0} item(ns)"
 
 #: frontend/src/components/ViewControls.vue:1097
 msgid "Unpin View"
@@ -7902,7 +7902,7 @@ msgstr "Alterações não salvas"
 #: frontend/src/components/Modals/CreateDocumentModal.vue:8
 #: frontend/src/components/SidePanelLayoutEditor.vue:19
 msgid "Untitled"
-msgstr ""
+msgstr "Sem título"
 
 #: frontend/src/components/ColumnSettings.vue:129
 #: frontend/src/components/Modals/AssignmentModal.vue:84
@@ -7933,32 +7933,32 @@ msgstr ""
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:163
 #: frontend/src/components/Settings/Telephony/TelephonySettings.vue:190
 msgid "Update Configuration"
-msgstr ""
+msgstr "Atualizar configuração"
 
 #. Description of the 'Update timestamp on new communication' (Check) field in
 #. DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "Update the modified timestamp on new email communication & comment for leads & deals"
-msgstr ""
+msgstr "Atualizar a data e a hora de modificação ao receber uma nova comunicação por e-mail ou um novo comentário em leads e negócios"
 
 #: frontend/src/components/Settings/GeneralSettings.vue:20
 msgid "Update the modified timestamp on new email communication & comments for leads & deals"
-msgstr ""
+msgstr "Atualizar a data e a hora de modificação ao receber novas comunicações por e-mail ou comentários em leads e negócios"
 
 #. Label of the update_timestamp_on_new_communication (Check) field in DocType
 #. 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 #: frontend/src/components/Settings/GeneralSettings.vue:16
 msgid "Update timestamp on new communication"
-msgstr ""
+msgstr "Atualizar a data e a hora ao receber uma nova comunicação"
 
 #: frontend/src/components/Modals/EditValueModal.vue:29
 msgid "Update {0} Records"
-msgstr ""
+msgstr "Atualizar {0} registros"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:466
 msgid "Updated reports to"
-msgstr ""
+msgstr "Superior hierárquico atualizado"
 
 #: frontend/src/components/Controls/ImageUploader.vue:15
 #: frontend/src/components/FilesUploader/FilesUploader.vue:77
@@ -7968,11 +7968,11 @@ msgstr "Carregar"
 #: frontend/src/components/Activities/ActivityHeader.vue:55
 #: frontend/src/components/Activities/ActivityHeader.vue:157
 msgid "Upload Attachment"
-msgstr ""
+msgstr "Enviar anexo"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:152
 msgid "Upload Document"
-msgstr ""
+msgstr "Enviar documento"
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:160
 #: frontend/src/pages/Contact.vue:48 frontend/src/pages/Lead.vue:93
@@ -7988,15 +7988,15 @@ msgstr ""
 
 #: frontend/src/components/Activities/WhatsAppBox.vue:168
 msgid "Upload Video"
-msgstr ""
+msgstr "Enviar vídeo"
 
 #: frontend/src/components/Controls/ImageUploader.vue:12
 msgid "Uploading {0}%"
-msgstr ""
+msgstr "Enviando {0}%"
 
 #: crm/fcrm/doctype/crm_product/crm_product.py:45
 msgid "Use ERPNext to Create Products"
-msgstr ""
+msgstr "Usar o ERPNext para criar produtos"
 
 #. Label of the user (Link) field in DocType 'CRM Dashboard'
 #. Label of the user (Link) field in DocType 'CRM Sales Hierarchy'
@@ -8024,23 +8024,23 @@ msgstr "Nome do usuário"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:502
 msgid "User added to hierarchy"
-msgstr ""
+msgstr "Usuário adicionado à hierarquia"
 
 #: crm/api/user.py:141
 msgid "User {0} cannot be removed as it has a Role Profile assigned to it."
-msgstr ""
+msgstr "O usuário {0} não pode ser removido porque possui um Perfil de função atribuído."
 
 #: frontend/src/components/Settings/Users.vue:283
 msgid "User {0} has been removed"
-msgstr ""
+msgstr "O usuário {0} foi removido"
 
 #: crm/api/user.py:158
 msgid "User {0} has been removed from CRM roles."
-msgstr ""
+msgstr "O usuário {0} foi removido das funções do CRM."
 
 #: crm/fcrm/doctype/crm_sales_hierarchy/crm_sales_hierarchy.py:43
 msgid "User {0} is already mapped to hierarchy node {1}."
-msgstr ""
+msgstr "O usuário {0} já está associado ao nó {1} da hierarquia."
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:20
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:608
@@ -8051,19 +8051,19 @@ msgstr "Usuários"
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:105
 msgid "Users Added Successfully"
-msgstr ""
+msgstr "Usuários adicionados com sucesso"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:465
 msgid "Users are required"
-msgstr ""
+msgstr "Informe pelo menos um usuário"
 
 #: frontend/src/components/Settings/Sla/SlaPolicyView.vue:168
 msgid "Valid From"
-msgstr ""
+msgstr "Válido a partir de"
 
 #: frontend/src/components/Settings/Sla/utils.js:187
 msgid "Valid conditions are required"
-msgstr ""
+msgstr "Informe pelo menos uma condição válida"
 
 #. Label of the section_break_nevd (Section Break) field in DocType 'CRM
 #. Service Level Agreement'
@@ -8077,7 +8077,7 @@ msgstr "Valor"
 
 #: frontend/src/components/Settings/ERPNextSettings.vue:110
 msgid "Verify Connection"
-msgstr ""
+msgstr "Verificar conexão"
 
 #: frontend/src/pages/Deal.vue:229
 msgid "View Contact"
@@ -8085,11 +8085,11 @@ msgstr ""
 
 #: frontend/src/components/Controls/GeolocationControl.vue:50
 msgid "View Location"
-msgstr ""
+msgstr "Ver localização"
 
 #: frontend/src/components/Modals/ViewModal.vue:14
 msgid "View Name"
-msgstr ""
+msgstr "Nome da visualização"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:9
 msgid "View documentation"
@@ -8105,11 +8105,11 @@ msgstr "Visibilidade"
 
 #: frontend/src/pages/PersonaForm.vue:80
 msgid "Walk-ins"
-msgstr ""
+msgstr "Atendimentos presenciais"
 
 #: frontend/src/components/SalesHierarchyBanner.vue:20
 msgid "We are changing how permissions work in Frappe CRM"
-msgstr ""
+msgstr "Estamos mudando o funcionamento das permissões no Frappe CRM"
 
 #: frontend/src/components/Layouts/AppSidebar.vue:593
 msgid "Web Form"
@@ -8120,7 +8120,7 @@ msgstr "Formulário web"
 #: crm/fcrm/doctype/crm_exotel_settings/crm_exotel_settings.json
 #: frontend/src/components/Settings/Telephony/ExotelSettings.vue:67
 msgid "Webhook Verify Token"
-msgstr ""
+msgstr "Token de verificação do webhook"
 
 #. Label of the website (Data) field in DocType 'CRM Deal'
 #. Label of the website (Data) field in DocType 'CRM Lead'
@@ -8134,7 +8134,7 @@ msgstr "Site"
 
 #: frontend/src/pages/PersonaForm.vue:73
 msgid "Website forms"
-msgstr ""
+msgstr "Formulários do site"
 
 #. Option for the 'Weekly Off' (Select) field in DocType 'CRM Holiday List'
 #. Option for the 'Workday' (Select) field in DocType 'CRM Service Day'
@@ -8159,27 +8159,27 @@ msgstr "Semanal"
 #: crm/fcrm/doctype/crm_holiday/crm_holiday.json
 #: crm/fcrm/doctype/crm_holiday_list/crm_holiday_list.json
 msgid "Weekly Off"
-msgstr ""
+msgstr "Folga semanal"
 
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:10
 msgid "Welcome Message"
-msgstr ""
+msgstr "Mensagem de boas-vindas"
 
 #: frontend/src/pages/PersonaForm.vue:132
 msgid "Welcome to Frappe CRM"
-msgstr ""
+msgstr "Boas-vindas ao Frappe CRM"
 
 #: frontend/src/pages/Welcome.vue:4
 msgid "Welcome {0}, lets add your first lead"
-msgstr ""
+msgstr "Boas-vindas, {0}. Vamos adicionar seu primeiro lead"
 
 #: frontend/src/pages/PersonaForm.vue:87
 msgid "What are your biggest challenges with sales today?"
-msgstr ""
+msgstr "Quais são seus maiores desafios de vendas hoje?"
 
 #: frontend/src/pages/PersonaForm.vue:118
 msgid "What would you like to accomplish first?"
-msgstr ""
+msgstr "O que você gostaria de fazer primeiro?"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Notification'
 #: crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -8193,16 +8193,16 @@ msgstr "WhatsApp"
 
 #: frontend/src/components/Activities/ActivityHeader.vue:162
 msgid "WhatsApp Message"
-msgstr ""
+msgstr "Mensagem do WhatsApp"
 
 #: frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue:2
 msgid "WhatsApp Templates"
-msgstr ""
+msgstr "Modelos do WhatsApp"
 
 #: frontend/src/components/ConditionsFilter/CFCondition.vue:20
 #: frontend/src/components/Filter.vue:43 frontend/src/components/Filter.vue:83
 msgid "Where"
-msgstr ""
+msgstr "Onde"
 
 #: frontend/src/components/ColumnSettings.vue:109
 msgid "Width"
@@ -8210,7 +8210,7 @@ msgstr "Largura"
 
 #: frontend/src/components/ColumnSettings.vue:113
 msgid "Width can be in number, pixel or rem (eg. 3, 30px, 10rem)"
-msgstr ""
+msgstr "A largura pode ser informada como número, pixel ou rem (ex.: 3, 30px, 10rem)"
 
 #. Option for the 'Type' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Type' (Select) field in DocType 'CRM Lead Status'
@@ -8218,7 +8218,7 @@ msgstr ""
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 #: frontend/src/components/Settings/ERPNextSettings.vue:254
 msgid "Won"
-msgstr ""
+msgstr "Ganho"
 
 #: frontend/src/components/Dashboard/AddChartModal.vue:75
 msgid "Won Deals"
@@ -8226,17 +8226,17 @@ msgstr ""
 
 #: crm/api/dashboard.py:306
 msgid "Won deals"
-msgstr ""
+msgstr "Negócios ganhos"
 
 #: frontend/src/components/Settings/Sla/SlaHolidays.vue:5
 msgid "Work Schedule & Holidays"
-msgstr ""
+msgstr "Jornada de trabalho e feriados"
 
 #. Label of the workday (Select) field in DocType 'CRM Service Day'
 #: crm/fcrm/doctype/crm_service_day/crm_service_day.json
 #: frontend/src/components/Settings/Sla/WorkDayModal.vue:16
 msgid "Workday"
-msgstr ""
+msgstr "Dia útil"
 
 #. Label of the section_break_rmgo (Section Break) field in DocType 'CRM
 #. Service Level Agreement'
@@ -8263,27 +8263,27 @@ msgstr "Você"
 
 #: crm/api/__init__.py:106
 msgid "You are not allowed to invite Sales Managers"
-msgstr ""
+msgstr "Você não tem permissão para convidar gerentes de vendas"
 
 #: crm/api/__init__.py:103
 msgid "You are not allowed to invite System Managers"
-msgstr ""
+msgstr "Você não tem permissão para convidar gerentes do sistema"
 
 #: crm/api/session.py:11
 msgid "You are not permitted to access CRM resources."
-msgstr ""
+msgstr "Você não tem permissão para acessar os recursos do CRM."
 
 #: crm/utils/__init__.py:133
 msgid "You are not permitted to access this resource."
-msgstr ""
+msgstr "Você não tem permissão para acessar este recurso."
 
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.py:265
 msgid "You are not permitted to create leads."
-msgstr ""
+msgstr "Você não tem permissão para criar leads."
 
 #: crm/fcrm/doctype/crm_call_log/crm_call_log.py:262
 msgid "You are not permitted to update this call log."
-msgstr ""
+msgstr "Você não tem permissão para atualizar este registro de chamada."
 
 #: crm/templates/emails/helpdesk_invitation.html:22
 msgid "You can also copy-paste following link in your browser"
@@ -8291,7 +8291,7 @@ msgstr "Você também pode copiar e colar o seguinte link no seu navegador"
 
 #: frontend/src/components/Telephony/CallUI.vue:37
 msgid "You can change the default calling medium from the settings"
-msgstr ""
+msgstr "Você pode alterar o canal de chamada padrão nas configurações"
 
 #: frontend/src/components/Settings/DashboardSettings.vue:145
 msgid "You can get your Access Key from "
@@ -8303,43 +8303,43 @@ msgstr ""
 
 #: crm/api/user.py:129
 msgid "You cannot remove yourself."
-msgstr ""
+msgstr "Você não pode remover seu próprio usuário."
 
 #: crm/integrations/exotel/handler.py:84
 msgid "You do not have Exotel Number set in your Telephony Agent"
-msgstr ""
+msgstr "Você não definiu um número do Exotel no seu agente de telefonia"
 
 #: frontend/src/pages/NotPermitted.vue:12
 msgid "You do not have enough permissions to access Frappe CRM. Please contact your administrator if you believe this is an error."
-msgstr ""
+msgstr "Você não tem permissões suficientes para acessar o Frappe CRM. Se acredita que isso é um erro, entre em contato com o administrador."
 
 #: crm/integrations/exotel/handler.py:92
 msgid "You do not have mobile number set in your Telephony Agent"
-msgstr ""
+msgstr "Você não definiu um número de celular no seu agente de telefonia"
 
 #: crm/www/crm.py:18
 msgid "You do not have permission to access Frappe CRM"
-msgstr ""
+msgstr "Você não tem permissão para acessar o Frappe CRM"
 
 #: frontend/src/data/document.js:45
 msgid "You do not have permission to access this document"
-msgstr ""
+msgstr "Você não tem permissão para acessar este documento"
 
 #: crm/api/__init__.py:143
 msgid "You don't have permission to delete this attachment"
-msgstr ""
+msgstr "Você não tem permissão para excluir este anexo"
 
 #: crm/api/user.py:17
 msgid "You must be logged in to change your password"
-msgstr ""
+msgstr "Você precisa estar conectado para alterar sua senha"
 
 #: crm/fcrm/doctype/crm_form_script/crm_form_script.py:39
 msgid "You need to be in developer mode to edit a Standard Form Script"
-msgstr ""
+msgstr "Você precisa estar no modo de desenvolvedor para editar um script de formulário padrão"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeSearch.vue:152
 msgid "You will be redirected to invite user page, unsaved changes will be lost."
-msgstr ""
+msgstr "Você será redirecionado para a página de convite de usuários e as alterações não salvas serão perdidas."
 
 #: frontend/src/components/Settings/LeadSyncing/leadSyncSourceConfig.js:8
 msgid "You will need a Meta developer account and an access token to sync leads from Facebook. Read more"
@@ -8347,7 +8347,7 @@ msgstr "Você precisará de uma conta de desenvolvedor Meta e um token de acesso
 
 #: crm/api/todo.py:110
 msgid "Your assignment on task {0} has been removed by {1}"
-msgstr ""
+msgstr "Sua atribuição na tarefa {0} foi removida por {1}"
 
 #: crm/api/todo.py:47 crm/api/todo.py:88
 msgid "Your assignment on {0} {1} has been removed by {2}"
@@ -8367,34 +8367,34 @@ msgstr ""
 
 #: frontend/src/pages/PersonaForm.vue:62
 msgid "Zoho CRM"
-msgstr ""
+msgstr "Zoho CRM"
 
 #: frontend/src/components/Activities/CommentArea.vue:9
 msgid "added a"
-msgstr ""
+msgstr "adicionou um"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "amber"
-msgstr ""
+msgstr "âmbar"
 
 #: crm/api/todo.py:119
 msgid "assigned a new task {0} to you"
-msgstr ""
+msgstr "atribuiu uma nova tarefa {0} a você"
 
 #: crm/api/todo.py:99
 msgid "assigned a {0} {1} to you"
-msgstr ""
+msgstr "atribuiu {0} {1} a você"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:33
 msgid "at"
-msgstr ""
+msgstr "às"
 
 #: frontend/src/components/Settings/CalendarSettings.vue:221
 msgid "before at"
-msgstr ""
+msgstr "antes, às"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -8412,23 +8412,23 @@ msgstr "Azul"
 
 #: frontend/src/components/Activities/Activities.vue:252
 msgid "changes from"
-msgstr ""
+msgstr "alterou de"
 
 #: frontend/src/components/Activities/CommentArea.vue:11
 msgid "comment"
-msgstr ""
+msgstr "comentário"
 
 #: crm/api/activities.py:54
 msgid "converted the lead to this deal"
-msgstr ""
+msgstr "converteu o lead neste negócio"
 
 #: crm/api/activities.py:50
 msgid "created this deal"
-msgstr ""
+msgstr "criou este negócio"
 
 #: crm/api/activities.py:202
 msgid "created this lead"
-msgstr ""
+msgstr "criou este lead"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -8446,7 +8446,7 @@ msgstr "dia"
 #: frontend/src/components/Calendar/EventNotifications.vue:175
 #: frontend/src/components/Calendar/EventNotifications.vue:194
 msgid "day before"
-msgstr ""
+msgstr "dia antes"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:244
 #: frontend/src/components/Settings/CalendarSettings.vue:120
@@ -8457,7 +8457,7 @@ msgstr "dias"
 #: frontend/src/components/Calendar/EventNotifications.vue:175
 #: frontend/src/components/Calendar/EventNotifications.vue:194
 msgid "days before"
-msgstr ""
+msgstr "dias antes"
 
 #: frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue:135
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:380
@@ -8476,17 +8476,17 @@ msgstr "desativado"
 #. Option for the 'Service Provider' (Select) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "exchangerate-api"
-msgstr ""
+msgstr "exchangerate-api"
 
 #. Option for the 'Service Provider' (Select) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "exchangerate.host"
-msgstr ""
+msgstr "exchangerate.host"
 
 #. Option for the 'Service Provider' (Select) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "fawazahmed-exchange-api"
-msgstr ""
+msgstr "fawazahmed-exchange-api"
 
 #: frontend/src/components/FieldLayoutEditor.vue:157
 msgid "field"
@@ -8499,7 +8499,7 @@ msgstr "campos"
 #. Option for the 'Service Provider' (Select) field in DocType 'FCRM Settings'
 #: crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
 msgid "frankfurter.app"
-msgstr ""
+msgstr "frankfurter.app"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -8518,20 +8518,20 @@ msgstr "verde"
 #. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "group_by"
-msgstr ""
+msgstr "agrupar por"
 
 #: frontend/src/components/Activities/CallArea.vue:16
 msgid "has made a call"
-msgstr ""
+msgstr "fez uma chamada"
 
 #: frontend/src/components/Activities/CallArea.vue:15
 msgid "has reached out"
-msgstr ""
+msgstr "entrou em contato"
 
 #: frontend/src/components/Settings/EmailAdd.vue:36
 #: frontend/src/components/Settings/EmailEdit.vue:25
 msgid "here"
-msgstr ""
+msgstr "aqui"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:241
 #: frontend/src/components/Settings/CalendarSettings.vue:116
@@ -8540,80 +8540,80 @@ msgstr "hora"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:190
 msgid "hour before"
-msgstr ""
+msgstr "hora antes"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:241
 #: frontend/src/components/Settings/CalendarSettings.vue:116
 msgid "hours"
-msgstr ""
+msgstr "horas"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:190
 msgid "hours before"
-msgstr ""
+msgstr "horas antes"
 
 #: frontend/src/utils/index.js:178
 msgid "in 1 hour"
-msgstr ""
+msgstr "em 1 hora"
 
 #: frontend/src/utils/index.js:174
 msgid "in 1 minute"
-msgstr ""
+msgstr "em 1 minuto"
 
 #: frontend/src/utils/index.js:192
 msgid "in 1 year"
-msgstr ""
+msgstr "em 1 ano"
 
 #: frontend/src/utils/index.js:143
 msgid "in {0} M"
-msgstr ""
+msgstr "em {0} mês"
 
 #: frontend/src/utils/index.js:139
 msgid "in {0} d"
-msgstr ""
+msgstr "em {0} dia"
 
 #: frontend/src/utils/index.js:186
 msgid "in {0} days"
-msgstr ""
+msgstr "em {0} dias"
 
 #: frontend/src/utils/index.js:133
 msgid "in {0} h"
-msgstr ""
+msgstr "em {0} h"
 
 #: frontend/src/utils/index.js:180
 msgid "in {0} hours"
-msgstr ""
+msgstr "em {0} horas"
 
 #: frontend/src/utils/index.js:131
 msgid "in {0} m"
-msgstr ""
+msgstr "em {0} min"
 
 #: frontend/src/utils/index.js:176
 msgid "in {0} minutes"
-msgstr ""
+msgstr "em {0} minutos"
 
 #: frontend/src/utils/index.js:190
 msgid "in {0} months"
-msgstr ""
+msgstr "em {0} meses"
 
 #: frontend/src/utils/index.js:141
 msgid "in {0} w"
-msgstr ""
+msgstr "em {0} sem"
 
 #: frontend/src/utils/index.js:188
 msgid "in {0} weeks"
-msgstr ""
+msgstr "em {0} semanas"
 
 #: frontend/src/utils/index.js:145
 msgid "in {0} y"
-msgstr ""
+msgstr "em {0} a"
 
 #: frontend/src/utils/index.js:194
 msgid "in {0} years"
-msgstr ""
+msgstr "em {0} anos"
 
 #: frontend/src/components/Modals/AddExistingUserModal.vue:29
 msgid "john@doe.com"
-msgstr ""
+msgstr "john@doe.com"
 
 #: frontend/src/utils/index.js:172 frontend/src/utils/index.js:198
 msgid "just now"
@@ -8636,12 +8636,12 @@ msgstr "leads"
 #. Option for the 'Type' (Select) field in DocType 'CRM View Settings'
 #: crm/fcrm/doctype/crm_view_settings/crm_view_settings.json
 msgid "list"
-msgstr ""
+msgstr "lista"
 
 #: crm/api/comment.py:39 frontend/src/components/Notifications.vue:64
 #: frontend/src/pages/MobileNotification.vue:50
 msgid "mentioned you in {0}"
-msgstr ""
+msgstr "mencionou você em {0}"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:238
 #: frontend/src/components/Settings/CalendarSettings.vue:112
@@ -8650,7 +8650,7 @@ msgstr "minuto"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:186
 msgid "minute before"
-msgstr ""
+msgstr "minuto antes"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:59
 #: frontend/src/components/Calendar/EventNotifications.vue:120
@@ -8663,7 +8663,7 @@ msgstr "minutos"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:186
 msgid "minutes before"
-msgstr ""
+msgstr "minutos antes"
 
 #: frontend/src/components/FieldLayoutEditor.vue:513
 msgid "next"
@@ -8675,7 +8675,7 @@ msgstr "agora"
 
 #: crm/api/activities.py:109 crm/api/activities.py:250
 msgid "old_value"
-msgstr ""
+msgstr "old_value"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -8712,7 +8712,7 @@ msgstr "roxo"
 
 #: crm/api/whatsapp.py:72
 msgid "received a whatsapp message in {0}"
-msgstr ""
+msgstr "recebeu uma mensagem pelo WhatsApp em {0}"
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -8726,7 +8726,7 @@ msgstr "vermelho"
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "teal"
-msgstr ""
+msgstr "verde-azulado"
 
 #: frontend/src/components/Activities/Activities.vue:291
 #: frontend/src/components/Activities/Activities.vue:354
@@ -8740,7 +8740,7 @@ msgstr "amanhã"
 #. Option for the 'Kind' (Select) field in DocType 'CRM Product Sync Issue'
 #: crm/fcrm/doctype/crm_product_sync_issue/crm_product_sync_issue.json
 msgid "unlinked_orphan"
-msgstr ""
+msgstr "unlinked_orphan"
 
 #: crm/api/activities.py:106 crm/api/activities.py:247
 msgid "value"
@@ -8751,7 +8751,7 @@ msgstr "valor"
 #: crm/fcrm/doctype/crm_deal_status/crm_deal_status.json
 #: crm/fcrm/doctype/crm_lead_status/crm_lead_status.json
 msgid "violet"
-msgstr ""
+msgstr "violeta"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:247
 #: frontend/src/components/Settings/CalendarSettings.vue:124
@@ -8762,7 +8762,7 @@ msgstr "semana"
 #: frontend/src/components/Calendar/EventNotifications.vue:179
 #: frontend/src/components/Calendar/EventNotifications.vue:198
 msgid "week before"
-msgstr ""
+msgstr "semana antes"
 
 #: frontend/src/components/Calendar/EventNotifications.vue:247
 #: frontend/src/components/Settings/CalendarSettings.vue:124
@@ -8773,12 +8773,12 @@ msgstr "semanas"
 #: frontend/src/components/Calendar/EventNotifications.vue:179
 #: frontend/src/components/Calendar/EventNotifications.vue:198
 msgid "weeks before"
-msgstr ""
+msgstr "semanas antes"
 
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:193
 #: frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue:277
 msgid "which are not compatible with this UI, you will need to recreate the conditions here if you want to manage and add new conditions from this UI."
-msgstr ""
+msgstr "que não são compatíveis com esta interface. Se quiser gerenciar e adicionar novas condições por aqui, será necessário recriá-las nesta interface."
 
 #. Option for the 'Color' (Select) field in DocType 'CRM Deal Status'
 #. Option for the 'Color' (Select) field in DocType 'CRM Lead Status'
@@ -8793,15 +8793,15 @@ msgstr "ontem"
 
 #: frontend/src/components/Settings/Sla/utils.js:254
 msgid "{0} (Invalid time format)"
-msgstr ""
+msgstr "{0} (formato de hora inválido)"
 
 #: frontend/src/utils/index.js:162
 msgid "{0} M"
-msgstr ""
+msgstr "{0} mês"
 
 #: crm/api/todo.py:51
 msgid "{0} assigned a {1} {2} to you"
-msgstr ""
+msgstr "{0} atribuiu {1} {2} a você"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:135
 msgid "{0} attendees"
@@ -8809,11 +8809,11 @@ msgstr "{0} participantes"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:655
 msgid "{0} awaiting"
-msgstr ""
+msgstr "{0} aguardando"
 
 #: frontend/src/utils/index.js:158
 msgid "{0} d"
-msgstr ""
+msgstr "{0} d"
 
 #: frontend/src/utils/index.js:213
 msgid "{0} days ago"
@@ -8821,7 +8821,7 @@ msgstr "há {0} dias"
 
 #: frontend/src/utils/index.js:153
 msgid "{0} h"
-msgstr ""
+msgstr "{0} h"
 
 #: frontend/src/utils/index.js:206
 msgid "{0} hours ago"
@@ -8829,15 +8829,15 @@ msgstr "{0} horas atrás"
 
 #: frontend/src/composables/event.js:207
 msgid "{0} hrs"
-msgstr ""
+msgstr "{0} h"
 
 #: frontend/src/components/Controls/EmailMultiSelect.vue:131
 msgid "{0} is an Invalid Value"
-msgstr ""
+msgstr "{0} é um valor inválido"
 
 #: frontend/src/components/Calendar/Attendee.vue:126
 msgid "{0} is an Invalid value"
-msgstr ""
+msgstr "{0} é um valor inválido"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:368
 #: frontend/src/components/EmailEditor.vue:47
@@ -8846,7 +8846,7 @@ msgstr ""
 #: frontend/src/components/Modals/AddExistingUserModal.vue:37
 #: frontend/src/components/Modals/EventModal.vue:127
 msgid "{0} is an invalid email address"
-msgstr ""
+msgstr "{0} é um endereço de e-mail inválido"
 
 #: frontend/src/components/Modals/ContactModal.vue:106
 #: frontend/src/components/Modals/ConvertToDealModal.vue:169
@@ -8859,11 +8859,11 @@ msgstr "{0} mi"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:651
 msgid "{0} maybe"
-msgstr ""
+msgstr "{0} talvez"
 
 #: frontend/src/composables/event.js:201
 msgid "{0} mins"
-msgstr ""
+msgstr "{0} min"
 
 #: frontend/src/utils/index.js:202
 msgid "{0} minutes ago"
@@ -8875,11 +8875,11 @@ msgstr "{0} meses atrás"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:647
 msgid "{0} no"
-msgstr ""
+msgstr "{0} não"
 
 #: frontend/src/components/Settings/Hierarchy/Hierarchy.vue:503
 msgid "{0} users added to hierarchy"
-msgstr ""
+msgstr "{0} usuários adicionados à hierarquia"
 
 #: frontend/src/utils/index.js:160
 msgid "{0} w"
@@ -8899,30 +8899,30 @@ msgstr "{0} anos atrás"
 
 #: frontend/src/components/Calendar/CalendarEventPanel.vue:645
 msgid "{0} yes"
-msgstr ""
+msgstr "{0} sim"
 
 #: frontend/src/components/Questionnaire.vue:92
 #, python-format
 msgid "{0}% complete"
-msgstr ""
+msgstr "{0}% concluído"
 
 #: frontend/src/utils/scriptHelpers.js:43
 msgid "⚠️ Avoid using \"trigger\" as a field name — it conflicts with the built-in trigger() method."
-msgstr ""
+msgstr "⚠️ Evite usar \"trigger\" como nome de campo, pois ele entra em conflito com o método trigger() integrado."
 
 #: frontend/src/utils/scriptHelpers.js:55
 msgid "⚠️ Method \"{0}\" not found in class."
-msgstr ""
+msgstr "⚠️ O método \"{0}\" não foi encontrado na classe."
 
 #: frontend/src/data/script.js:116
 msgid "⚠️ No class found for doctype: {0}, it is mandatory to have a class for the parent doctype. it can be empty, but it should be present."
-msgstr ""
+msgstr "⚠️ Nenhuma classe foi encontrada para o DocType {0}. É obrigatório ter uma classe para o DocType pai. Ela pode estar vazia, mas deve existir."
 
 #: frontend/src/data/script.js:249
 msgid "⚠️ No data found for parent field: {0}"
-msgstr ""
+msgstr "⚠️ Nenhum dado foi encontrado para o campo pai: {0}"
 
 #: frontend/src/data/script.js:257
 msgid "⚠️ No row found for idx: {0} in parent field: {1}"
-msgstr ""
+msgstr "⚠️ Nenhuma linha foi encontrada para o idx {0} no campo pai: {1}"
 


### PR DESCRIPTION
## What changed

- fills 1,048 previously empty Brazilian Portuguese translations in `crm/locale/pt_BR.po`
- uses natural Brazilian Portuguese for CRM, sales, telephony, email, integrations, permissions, settings, and validation messages
- preserves placeholders, HTML tags, URLs, line breaks, and product names
- keeps this batch separate from the 263 translations in #2466, with no overlapping entries

## Why

Large parts of the CRM interface still fall back to English in Brazilian Portuguese. This complements #2466 and brings the combined catalog to full coverage for the current `develop` catalog.

## Impact

Users with Portuguese (Brazil) selected will see consistent translations across the remaining CRM interface. There are no runtime code or schema changes.

## Validation

- Babel PO parser: 1,781 messages, 0 fuzzy entries
- 1,048 translated entries in this PR
- 0 placeholder, HTML tag, URL, or line break mismatches
- 0 overlapping entries with #2466
- 0 empty translations when this PR and #2466 are combined
- `git diff --check`
