### PR TITLE
fix(forms): builder UI polish + settings consistency

### DIFF
--- a/crm/www/crm_form.html
+++ b/crm/www/crm_form.html
@@ -59,7 +59,7 @@
       body.embed { background: transparent; padding: 0; min-height: 0; }
       body.embed .card { max-width: none; border: none; border-radius: 0; box-shadow: none; padding: 0; }
       body.embed .draft-banner { max-width: none; }
-      .title { font-size: 20px; font-weight: 600; color: var(--ink-strong); margin: 0 0 5px; letter-spacing: -0.01em; }
+      .title { font-size: 20px; font-weight: 600; color: var(--ink-strong); margin: 0 0 14px; letter-spacing: -0.01em; line-height: 1.3; }
       /* with no description, the title supplies the gap the subtitle normally would */
       .title.title-only { margin-bottom: 22px; }
       .subtitle { font-size: 14px; color: var(--muted); margin: 0 0 22px; line-height: 1.5; }

--- a/frontend/src/components/Settings/Forms/FormBuilderPanel.vue
+++ b/frontend/src/components/Settings/Forms/FormBuilderPanel.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="flex h-full flex-col text-ink-gray-8">
     <!-- header -->
-    <div class="flex items-center justify-between border-b px-6 py-3">
+    <div class="flex items-center justify-between px-6 pt-8 pb-4">
       <div class="flex items-center gap-2">
         <Button
           variant="ghost"
           icon-left="lucide-chevron-left"
           :label="form.title || __('Untitled')"
           size="md"
-          class="-ml-4 cursor-pointer !max-w-96 !justify-start !pr-0 text-2xl-semibold no-underline hover:bg-transparent hover:no-underline hover:opacity-70 focus:bg-transparent focus:outline-none focus:ring-0"
+          class="-ml-4 cursor-pointer !max-w-96 !justify-start !pr-0 text-lg-semibold text-ink-gray-7 no-underline hover:bg-transparent hover:no-underline hover:opacity-70 focus:bg-transparent focus:outline-none focus:ring-0"
           @click="goBack"
         />
         <Badge
@@ -49,7 +49,7 @@
 
     <div v-if="loaded" class="flex-1 overflow-y-auto px-6 pb-6">
       <!-- EDIT MODE -->
-      <div v-if="mode === 'edit'" class="wf-tabs mx-auto max-w-2xl">
+      <div v-if="mode === 'edit'" class="wf-tabs">
         <Tabs v-model="tabIndex" as="div" :tabs="tabs">
           <template #tab-panel="{ tab }">
             <!-- EDITOR TAB -->
@@ -329,7 +329,7 @@
                     v-model="form.success_message"
                     type="textarea"
                     :label="__('Success message')"
-                    :rows="2"
+                    :rows="4"
                     :placeholder="__('Shown after a successful submission')"
                     @input="markDirty"
                   />
@@ -496,7 +496,7 @@
       </div>
 
       <!-- PREVIEW MODE -->
-      <div v-else class="mx-auto max-w-2xl pt-6">
+      <div v-else class="max-w-2xl pt-6">
         <div class="rounded-xl border bg-surface-white p-7">
           <!-- simulated success screen -->
           <div
@@ -515,10 +515,11 @@
           </div>
 
           <template v-else>
-            <div class="text-lg font-semibold text-ink-gray-9">
+            <!-- mirror the public page (crm_form.html): 20px title, ~14px gap -->
+            <div class="text-xl font-semibold text-ink-gray-9">
               {{ form.title || __('Form title') }}
             </div>
-            <div v-if="form.description" class="mt-1 text-sm text-ink-gray-6">
+            <div v-if="form.description" class="mt-3.5 text-sm text-ink-gray-6">
               {{ form.description }}
             </div>
             <div class="mt-5 flex flex-col gap-5">
@@ -647,7 +648,7 @@ import LucideLayoutList from '~icons/lucide/layout-list'
 import LucideSettings from '~icons/lucide/settings'
 import { globalStore } from '@/stores/global'
 import { copyToClipboard } from '@/utils'
-import { ref, reactive, computed, nextTick } from 'vue'
+import { ref, reactive, computed, watch, onMounted } from 'vue'
 
 const { $dialog } = globalStore()
 
@@ -869,6 +870,16 @@ const form = reactive({
   published: 0,
   fields: [],
 })
+
+// Keep the description box sized to its text. flush:'post' runs after the DOM
+// settles, so it fires whenever the textarea actually mounts (initial load, or
+// re-entering Edit — it lives inside a lazily-rendered Tabs panel) or its content
+// changes — no more 1-row box scrolled to the last line.
+watch([descInput, () => form.description], () => autoGrow(descInput.value), {
+  flush: 'post',
+})
+// re-measure once web fonts load: scrollHeight with the fallback font wraps wrong
+onMounted(() => document.fonts?.ready?.then(() => autoGrow(descInput.value)))
 
 const publicUrl = computed(
   () => `${window.location.origin}/crm-form/${form.route}`,
@@ -1151,7 +1162,6 @@ createResource({
     routeEdited.value = !/^untitled-form(-\d+)?$/.test(form.route)
     loaded.value = true
     availableFields.reload()
-    nextTick(() => autoGrow(descInput.value))
   },
 })
 

