### PR TITLE
fix: reconcile kanban columns with current options

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -12,6 +12,10 @@ from pypika import Criterion
 
 from crm.api.views import get_views
 from crm.fcrm.doctype.crm_form_script.crm_form_script import get_form_script
+from crm.fcrm.doctype.crm_view_settings.crm_view_settings import (
+	get_kanban_column_options,
+	reconcile_kanban_columns,
+)
 from crm.utils import is_frappe_version
 
 COUNT_NAME = (
@@ -371,16 +375,9 @@ def get_data(
 		if not rows:
 			rows = default_rows
 
-		if not kanban_columns and column_field:
-			field_meta = frappe.get_meta(doctype).get_field(column_field)
-			if field_meta.fieldtype == "Link":
-				kanban_columns = frappe.get_all(
-					field_meta.options,
-					fields=["name"],
-					order_by="modified asc",
-				)
-			elif field_meta.fieldtype == "Select":
-				kanban_columns = [{"name": option} for option in field_meta.options.split("\n")]
+		if column_field:
+			current_columns = get_kanban_column_options(doctype, column_field)
+			kanban_columns = reconcile_kanban_columns(kanban_columns, current_columns)
 
 		if not title_field:
 			title_field = "name"

--- a/crm/fcrm/doctype/crm_view_settings/crm_view_settings.py
+++ b/crm/fcrm/doctype/crm_view_settings/crm_view_settings.py
@@ -182,19 +182,51 @@ def sync_default_columns(view):
 	columns = []
 
 	if view.type == "kanban" and view.column_field:
-		field_meta = frappe.get_meta(doctype).get_field(view.column_field)
-		if field_meta.fieldtype == "Link":
-			columns = frappe.get_all(
-				field_meta.options,
-				fields=["name"],
-				order_by="modified asc",
-			)
-		elif field_meta.fieldtype == "Select":
-			columns = [{"name": option} for option in field_meta.options.split("\n")]
+		columns = get_kanban_column_options(doctype, view.column_field)
 	elif hasattr(list, "default_list_data"):
 		columns = list.default_list_data().get("columns")
 
 	return columns
+
+
+def get_kanban_column_options(doctype, column_field):
+	field_meta = frappe.get_meta(doctype).get_field(column_field)
+	if not field_meta:
+		return []
+
+	if field_meta.fieldtype == "Link":
+		options_meta = frappe.get_meta(field_meta.options)
+		order_by = "position asc" if options_meta.get_field("position") else "modified asc"
+		return frappe.get_all(field_meta.options, fields=["name"], order_by=order_by)
+
+	if field_meta.fieldtype == "Select":
+		return [{"name": option} for option in field_meta.options.split("\n") if option]
+
+	return []
+
+
+def reconcile_kanban_columns(existing_columns, current_columns, hide_new=False):
+	"""Keep saved column settings while syncing names with the field's current options."""
+	current_by_name = {column.get("name"): column for column in current_columns if column.get("name")}
+	reconciled = []
+	seen = set()
+
+	for column in existing_columns:
+		name = column.get("name")
+		if not name or name in seen or name not in current_by_name:
+			continue
+		reconciled.append(column)
+		seen.add(name)
+
+	for name, column in current_by_name.items():
+		if name in seen:
+			continue
+		new_column = dict(column)
+		if hide_new:
+			new_column["delete"] = True
+		reconciled.append(new_column)
+
+	return reconciled
 
 
 @frappe.whitelist()
@@ -295,10 +327,7 @@ def fetch_and_update_kanban_columns(name: str | int):
 
 	new_columns = sync_default_columns(doc)
 	existing_columns = parse_json(doc.kanban_columns or "[]")
-	existing_column_names = [column.get("name") for column in existing_columns]
-	for column in new_columns:
-		if column.get("name") not in existing_column_names:
-			existing_columns.append({"name": column.get("name"), "delete": True})
+	existing_columns = reconcile_kanban_columns(existing_columns, new_columns, hide_new=True)
 
 	doc.kanban_columns = json.dumps(existing_columns)
 	doc.save(ignore_permissions=True)

--- a/crm/fcrm/doctype/crm_view_settings/test_crm_view_settings.py
+++ b/crm/fcrm/doctype/crm_view_settings/test_crm_view_settings.py
@@ -1,9 +1,35 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+from crm.fcrm.doctype.crm_view_settings.crm_view_settings import reconcile_kanban_columns
 from frappe.tests import UnitTestCase
 
 
 class TestCRMViewSettings(UnitTestCase):
-	pass
+	def test_reconcile_kanban_columns_removes_stale_and_preserves_settings(self):
+		existing = [
+			{"name": "Contacted", "color": "blue", "order": ["LEAD-1"]},
+			{"name": "Old Status", "color": "red"},
+			{"name": "Qualified", "delete": True},
+		]
+		current = [{"name": "New"}, {"name": "Contacted"}, {"name": "Qualified"}]
+
+		columns = reconcile_kanban_columns(existing, current)
+
+		self.assertEqual(
+			columns,
+			[
+				{"name": "Contacted", "color": "blue", "order": ["LEAD-1"]},
+				{"name": "Qualified", "delete": True},
+				{"name": "New"},
+			],
+		)
+
+	def test_reconcile_kanban_columns_can_hide_new_columns(self):
+		columns = reconcile_kanban_columns(
+			[{"name": "New"}],
+			[{"name": "New"}, {"name": "Qualified"}],
+			hide_new=True,
+		)
+
+		self.assertEqual(columns, [{"name": "New"}, {"name": "Qualified", "delete": True}])


### PR DESCRIPTION
## What changed

- synchronize saved Kanban columns with the current options from the configured field
- remove stale columns while preserving saved color, visibility, and card order for valid columns
- order linked status doctypes by `position` when that field is available
- reuse the same reconciliation logic when loading data and refreshing view settings
- add regression tests for removed and newly added statuses

## Why

Kanban view settings can retain status columns that no longer exist after statuses are renamed or removed. New statuses are also not consistently reconciled with saved column settings, so the board can show stale columns or require manual view recreation.

## Validation

- rebased on the current `develop` branch
- Python compilation completed for all changed modules
- `git diff --check` passed
- regression tests added to `TestCRMViewSettings`

The full Frappe server test matrix is expected to run in CI.