--- a/frontend/src/components/Settings/Forms/FormsList.vue
+++ b/frontend/src/components/Settings/Forms/FormsList.vue
@@ -42,21 +42,21 @@
         <div class="flex items-center p-2 text-sm text-ink-gray-5">
           <div class="w-6/12">{{ __('Form') }}</div>
           <div class="w-3/12">{{ __('Maps to') }}</div>
-          <div class="w-3/12">{{ __('Published') }}</div>
+          <div class="w-3/12">{{ __('Status') }}</div>
         </div>
         <div class="h-px border-t mx-2 border-outline-elevation-2" />
         <template v-for="(form, i) in forms.data" :key="form.name">
           <div
-            class="flex w-full items-center rounded p-2 hover:bg-surface-gray-2"
+            class="flex w-full items-center rounded px-2 py-3 hover:bg-surface-gray-2"
           >
             <div
               class="w-6/12 min-w-0 cursor-pointer"
               @click="$emit('open', form.name)"
             >
-              <div class="truncate text-base text-ink-gray-8">
+              <div class="truncate text-base-medium text-ink-gray-7">
                 {{ form.title }}
               </div>
-              <div class="truncate text-p-sm text-ink-gray-4">
+              <div class="mt-0.5 truncate text-p-base text-ink-gray-5">
                 /crm-form/{{ form.route }}
               </div>
             </div>

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -201,6 +201,11 @@ const tabs = computed(() => {
           icon: markRaw(h(ShieldCheck)),
           component: markRaw(SlaConfig),
         },
+        {
+          label: __('Forms'),
+          component: markRaw(FormsSettings),
+          icon: markRaw(LucideTextCursorInput),
+        },
       ],
       condition: () => isManager(),
     },
@@ -211,11 +216,6 @@ const tabs = computed(() => {
           label: __('Home Actions'),
           component: markRaw(HomeActions),
           icon: 'home',
-        },
-        {
-          label: __('Forms'),
-          component: markRaw(FormsSettings),
-          icon: markRaw(LucideTextCursorInput),
         },
       ],
       condition: () => isManager(),


### PR DESCRIPTION
Follow-up polish to the Forms feature (#2474), making the builder + public page consistent with the other Settings pages (SLA Policies / Assignment Rules) and fixing a couple of small UX issues.

### Builder ↔ Settings consistency
- **Header** now matches the SLA / Assignment Rule pages: SLA-style title (`text-lg-semibold`, `ink-gray-7`), removed the redundant `border-b` under the title, and added top padding (`pt-8`).
<img width="1470" height="268" alt="image" src="https://github.com/user-attachments/assets/f375aad6-a9c9-47ba-a0d4-37cf6516e144" />

- **Layout** left-aligned and full-width (was centered `max-w-2xl`), so the tab underline and fields reach the right edge like SLA.
<img width="1470" height="759" alt="image" src="https://github.com/user-attachments/assets/e2f9d4b3-ca45-4531-bca4-c8b12daafb29" />

- **List rows** now match the Assignment Rule list-item height/typography.
<img width="1468" height="547" alt="image" src="https://github.com/user-attachments/assets/846d183a-4963-48e8-a0e4-ab6e26baf1fe" />

- **Nav:** moved **Forms** from *Customization* into **Automation & Rules** (next to Assignment Rules and SLA Policies).
<img width="499" height="771" alt="image" src="https://github.com/user-attachments/assets/f0c7cdac-cb49-4675-8f7d-56c0816efaf5" />


### Public page + preview
- Title/description spacing matches the framework web form (~14px gap), applied to both the public page (`crm_form.html`) and the builder preview.

<img width="902" height="504" alt="image" src="https://github.com/user-attachments/assets/18793906-0fc8-4064-943a-b9d93aaf1c63" />


### UX fixes
- **Description field auto-size:** the box now reliably grows to fit its text — re-measures after web fonts load and when re-entering Edit — instead of opening one row tall and scrolled.

<img width="783" height="284" alt="image" src="https://github.com/user-attachments/assets/40b020fa-39c2-4c5b-9559-f4c2ee4e7fc4" />

- Bigger default **Success message** box (2 → 4 rows).
<img width="1144" height="608" alt="image" src="https://github.com/user-attachments/assets/94595a0f-7fc5-4ac8-8549-b61f5655df53" />

- Renamed the list **"Published"** column header to **"Status"**.
<img width="831" height="447" alt="image" src="https://github.com/user-attachments/assets/d9404b28-2bb2-45e3-8536-1e037e4b3ed3" />


Scope: CRM app only. No backend/schema changes.

