### PR TITLE
feat(domain-enrichment): sitemap seeding and extraction fixes

### DIFF
--- a/crm/domain_enrichment/config.py
+++ b/crm/domain_enrichment/config.py
@@ -159,7 +159,11 @@ def _compile_pattern(pattern: str, is_regex: int):
 	try:
 		if is_regex:
 			return re.compile(pattern, re.IGNORECASE)
-		return re.compile(re.escape(pattern), re.IGNORECASE)
+		# Word-boundary-anchor substring patterns: an un-anchored short keyword like
+		# "erp" or "api" matches inside completely unrelated words ("waterproofing",
+		# "capital"), causing false industry-classification hits. An admin who wants
+		# unanchored substring matching can still opt in via is_regex=1.
+		return re.compile(rf"\b{re.escape(pattern)}\b", re.IGNORECASE)
 	except re.error:
 		# A malformed admin-entered regex must not break the whole config build.
 		frappe.log_error(

--- a/crm/domain_enrichment/config.py
+++ b/crm/domain_enrichment/config.py
@@ -35,6 +35,7 @@ DEFAULT_SETTINGS = {
 	"auto_enrich": 0,
 	"max_pages": 10,
 	"max_depth": 2,
+	"use_sitemap": 1,
 	"request_timeout": 10,
 	"max_download_bytes": 3_000_000,
 	"retry_count": 2,

--- a/crm/domain_enrichment/crawler.py
+++ b/crm/domain_enrichment/crawler.py
@@ -57,8 +57,19 @@ SKIP_SCHEMES = ("mailto:", "tel:", "javascript:", "data:", "#")
 
 
 def normalize_url(url: str) -> str:
-	"""Strip fragments and trailing slashes for stable dedupe."""
+	"""Strip fragments, query strings and trailing slashes for stable dedupe.
+
+	Query strings are dropped rather than canonicalized: for the pages this crawler
+	cares about (About/Contact/Team/company pages) a query string is overwhelmingly
+	tracking noise (``?utm_*``, ``?ref=``) or a variant parameter that still renders
+	the same page, not a distinct page identity. Keeping them let the same page get
+	queued and fetched multiple times under different query strings, wasting real
+	page-budget slots on duplicate content.
+	"""
 	url, _frag = urldefrag(url)
+	parsed = urlparse(url)
+	if parsed.query:
+		url = parsed._replace(query="").geturl()
 	if url.endswith("/") and len(urlparse(url).path) > 1:
 		url = url.rstrip("/")
 	return url
@@ -107,8 +118,16 @@ def same_site(url: str, base_netloc: str) -> bool:
 def _link_priority(url: str, anchor_text: str, link_priority: list) -> float:
 	"""Lower number = crawl sooner. Matching links score by their keyword's rank,
 	weighted; non-matching pages sort last. ``link_priority`` is a list of
-	(keyword, weight) tuples from config."""
-	haystack = (urlparse(url).path + " " + (anchor_text or "")).lower()
+	(keyword, weight) tuples from config.
+
+	Matches against the leaf path segment only, not the whole path: otherwise any
+	page nested under a segment that happens to match (e.g. "/about-us/corporate-news/
+	2023/some-unrelated-article") inherits top-tier priority from an ancestor
+	directory alone, starving the pages the keyword was actually meant to prioritize.
+	"""
+	path = urlparse(url).path.rstrip("/")
+	leaf = path.rsplit("/", 1)[-1] if path else ""
+	haystack = (leaf + " " + (anchor_text or "")).lower()
 	best = None
 	for idx, (kw, weight) in enumerate(link_priority):
 		if kw and kw in haystack:
@@ -425,6 +444,11 @@ def crawl(start_url, cfg, session=None, progress=None):
 	robots = load_robots(start_url, cfg, session) if crawl_beyond_homepage else None
 
 	visited = set()
+	# Resolved (post-redirect) URLs already crawled -- catches a duplicate that the
+	# pre-fetch `visited` check above can't (e.g. /contact.html redirecting to an
+	# already-crawled /contact): the two *requested* URLs genuinely differ, so only
+	# the resolved URL reveals they're the same page.
+	visited_resolved = set()
 	results = []
 	# Queue holds (url, depth, anchor_text). We pop the highest-priority item.
 	queue = deque([(start_url, 0, "")])
@@ -468,14 +492,48 @@ def crawl(start_url, cfg, session=None, progress=None):
 			if progress:
 				progress(f"Crawling {url}")
 			page, soup = crawl_page(url, cfg, session=session)
-			results.append((page, soup))
+			resolved = normalize_url(page.url) if page.url else ""
 
-			# If the homepage redirected to another host, adopt the resolved domain as
-			# the same-site base so the rest of the crawl follows the real site.
-			if len(results) == 1:
-				resolved_netloc = urlparse(page.url).netloc
-				if resolved_netloc:
-					base_netloc = resolved_netloc
+			if not results:
+				# Homepage: never a duplicate (nothing crawled yet). If it
+				# redirected to another host, adopt the resolved domain as the
+				# same-site base so the rest of the crawl follows the real site.
+				if resolved:
+					base_netloc = urlparse(page.url).netloc or base_netloc
+			else:
+				# A redirect can land on a page already crawled under a different
+				# requested URL (e.g. /contact.html -> /contact) -- drop the
+				# duplicate silently instead of double-reporting/double-extracting
+				# the same content, and don't let it consume a page-budget slot:
+				# the loop just fetches one more page in its place.
+				if resolved and resolved in visited_resolved:
+					continue
+				if soup is not None and page.url and not same_site(page.url, base_netloc):
+					# A same-site link that redirected off-domain mid-crawl.
+					# same_site() is only re-checked here, after the fact:
+					# fetch()'s redirect loop (http.py) re-validates each hop for
+					# SSRF safety but has no notion of "stay on this site" -- it's
+					# a generic HTTP layer also used for robots.txt/sitemaps.
+					# Treat the resolved page as out of scope: keep it visible as
+					# an error (consistent with a network failure) but don't
+					# extract from it or follow its links. Clear every parsed
+					# artifact, not just html/text -- title/headings are
+					# populated by crawl_page() before this check runs, and
+					# extractors (e.g. classify_industry's About-page lookup)
+					# read them straight off the CrawledPage without checking
+					# soup/error, so leaving them behind would leak off-site
+					# content past this guard.
+					page.error = page.error or f"redirected off-site to {urlparse(page.url).netloc}"
+					page.html = ""
+					page.text = ""
+					page.title = ""
+					page.headings = []
+					soup = None
+
+			if resolved:
+				visited_resolved.add(resolved)
+
+			results.append((page, soup))
 
 			if soup is None or depth >= max_depth:
 				continue

--- a/crm/domain_enrichment/crawler.py
+++ b/crm/domain_enrichment/crawler.py
@@ -20,6 +20,7 @@ from collections import deque
 from functools import lru_cache
 from urllib.parse import urldefrag, urljoin, urlparse
 from urllib.robotparser import RobotFileParser
+from xml.etree import ElementTree as ET
 
 import tldextract
 from bs4 import BeautifulSoup
@@ -286,6 +287,117 @@ def probe_about_pages(home_url, cfg, session=None, skip_urls=()):
 	return []
 
 
+# --------------------------------------------------------------------------- #
+# Sitemap discovery
+# --------------------------------------------------------------------------- #
+# Sitemap-derived URLs are an addition on top of the ordinary link-following BFS,
+# not a replacement: they seed the queue with pages the sitemap author flagged as
+# worth visiting (locale variants, sections not linked from the homepage nav), so
+# the crawler doesn't rely purely on stumbling onto them within max_depth. A site
+# with no sitemap -- or an unreadable one -- must fall straight through to plain
+# link-following with no error, no log noise, and no behavior change.
+SITEMAP_MAX_SITEMAPS = 5  # sitemap files fetched; guards pathological sitemap indexes
+SITEMAP_MAX_URLS = 200  # total <loc> entries collected across all fetched sitemaps
+
+
+def _local_tag(tag: str) -> str:
+	"""Strip the XML namespace off a tag: '{http://.../0.9}urlset' -> 'urlset'."""
+	return tag.rsplit("}", 1)[-1] if tag else tag
+
+
+def _parse_sitemap(xml_text: str):
+	"""Parse a sitemap document. Returns ('urlset' | 'sitemapindex' | None, [loc, ...]).
+
+	Rejects any document containing a DOCTYPE before parsing: a legitimate sitemap
+	never has one (the sitemaps.org schema defines none), so this is a zero-cost
+	guard against XML entity-expansion abuse from a hostile or compromised site.
+	Never raises -- malformed XML yields (None, []).
+	"""
+	if "<!doctype" in xml_text.lower():
+		return None, []
+	try:
+		root = ET.fromstring(xml_text)
+	except ET.ParseError:
+		return None, []
+	kind = _local_tag(root.tag)
+	if kind not in ("urlset", "sitemapindex"):
+		return None, []
+	child_tag = "sitemap" if kind == "sitemapindex" else "url"
+	locs = []
+	for el in root:
+		if _local_tag(el.tag) != child_tag:
+			continue
+		for child in el:
+			if _local_tag(child.tag) == "loc" and child.text:
+				locs.append(child.text.strip())
+				break
+	return kind, locs
+
+
+def discover_sitemap_urls(start_url, cfg, session, robots):
+	"""Best-effort page discovery from the site's sitemap(s).
+
+	Tries the sitemap location(s) declared via ``Sitemap:`` in robots.txt first,
+	falling back to the conventional ``/sitemap.xml`` path when robots.txt is
+	absent or declares none. Follows ``<sitemapindex>`` nesting one level deep,
+	bounded by ``SITEMAP_MAX_SITEMAPS`` / ``SITEMAP_MAX_URLS``. Every sitemap
+	fetch stays same-site and goes through the normal SSRF-guarded ``fetch()``.
+
+	Always returns a list, possibly empty -- a missing sitemap, a non-200, a
+	timeout, or malformed XML all silently fall through to the ordinary BFS.
+	Never raises.
+	"""
+	try:
+		parsed = urlparse(normalize_url(start_url))
+		if not parsed.netloc:
+			return []
+
+		candidates = []
+		if robots is not None:
+			try:
+				candidates.extend(robots.site_maps() or [])
+			except Exception:
+				pass
+		if not candidates:
+			candidates.append(f"{parsed.scheme}://{parsed.netloc}/sitemap.xml")
+
+		to_fetch = deque(candidates[:SITEMAP_MAX_SITEMAPS])
+		fetched_sitemaps = set()
+		urls = []
+		seen_urls = set()
+
+		while to_fetch and len(fetched_sitemaps) < SITEMAP_MAX_SITEMAPS and len(urls) < SITEMAP_MAX_URLS:
+			sitemap_url = to_fetch.popleft()
+			if sitemap_url in fetched_sitemaps:
+				continue
+			fetched_sitemaps.add(sitemap_url)
+			if not same_site(sitemap_url, parsed.netloc):
+				continue
+
+			status, body, error, _final = fetch(sitemap_url, cfg, session=session, html_only=False)
+			if error or status != 200 or not body:
+				continue
+
+			kind, locs = _parse_sitemap(body)
+			if kind == "sitemapindex":
+				for loc in locs:
+					if len(fetched_sitemaps) + len(to_fetch) < SITEMAP_MAX_SITEMAPS:
+						to_fetch.append(loc)
+			elif kind == "urlset":
+				for loc in locs:
+					norm = normalize_url(loc)
+					if norm in seen_urls:
+						continue
+					seen_urls.add(norm)
+					urls.append(norm)
+					if len(urls) >= SITEMAP_MAX_URLS:
+						break
+
+		return urls
+	except Exception:
+		return []
+
+
 def crawl(start_url, cfg, session=None, progress=None):
 	"""Breadth-first crawl from ``start_url``, prioritizing company-info pages.
 
@@ -309,12 +421,31 @@ def crawl(start_url, cfg, session=None, progress=None):
 	# Respect robots.txt for discovered links -- but only when we actually crawl beyond
 	# the homepage (skip the extra fetch for homepage-only / preview runs, which follow
 	# no links). The explicit start URL is always fetched; robots gates discovery.
-	robots = load_robots(start_url, cfg, session) if (max_depth >= 1 and max_pages > 1) else None
+	crawl_beyond_homepage = max_depth >= 1 and max_pages > 1
+	robots = load_robots(start_url, cfg, session) if crawl_beyond_homepage else None
 
 	visited = set()
 	results = []
 	# Queue holds (url, depth, anchor_text). We pop the highest-priority item.
 	queue = deque([(start_url, 0, "")])
+
+	# Sitemap-seeded candidates join at depth 1, never depth 0, so the homepage
+	# always still wins the first pop (the sort key's top tier is depth==0 only --
+	# see the priority sort below). An addition on top of ordinary link-following,
+	# not a replacement: a site with no sitemap contributes nothing here and the
+	# crawl proceeds exactly as it did before this existed.
+	if crawl_beyond_homepage and cfg.setting("use_sitemap", True):
+		queued_from_sitemap = set()
+		for loc in discover_sitemap_urls(start_url, cfg, session, robots):
+			link = normalize_url(loc)
+			if link == start_url or link in queued_from_sitemap:
+				continue
+			if not same_site(link, base_netloc) or not _is_crawlable(link, skip_patterns):
+				continue
+			if not _robots_allows(robots, user_agent, link):
+				continue
+			queued_from_sitemap.add(link)
+			queue.append((link, 1, ""))
 
 	try:
 		while queue and len(results) < max_pages:

--- a/crm/domain_enrichment/crawler.py
+++ b/crm/domain_enrichment/crawler.py
@@ -93,9 +93,7 @@ def same_site(url: str, base_netloc: str) -> bool:
 
 
 def _link_priority(url: str, anchor_text: str, link_priority: list) -> float:
-	"""Lower number = crawl sooner. Matches the leaf path segment only -- an
-	ancestor match alone (e.g. a news article under "/about-us/...") must not
-	inherit that segment's priority."""
+	"""Lower number = crawl sooner."""
 	path = urlparse(url).path.rstrip("/")
 	leaf = path.rsplit("/", 1)[-1] if path else ""
 	haystack = (leaf + " " + (anchor_text or "")).lower()
@@ -123,7 +121,6 @@ def _is_crawlable(url: str, skip_patterns: list) -> bool:
 			if re.search(pat, url, re.IGNORECASE):
 				return False
 		except re.error:
-			# Malformed regex: fall back to substring match.
 			if pat.lower() in low:
 				return False
 	return True
@@ -151,7 +148,6 @@ def extract_content(soup: BeautifulSoup) -> dict:
 
 
 def _links_on_page(soup, page_url, base_netloc, skip_patterns):
-	"""Yield (normalized_url, anchor_text) for same-site, crawlable links."""
 	for a in soup.find_all("a", href=True):
 		href = a["href"].strip()
 		if not href or any(href.lower().startswith(s) for s in SKIP_SCHEMES):
@@ -175,8 +171,6 @@ def _parse_and_fill(page, html):
 
 
 def crawl_page(url, cfg, session=None):
-	"""Returns (CrawledPage, soup_or_None); failures land on ``CrawledPage.error``
-	instead of raising."""
 	status, html, error, final_url = fetch(url, cfg, session=session)
 	# Resolved URL: links and provenance match the host that actually served the body.
 	page = CrawledPage(url=final_url or url, status_code=status, html=html or "", error=error)
@@ -189,8 +183,7 @@ ABOUT_MIN_TEXT = 200
 
 
 def load_robots(start_url, cfg, session=None):
-	"""Returns ``None`` when absent/unreadable (convention: allow all). Never raises
-	-- robots is advisory and must not break enrichment."""
+	"""Returns ``None`` when absent/unreadable (convention: allow all)."""
 	try:
 		parsed = urlparse(normalize_url(start_url))
 		if not parsed.netloc:
@@ -213,7 +206,6 @@ def load_robots(start_url, cfg, session=None):
 
 
 def _robots_allows(robots, user_agent, url):
-	"""True if robots is absent or permits ``url`` for ``user_agent``; fails open."""
 	if robots is None:
 		return True
 	try:
@@ -223,8 +215,6 @@ def _robots_allows(robots, user_agent, url):
 
 
 def probe_about_pages(home_url, cfg, session=None, skip_urls=()):
-	"""Returns ``[(CrawledPage, soup)]`` for the first readable hit among
-	``ABOUT_PROBE_PATHS`` not already crawled, else ``[]``."""
 	skip = {normalize_url(u) for u in skip_urls}
 	user_agent = cfg.setting("user_agent")
 	own_session = session is None
@@ -256,7 +246,6 @@ def probe_about_pages(home_url, cfg, session=None, skip_urls=()):
 # Sitemap discovery
 # --------------------------------------------------------------------------- #
 # Additive on top of link-following BFS: seeds pages the sitemap author flagged.
-# No sitemap, or an unreadable one, falls through to plain link-following, silently.
 SITEMAP_MAX_SITEMAPS = 5  # sitemap files fetched; guards pathological sitemap indexes
 SITEMAP_MAX_URLS = 200  # total <loc> entries collected across all fetched sitemaps
 
@@ -294,9 +283,8 @@ def _parse_sitemap(xml_text: str):
 
 
 def discover_sitemap_urls(start_url, cfg, session, robots):
-	"""robots.txt ``Sitemap:`` first, else ``/sitemap.xml``. Follows one level of
-	``<sitemapindex>`` nesting, bounded by ``SITEMAP_MAX_SITEMAPS``/``SITEMAP_MAX_URLS``.
-	Never raises -- any failure returns ``[]`` and falls through to plain BFS."""
+	"""Falls back from robots.txt ``Sitemap:`` to ``/sitemap.xml``, bounded by
+	``SITEMAP_MAX_SITEMAPS``/``SITEMAP_MAX_URLS``."""
 	try:
 		parsed = urlparse(normalize_url(start_url))
 		if not parsed.netloc:
@@ -354,8 +342,6 @@ def discover_sitemap_urls(start_url, cfg, session, robots):
 
 
 def crawl(start_url, cfg, session=None, progress=None):
-	"""Breadth-first crawl prioritizing company-info pages. Caps, link-priority and
-	skip patterns come from ``cfg``. ``progress`` is an optional ``fn(message)`` callback."""
 	max_pages = int(cfg.setting("max_pages"))
 	max_depth = int(cfg.setting("max_depth"))
 	link_priority = cfg.link_priority

--- a/crm/domain_enrichment/crawler.py
+++ b/crm/domain_enrichment/crawler.py
@@ -5,12 +5,9 @@
 come from config (Settings child tables), not module constants.
 
 Exposes:
-
-    crawl()             -> ranked list of (CrawledPage, soup) tuples, homepage first
-    crawl_page()        -> fetch + parse a single page into a CrawledPage
-    extract_content()   -> pull title/headings/visible text from soup
-
-Same registrable domain only; respects the page cap, depth cap, and skip patterns.
+    crawl()           -> ranked list of (CrawledPage, soup) tuples, homepage first
+    crawl_page()      -> fetch + parse a single page into a CrawledPage
+    extract_content() -> pull title/headings/visible text from soup
 """
 
 from __future__ import annotations
@@ -28,7 +25,6 @@ from bs4 import BeautifulSoup
 from .http import build_session, fetch
 from .result import CrawledPage
 
-# Asset / non-HTML extensions we never want to crawl (mechanics, not knowledge).
 SKIP_EXTENSIONS = (
 	".pdf",
 	".jpg",
@@ -57,15 +53,8 @@ SKIP_SCHEMES = ("mailto:", "tel:", "javascript:", "data:", "#")
 
 
 def normalize_url(url: str) -> str:
-	"""Strip fragments, query strings and trailing slashes for stable dedupe.
-
-	Query strings are dropped rather than canonicalized: for the pages this crawler
-	cares about (About/Contact/Team/company pages) a query string is overwhelmingly
-	tracking noise (``?utm_*``, ``?ref=``) or a variant parameter that still renders
-	the same page, not a distinct page identity. Keeping them let the same page get
-	queued and fetched multiple times under different query strings, wasting real
-	page-budget slots on duplicate content.
-	"""
+	"""Query strings are dropped, not canonicalized -- almost always tracking
+	noise, not a distinct page identity, for the pages this crawler cares about."""
 	url, _frag = urldefrag(url)
 	parsed = urlparse(url)
 	if parsed.query:
@@ -77,14 +66,8 @@ def normalize_url(url: str) -> str:
 
 @lru_cache(maxsize=1)
 def _tld_extractor() -> tldextract.TLDExtract:
-	"""Public Suffix List backed extractor, built once and cached.
-
-	``suffix_list_urls=()`` + ``cache_dir=None`` pin it to the snapshot bundled
-	with tldextract -- it never fetches the PSL over the network (deterministic,
-	offline, no surprise latency on first crawl). ``include_psl_private_domains``
-	makes hosting suffixes like ``github.io`` / ``vercel.app`` registrable, so two
-	tenants under one of them count as different sites for scoping.
-	"""
+	"""Pinned to the bundled PSL snapshot (no network fetch); private suffixes like
+	``github.io``/``vercel.app`` stay registrable so distinct tenants count as distinct sites."""
 	return tldextract.TLDExtract(
 		suffix_list_urls=(),
 		cache_dir=None,
@@ -93,14 +76,8 @@ def _tld_extractor() -> tldextract.TLDExtract:
 
 
 def registrable_domain(netloc: str) -> str:
-	"""The registrable domain of ``netloc`` per the Public Suffix List.
-
-	``www.acme.co.uk`` -> ``acme.co.uk``; ``blog.acme.com`` -> ``acme.com``. This
-	is the same-site key: a naive last-two-labels rule collapses every ``*.co.uk``
-	(or ``*.github.io``) to one bucket, so the crawler would wander into unrelated
-	third-party sites sharing a public suffix. Hosts with no registrable suffix
-	(bare hostnames, IPs, ``localhost``) fall back to the host itself.
-	"""
+	"""``www.acme.co.uk`` -> ``acme.co.uk`` -- avoids a naive last-two-labels rule
+	collapsing all of ``*.co.uk`` into one same-site bucket."""
 	netloc = netloc.lower().split(":")[0]
 	extracted = _tld_extractor()(netloc)
 	if extracted.domain and extracted.suffix:
@@ -116,15 +93,9 @@ def same_site(url: str, base_netloc: str) -> bool:
 
 
 def _link_priority(url: str, anchor_text: str, link_priority: list) -> float:
-	"""Lower number = crawl sooner. Matching links score by their keyword's rank,
-	weighted; non-matching pages sort last. ``link_priority`` is a list of
-	(keyword, weight) tuples from config.
-
-	Matches against the leaf path segment only, not the whole path: otherwise any
-	page nested under a segment that happens to match (e.g. "/about-us/corporate-news/
-	2023/some-unrelated-article") inherits top-tier priority from an ancestor
-	directory alone, starving the pages the keyword was actually meant to prioritize.
-	"""
+	"""Lower number = crawl sooner. Matches the leaf path segment only -- an
+	ancestor match alone (e.g. a news article under "/about-us/...") must not
+	inherit that segment's priority."""
 	path = urlparse(url).path.rstrip("/")
 	leaf = path.rsplit("/", 1)[-1] if path else ""
 	haystack = (leaf + " " + (anchor_text or "")).lower()
@@ -152,18 +123,15 @@ def _is_crawlable(url: str, skip_patterns: list) -> bool:
 			if re.search(pat, url, re.IGNORECASE):
 				return False
 		except re.error:
-			# Treat a malformed admin skip-pattern as a plain substring.
+			# Malformed regex: fall back to substring match.
 			if pat.lower() in low:
 				return False
 	return True
 
 
 def extract_content(soup: BeautifulSoup) -> dict:
-	"""Pull title, headings and clean visible text out of a parsed page.
-
-	NOTE: this mutates ``soup`` (it decomposes script/style nodes), so callers
-	that need the original DOM afterwards must pass a throwaway copy.
-	"""
+	"""Mutates ``soup`` (decomposes script/style) -- pass a throwaway copy if the
+	caller needs the original DOM afterwards."""
 	title = ""
 	if soup.title and soup.title.string:
 		title = soup.title.string.strip()
@@ -174,11 +142,10 @@ def extract_content(soup: BeautifulSoup) -> dict:
 		if txt:
 			headings.append(txt)
 
-	# Remove non-content nodes before grabbing text.
 	for node in soup(["script", "style", "noscript", "template", "svg"]):
 		node.decompose()
 	text = soup.get_text(" ", strip=True)
-	text = " ".join(text.split())  # collapse runaway whitespace
+	text = " ".join(text.split())
 
 	return {"title": title, "headings": headings, "text": text}
 
@@ -198,11 +165,7 @@ def _links_on_page(soup, page_url, base_netloc, skip_patterns):
 
 
 def _parse_and_fill(page, html):
-	"""Parse ``html``, fill ``page`` title/headings/text, and return a fresh soup.
-
-	``extract_content`` mutates its soup (decomposes script/style), so it runs on a
-	throwaway parse while the returned soup stays unmutated for the caller.
-	"""
+	"""``extract_content`` runs on a throwaway parse so the returned soup stays unmutated."""
 	soup = BeautifulSoup(html, "html.parser")
 	content = extract_content(BeautifulSoup(html, "html.parser"))
 	page.title = content["title"]
@@ -212,34 +175,22 @@ def _parse_and_fill(page, html):
 
 
 def crawl_page(url, cfg, session=None):
-	"""Fetch and parse a single page. Returns (CrawledPage, soup_or_None).
-
-	Failures are captured on ``CrawledPage.error`` rather than raised. The soup
-	returned is a fresh, unmutated parse (``extract_content`` runs on a copy).
-	"""
+	"""Returns (CrawledPage, soup_or_None); failures land on ``CrawledPage.error``
+	instead of raising."""
 	status, html, error, final_url = fetch(url, cfg, session=session)
-	# Use the post-redirect URL so relative links resolve and provenance is recorded
-	# against the host that actually served the body.
+	# Resolved URL: links and provenance match the host that actually served the body.
 	page = CrawledPage(url=final_url or url, status_code=status, html=html or "", error=error)
 	soup = _parse_and_fill(page, html) if (html and not error) else None
 	return page, soup
 
 
-# Common About-page paths probed when the BFS didn't surface one (some sites don't
-# link About prominently, but it's the best source of a company description).
 ABOUT_PROBE_PATHS = ("/about", "/about-us", "/company", "/our-story")
-# A probed page needs at least this much readable text to be worth keeping.
 ABOUT_MIN_TEXT = 200
 
 
 def load_robots(start_url, cfg, session=None):
-	"""Fetch and parse the site's ``robots.txt`` via the SSRF-guarded fetcher.
-
-	Returns a populated ``RobotFileParser``, or ``None`` when robots.txt is absent or
-	unreadable (per convention: allow all). Uses ``fetch(..., html_only=False)`` so the
-	``text/plain`` body isn't skipped, and never raises -- robots is advisory here and
-	must not break enrichment.
-	"""
+	"""Returns ``None`` when absent/unreadable (convention: allow all). Never raises
+	-- robots is advisory and must not break enrichment."""
 	try:
 		parsed = urlparse(normalize_url(start_url))
 		if not parsed.netloc:
@@ -262,8 +213,7 @@ def load_robots(start_url, cfg, session=None):
 
 
 def _robots_allows(robots, user_agent, url):
-	"""True if robots is absent or permits fetching ``url`` for ``user_agent``. A
-	malformed robots quirk never blocks enrichment (fails open)."""
+	"""True if robots is absent or permits ``url`` for ``user_agent``; fails open."""
 	if robots is None:
 		return True
 	try:
@@ -273,12 +223,8 @@ def _robots_allows(robots, user_agent, url):
 
 
 def probe_about_pages(home_url, cfg, session=None, skip_urls=()):
-	"""Best-effort fetch of common About-page paths not already crawled.
-
-	Returns ``[(CrawledPage, soup)]`` for the first probed path that returns a readable
-	page (or empty). SSRF + byte caps are enforced by ``fetch``; failures are ignored.
-	Bounded: stops at the first readable hit, at most ``len(ABOUT_PROBE_PATHS)`` fetches.
-	"""
+	"""Returns ``[(CrawledPage, soup)]`` for the first readable hit among
+	``ABOUT_PROBE_PATHS`` not already crawled, else ``[]``."""
 	skip = {normalize_url(u) for u in skip_urls}
 	user_agent = cfg.setting("user_agent")
 	own_session = session is None
@@ -309,12 +255,8 @@ def probe_about_pages(home_url, cfg, session=None, skip_urls=()):
 # --------------------------------------------------------------------------- #
 # Sitemap discovery
 # --------------------------------------------------------------------------- #
-# Sitemap-derived URLs are an addition on top of the ordinary link-following BFS,
-# not a replacement: they seed the queue with pages the sitemap author flagged as
-# worth visiting (locale variants, sections not linked from the homepage nav), so
-# the crawler doesn't rely purely on stumbling onto them within max_depth. A site
-# with no sitemap -- or an unreadable one -- must fall straight through to plain
-# link-following with no error, no log noise, and no behavior change.
+# Additive on top of link-following BFS: seeds pages the sitemap author flagged.
+# No sitemap, or an unreadable one, falls through to plain link-following, silently.
 SITEMAP_MAX_SITEMAPS = 5  # sitemap files fetched; guards pathological sitemap indexes
 SITEMAP_MAX_URLS = 200  # total <loc> entries collected across all fetched sitemaps
 
@@ -325,12 +267,10 @@ def _local_tag(tag: str) -> str:
 
 
 def _parse_sitemap(xml_text: str):
-	"""Parse a sitemap document. Returns ('urlset' | 'sitemapindex' | None, [loc, ...]).
+	"""Returns ('urlset' | 'sitemapindex' | None, [loc, ...]); never raises.
 
-	Rejects any document containing a DOCTYPE before parsing: a legitimate sitemap
-	never has one (the sitemaps.org schema defines none), so this is a zero-cost
-	guard against XML entity-expansion abuse from a hostile or compromised site.
-	Never raises -- malformed XML yields (None, []).
+	Rejects any DOCTYPE before parsing as an XML entity-expansion guard -- a
+	legitimate sitemap never has one.
 	"""
 	if "<!doctype" in xml_text.lower():
 		return None, []
@@ -354,18 +294,9 @@ def _parse_sitemap(xml_text: str):
 
 
 def discover_sitemap_urls(start_url, cfg, session, robots):
-	"""Best-effort page discovery from the site's sitemap(s).
-
-	Tries the sitemap location(s) declared via ``Sitemap:`` in robots.txt first,
-	falling back to the conventional ``/sitemap.xml`` path when robots.txt is
-	absent or declares none. Follows ``<sitemapindex>`` nesting one level deep,
-	bounded by ``SITEMAP_MAX_SITEMAPS`` / ``SITEMAP_MAX_URLS``. Every sitemap
-	fetch stays same-site and goes through the normal SSRF-guarded ``fetch()``.
-
-	Always returns a list, possibly empty -- a missing sitemap, a non-200, a
-	timeout, or malformed XML all silently fall through to the ordinary BFS.
-	Never raises.
-	"""
+	"""robots.txt ``Sitemap:`` first, else ``/sitemap.xml``. Follows one level of
+	``<sitemapindex>`` nesting, bounded by ``SITEMAP_MAX_SITEMAPS``/``SITEMAP_MAX_URLS``.
+	Never raises -- any failure returns ``[]`` and falls through to plain BFS."""
 	try:
 		parsed = urlparse(normalize_url(start_url))
 		if not parsed.netloc:
@@ -381,6 +312,7 @@ def discover_sitemap_urls(start_url, cfg, session, robots):
 			candidates.append(f"{parsed.scheme}://{parsed.netloc}/sitemap.xml")
 
 		to_fetch = deque(candidates[:SITEMAP_MAX_SITEMAPS])
+		sitemaps_queued = len(to_fetch)  # running total: seed + discovered children
 		fetched_sitemaps = set()
 		urls = []
 		seen_urls = set()
@@ -398,10 +330,14 @@ def discover_sitemap_urls(start_url, cfg, session, robots):
 				continue
 
 			kind, locs = _parse_sitemap(body)
+
 			if kind == "sitemapindex":
 				for loc in locs:
-					if len(fetched_sitemaps) + len(to_fetch) < SITEMAP_MAX_SITEMAPS:
-						to_fetch.append(loc)
+					if sitemaps_queued >= SITEMAP_MAX_SITEMAPS:
+						break
+					to_fetch.append(loc)
+					sitemaps_queued += 1
+
 			elif kind == "urlset":
 				for loc in locs:
 					norm = normalize_url(loc)
@@ -418,14 +354,8 @@ def discover_sitemap_urls(start_url, cfg, session, robots):
 
 
 def crawl(start_url, cfg, session=None, progress=None):
-	"""Breadth-first crawl from ``start_url``, prioritizing company-info pages.
-
-	Caps (``max_pages``/``max_depth``), link-priority order and skip patterns all
-	come from ``cfg``. Returns a list of (CrawledPage, soup) tuples, homepage
-	first. Respects the page cap, depth cap, and same-domain rule.
-
-	``progress`` is an optional ``fn(message)`` called per crawled URL.
-	"""
+	"""Breadth-first crawl prioritizing company-info pages. Caps, link-priority and
+	skip patterns come from ``cfg``. ``progress`` is an optional ``fn(message)`` callback."""
 	max_pages = int(cfg.setting("max_pages"))
 	max_depth = int(cfg.setting("max_depth"))
 	link_priority = cfg.link_priority
@@ -437,27 +367,20 @@ def crawl(start_url, cfg, session=None, progress=None):
 	start_url = normalize_url(start_url)
 	base_netloc = urlparse(start_url).netloc
 
-	# Respect robots.txt for discovered links -- but only when we actually crawl beyond
-	# the homepage (skip the extra fetch for homepage-only / preview runs, which follow
-	# no links). The explicit start URL is always fetched; robots gates discovery.
+	# robots.txt only gates discovered links; skip the fetch for homepage-only runs.
 	crawl_beyond_homepage = max_depth >= 1 and max_pages > 1
 	robots = load_robots(start_url, cfg, session) if crawl_beyond_homepage else None
 
 	visited = set()
-	# Resolved (post-redirect) URLs already crawled -- catches a duplicate that the
-	# pre-fetch `visited` check above can't (e.g. /contact.html redirecting to an
-	# already-crawled /contact): the two *requested* URLs genuinely differ, so only
-	# the resolved URL reveals they're the same page.
+	# Resolved (post-redirect) URLs already crawled -- catches a duplicate the
+	# pre-fetch `visited` check can't (e.g. /contact.html -> /contact).
 	visited_resolved = set()
 	results = []
-	# Queue holds (url, depth, anchor_text). We pop the highest-priority item.
+	# Queue holds (url, depth, anchor_text).
 	queue = deque([(start_url, 0, "")])
 
-	# Sitemap-seeded candidates join at depth 1, never depth 0, so the homepage
-	# always still wins the first pop (the sort key's top tier is depth==0 only --
-	# see the priority sort below). An addition on top of ordinary link-following,
-	# not a replacement: a site with no sitemap contributes nothing here and the
-	# crawl proceeds exactly as it did before this existed.
+	# Sitemap-seeded links join at depth 1, never 0, so the homepage still wins
+	# the first pop. Additive only -- a site with no sitemap is unaffected.
 	if crawl_beyond_homepage and cfg.setting("use_sitemap", True):
 		queued_from_sitemap = set()
 		for loc in discover_sitemap_urls(start_url, cfg, session, robots):
@@ -495,34 +418,20 @@ def crawl(start_url, cfg, session=None, progress=None):
 			resolved = normalize_url(page.url) if page.url else ""
 
 			if not results:
-				# Homepage: never a duplicate (nothing crawled yet). If it
-				# redirected to another host, adopt the resolved domain as the
-				# same-site base so the rest of the crawl follows the real site.
+				# Homepage: can't be a duplicate yet. Adopt its resolved host as the
+				# same-site base if it redirected elsewhere.
 				if resolved:
 					base_netloc = urlparse(page.url).netloc or base_netloc
 			else:
-				# A redirect can land on a page already crawled under a different
-				# requested URL (e.g. /contact.html -> /contact) -- drop the
-				# duplicate silently instead of double-reporting/double-extracting
-				# the same content, and don't let it consume a page-budget slot:
-				# the loop just fetches one more page in its place.
+				# A redirect can land here under a different requested URL (e.g.
+				# /contact.html -> /contact) -- drop the duplicate, no budget spent.
 				if resolved and resolved in visited_resolved:
 					continue
 				if soup is not None and page.url and not same_site(page.url, base_netloc):
-					# A same-site link that redirected off-domain mid-crawl.
-					# same_site() is only re-checked here, after the fact:
-					# fetch()'s redirect loop (http.py) re-validates each hop for
-					# SSRF safety but has no notion of "stay on this site" -- it's
-					# a generic HTTP layer also used for robots.txt/sitemaps.
-					# Treat the resolved page as out of scope: keep it visible as
-					# an error (consistent with a network failure) but don't
-					# extract from it or follow its links. Clear every parsed
-					# artifact, not just html/text -- title/headings are
-					# populated by crawl_page() before this check runs, and
-					# extractors (e.g. classify_industry's About-page lookup)
-					# read them straight off the CrawledPage without checking
-					# soup/error, so leaving them behind would leak off-site
-					# content past this guard.
+					# Same-site link redirected off-domain; fetch() only checks SSRF
+					# per hop, not same-site scope. Clear every parsed field (not just
+					# html/text) so nothing -- including title/headings, already
+					# filled in by crawl_page() -- leaks into extraction.
 					page.error = page.error or f"redirected off-site to {urlparse(page.url).netloc}"
 					page.html = ""
 					page.text = ""

--- a/crm/domain_enrichment/doctype/crm_enrichment_settings/crm_enrichment_settings.json
+++ b/crm/domain_enrichment/doctype/crm_enrichment_settings/crm_enrichment_settings.json
@@ -16,6 +16,7 @@
   "crawl_tab",
   "max_pages",
   "max_depth",
+  "use_sitemap",
   "request_timeout",
   "column_break_crawl",
   "max_download_bytes",
@@ -108,6 +109,13 @@
    "fieldname": "request_timeout",
    "fieldtype": "Int",
    "label": "Request Timeout (s)"
+  },
+  {
+   "default": "1",
+   "description": "Seed the crawl queue from the site's sitemap (declared in robots.txt, or the conventional /sitemap.xml) so pages not reachable within Max Depth still get a chance to be crawled. This is an addition on top of ordinary link-following, not a replacement -- a site with no sitemap falls straight through to link-following with no error.",
+   "fieldname": "use_sitemap",
+   "fieldtype": "Check",
+   "label": "Use Sitemap"
   },
   {
    "fieldname": "column_break_crawl",
@@ -208,7 +216,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-17 00:00:00.000000",
+ "modified": "2026-07-14 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Domain Enrichment",
  "name": "CRM Enrichment Settings",

--- a/crm/domain_enrichment/extractors.py
+++ b/crm/domain_enrichment/extractors.py
@@ -3,15 +3,11 @@
 
 """Generic, config-driven extractors.
 
-This module contains NO literal keyword / industry / social tables: the
-classifiers (``classify_industry``, social-profile matching) are generic rule
-executors that iterate over ``cfg.rules_by_type[...]``, honoring each rule's
-``match_scope``, ``weight`` and compiled (substring-or-regex) patterns.
-
-What stays as pure mechanics (these are not tunable knowledge, just algorithms):
-JSON-LD parsing, the favicon scorer, readability diagnosis, email/phone regex
-extraction, and company-name cleaning. These are deliberately NOT pushed into
-doctypes (avoid over-engineering).
+No literal keyword/industry/social tables here: classifiers iterate over
+``cfg.rules_by_type[...]``, honoring each rule's ``match_scope``, ``weight`` and
+compiled patterns. JSON-LD parsing, the favicon scorer, readability diagnosis,
+email/phone regex, and company-name cleaning stay as plain mechanics -- not
+tunable knowledge, so not pushed into doctypes.
 """
 
 from __future__ import annotations
@@ -34,7 +30,7 @@ from .result import (
 # --------------------------------------------------------------------------- #
 EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
-# International-ish phone numbers: optional +, country/area groups, separators.
+# Loosely international phone numbers.
 PHONE_RE = re.compile(
 	r"""(?<!\w)
     (\+?\d{1,3}[\s.-]?)?      # optional country code
@@ -64,9 +60,8 @@ SOCIAL_NEGATIVE = re.compile(r"/(sharer|share|intent|home|login|signup|privacy|t
 
 
 # --------------------------------------------------------------------------- #
-# Generic rule executors -- the heart of the config-driven engine
+# Generic rule executors
 # --------------------------------------------------------------------------- #
-# Map a rule's match_scope to the text key the executor should match against.
 SCOPE_HEADLINE = "Headline"
 SCOPE_FULL_TEXT = "Full Text"
 SCOPE_HTML = "HTML"
@@ -75,14 +70,10 @@ SCOPE_URL = "URL"
 
 
 def apply_keyword_rules(text_by_scope: dict, rules: list) -> dict:
-	"""Score keyword/regex rules against scoped text.
-
-	``text_by_scope`` maps a scope name (Headline/Full Text/URL/...) to the text
-	to match for that scope. Each rule is matched only against its own
-	``match_scope``. Returns ``{label: weighted_score}`` where ``label`` is the
-	rule's industry (Industry rules) or target_value (everything else), and the
-	score is ``pattern_hits * weight`` summed across rules sharing a label.
-	"""
+	"""Score keyword/regex rules against scoped text; each rule matches only its own
+	``match_scope``. Returns ``{label: weighted_score}`` -- ``label`` is the rule's
+	industry (Industry rules) or target_value (everything else), score is
+	``pattern_hits * weight`` summed per label."""
 	scores: dict = {}
 	for rule in rules:
 		text = text_by_scope.get(rule.match_scope, "")
@@ -125,11 +116,9 @@ def _ld_type_matches(block, wanted):
 # --------------------------------------------------------------------------- #
 # Readability diagnosis (mechanics)
 # --------------------------------------------------------------------------- #
-# Markers of a bot-protection / WAF challenge page served instead of content.
-# Kept as a small constant: these are diagnostic mechanics, not classifier
-# knowledge an admin tunes (and they map 1:1 to a fixed set of human messages).
-# Strong markers: unambiguous WAF/challenge fingerprints -- a page carrying one is a
-# challenge page regardless of how much other text it has.
+# WAF/bot-protection markers. Strong markers alone mean "blocked". Weak markers
+# (also legitimate on content-rich pages, e.g. a reCAPTCHA contact form) only
+# count when the page is also nearly devoid of text.
 WAF_MARKERS_STRONG = (
 	"_incapsula_resource",
 	"incapsula",
@@ -139,16 +128,12 @@ WAF_MARKERS_STRONG = (
 	"ddos protection",
 	"are you a human",
 )
-# Weak markers: generic phrases that legitimate content-rich pages also contain (a
-# contact form embedding reCAPTCHA, a stock <noscript> notice). Only treat these as a
-# block when the page is also nearly devoid of readable text.
 WAF_MARKERS_WEAK = (
 	"captcha",
 	"please enable javascript",
 	"enable cookies to continue",
 	"access denied",
 )
-# Below this much readable text, a weak marker is taken as a real challenge page.
 WAF_WEAK_TEXT_THRESHOLD = 1000
 
 READABILITY_MESSAGES = {
@@ -252,15 +237,14 @@ _APPLE_TOUCH_PX = 180
 
 
 def _safe_url(base_url, raw):
-	"""Resolve ``raw`` against ``base_url``; return it only if it is a non-empty
-	``http(s)`` URL. Rejects ``javascript:`` / ``data:`` / other schemes a crawled
-	site could inject into a stored logo/image/icon value (defense against stored XSS
-	-- these values land in a CRM field). Returns ``""`` otherwise."""
+	"""Resolve ``raw`` against ``base_url``; return it only if it's a non-empty
+	``http(s)`` URL. Rejects ``javascript:``/``data:`` schemes a crawled site could
+	inject into a stored logo/image/icon field (stored-XSS defense)."""
 	raw = (raw or "").strip()
 	if not raw:
 		return ""
-	# Reject an explicit non-http(s) scheme on the raw value up front (urljoin keeps
-	# javascript:/data: as-is), then re-check the resolved URL for relative inputs.
+	# urljoin() leaves javascript:/data: schemes as-is, so check the raw scheme
+	# first, then re-check the resolved URL for relative inputs.
 	scheme = urlparse(raw).scheme.lower()
 	if scheme and scheme not in ("http", "https"):
 		return ""
@@ -269,11 +253,8 @@ def _safe_url(base_url, raw):
 
 
 def _best_icon(soup, base_url):
-	"""Best ``<link rel=icon>`` candidate URL.
-
-	Scalable SVGs win over any raster; among rasters the largest declared size wins
-	(apple-touch-icons default to 180px). Returns ``""`` if no icon is declared.
-	"""
+	"""Best ``<link rel=icon>`` candidate: scalable SVG beats any raster, then
+	largest declared size wins. Returns ``""`` if no icon is declared."""
 	candidates = []
 	for tag in soup.find_all("link", href=True):
 		rel = tag.get("rel") or []
@@ -291,7 +272,6 @@ def _best_icon(soup, base_url):
 		)
 		m = re.search(r"(\d+)x\d+", tag.get("sizes", "") or "")
 		px = int(m.group(1)) if m else (_APPLE_TOUCH_PX if "apple-touch" in rel else 0)
-		# Sort key: SVG beats any raster; then by pixel size.
 		candidates.append(((1 if is_svg else 0, px), safe))
 	if not candidates:
 		return ""
@@ -300,13 +280,9 @@ def _best_icon(soup, base_url):
 
 
 def extract_logo(soup, base_url):
-	"""The company's **link icon** -- the crisp, square brand mark suitable as an
-	avatar. Only ``<link rel=icon>`` sources are considered: scalable SVG > largest
-	declared raster / apple-touch > the conventional ``/favicon.ico`` fallback.
-
-	The larger social-share / JSON-LD image is deliberately NOT used as the logo
-	(``og:image`` is usually a wide banner, not a brand mark); it is captured
-	separately by :func:`extract_image`. Returns a :class:`Field`.
+	"""The company's link icon -- a crisp, square brand mark, not the wider
+	social-share image (``og:image`` is usually a banner; see :func:`extract_image`).
+	Priority: SVG > largest declared raster/apple-touch > ``/favicon.ico`` fallback.
 	"""
 	icon_url = _best_icon(soup, base_url)
 	if icon_url:
@@ -319,11 +295,9 @@ def extract_logo(soup, base_url):
 
 
 def extract_image(soup, base_url):
-	"""The company's larger brand / social image: JSON-LD ``Organization.logo``
-	(curated, full-size) → ``og:image`` / ``twitter:image`` (social-share). Kept in the
-	run JSON for reference; it is NOT the company logo (that is the link icon -- see
-	:func:`extract_logo`). Returns a :class:`Field`, empty if none is declared.
-	"""
+	"""The larger brand/social image (JSON-LD ``Organization.logo`` -> ``og:image``/
+	``twitter:image``), NOT the company logo -- see :func:`extract_logo`. Returns a
+	:class:`Field`, empty if none declared."""
 	for block in parse_json_ld(soup):
 		if not _ld_type_matches(block, _ORG_TYPES):
 			continue
@@ -438,13 +412,10 @@ def extract_company_info(homepage, soup):
 	return info
 
 
-# Tags whose text is chrome (navigation/forms), not company copy -- skipped when
-# hunting for a body paragraph.
+# Chrome tags skipped when hunting for a body paragraph.
 _NON_CONTENT_PARENTS = {"nav", "header", "footer", "aside", "form"}
 _MIN_PARAGRAPH_LEN = 80
-# How many qualifying paragraphs to score before picking a winner -- bounded so a
-# very long page doesn't turn this into a full scan.
-_MAX_PARAGRAPHS_SCANNED = 6
+_MAX_PARAGRAPHS_SCANNED = 6  # bounded so a very long page isn't a full scan
 
 
 def _company_name_hits(text, company_name):
@@ -458,19 +429,11 @@ def _company_name_hits(text, company_name):
 def first_paragraph(soup, industry_rules=None, company_name=""):
 	"""Best substantial body paragraph on a page (mechanics).
 
-	Scans up to ``_MAX_PARAGRAPHS_SCANNED`` qualifying ``<p>`` tags (sentence-like
-	copy, not inside nav/header/footer/aside/form chrome) and picks the one with the
-	most Industry-rule keyword hits -- the same keyword corpus ``classify_industry``
-	uses. A paragraph naming actual business/product terms ("chemicals", "adhesives")
-	is far more likely to be a genuine description than generic marketing filler
-	("customer-centric... quality and innovation..."), which typically scores zero.
-	Mentions of ``company_name`` only break ties between paragraphs already tied on
-	keyword hits -- narrows down options further without letting a paragraph that
-	just happens to repeat the company name outrank one with real industry signal.
-	Falls back to the first qualifying paragraph when no candidate has any keyword
-	hit, or when ``industry_rules`` is empty -- strictly backward compatible with the
-	old "just take the first one" behavior. Used as a description fallback when a
-	site exposes no description metadata. Read-only -- does not mutate ``soup``.
+	Scores up to ``_MAX_PARAGRAPHS_SCANNED`` qualifying ``<p>`` tags by Industry-rule
+	keyword hits (the same corpus ``classify_industry`` uses); ``company_name``
+	mentions only break ties, never outrank keyword signal. Falls back to the first
+	qualifying paragraph when nothing scores or ``industry_rules`` is empty.
+	Read-only -- does not mutate ``soup``.
 	"""
 	candidates = []
 	for p in soup.find_all("p"):
@@ -488,12 +451,10 @@ def first_paragraph(soup, industry_rules=None, company_name=""):
 	if not industry_rules:
 		return candidates[0]
 
-	# max() returns the first-encountered element on ties, so a paragraph earlier
-	# in document order still wins when nothing scores higher -- including the
-	# "every candidate has zero keyword hits" case, which naturally falls back to
-	# candidates[0] without needing to special-case it. Company-name hits are a
-	# second tuple element, not added into the same number, so they can only ever
-	# decide between paragraphs already tied on industry hits.
+	# max() keeps the first-encountered element on ties, so document order still
+	# wins when nothing scores higher (covers the "all zero hits" case for free).
+	# Company-name hits are a separate tuple slot -- they can only break ties,
+	# never add to the industry-hit count.
 	return max(
 		candidates,
 		key=lambda text: (
@@ -506,12 +467,10 @@ def first_paragraph(soup, industry_rules=None, company_name=""):
 def select_description(pages, soups_by_url, industry_rules=None, company_name=""):
 	"""Pick the best *company* description across crawled pages (mechanics).
 
-	Priority (highest first): JSON-LD ``Organization.description`` → About-page body
-	paragraph → head ``og:description``/``<meta description>`` → home-page body
-	paragraph (last resort). The body-paragraph fallbacks let descriptions be derived
-	even when a site exposes no description metadata at all. ``industry_rules`` and
-	``company_name``, when given, steer the body-paragraph fallbacks toward the most
-	keyword-dense candidate (see ``first_paragraph``).
+	Priority: JSON-LD ``Organization.description`` -> About-page body paragraph ->
+	head ``og:description``/``<meta description>`` -> home-page body paragraph
+	(last resort). ``industry_rules``/``company_name`` steer the body-paragraph
+	fallbacks (see ``first_paragraph``).
 	"""
 	home_url = pages[0].url if pages else ""
 	best_key = None
@@ -533,19 +492,16 @@ def select_description(pages, soups_by_url, industry_rules=None, company_name=""
 		is_home = page.url == home_url
 		is_about = _is_about_page(page.url)
 
-		# JSON-LD Organization.description -- curated structured data, highest priority.
 		for block in parse_json_ld(soup):
 			if _ld_type_matches(block, _ORG_TYPES) and block.get("description"):
 				consider(Field(block["description"].strip(), page.url, Method.JSON_LD), 6)
 				break
 
-		# About-page body paragraph outranks head meta.
 		if is_about:
 			consider(
 				Field(first_paragraph(soup, industry_rules, company_name), page.url, Method.BODY_TEXT), 5
 			)
 
-		# Head description on the home or About page.
 		if is_home or is_about:
 			content, _name = _meta_with_method(soup, "og:description", "description")
 			if content:
@@ -553,7 +509,6 @@ def select_description(pages, soups_by_url, industry_rules=None, company_name=""
 				score = 2 if (is_home and _COMMERCE_RE.search(content)) else 4
 				consider(Field(content, page.url, Method.META_TAG), score)
 
-		# Home-page body paragraph -- last resort.
 		if is_home:
 			consider(
 				Field(first_paragraph(soup, industry_rules, company_name), page.url, Method.BODY_TEXT), 1
@@ -588,10 +543,9 @@ def extract_emails(pages):
 # TODO: Need to make this robust by adding proper mechanics or using a
 # thirdparty library like google/libphonenumbers
 def _valid_phone(raw):
-	# Require an explicit country-code prefix ("+..."). A number written without
-	# one is either a local/ambiguous format we can't verify, or noise (reference
-	# numbers, stats) that happens to fall in a phone-shaped digit range -- only
-	# accept numbers a page author clearly intended as international.
+	# Requires an explicit "+" country-code prefix: a bare digit string is either
+	# ambiguous local formatting or noise (stats, reference numbers) that happens
+	# to look phone-shaped -- precision over recall.
 	if not raw.strip().startswith("+"):
 		return False
 	digits = re.sub(r"\D", "", raw)
@@ -631,9 +585,9 @@ def extract_phones(pages):
 def extract_social_profiles(pages, soups_by_url, social_rules, extra_links=None):
 	"""Return dict network -> SocialProfile(value, source, method).
 
-	Each Social rule's ``target_value`` is the network name and its compiled
-	patterns are the host/path matchers. JSON-LD ``sameAs`` links (``extra_links``)
-	are considered first, then anchor hrefs discovered while crawling.
+	Each Social rule's ``target_value`` is the network name; its patterns match
+	host/path. JSON-LD ``sameAs`` links are considered before anchor hrefs found
+	while crawling.
 	"""
 	profiles = {rule.target_value: SocialProfile() for rule in social_rules}
 
@@ -666,15 +620,11 @@ def classify_industry(pages, company_info, industry_rules):
 	"""Rule-based industry from the homepage's (and, when crawled, the About page's)
 	headline corpus.
 
-	Builds a per-scope text map and runs ``apply_keyword_rules`` over Industry
-	rules. Industry rules are seeded with ``match_scope='Headline'`` so they match
-	the company name + description + homepage title/headings, never body/footer.
-	The homepage alone is frequently thin on plain descriptive language (stylized
-	brand copy, no meta description) -- when a genuine About page was crawled
-	(``_is_about_page``, already vetted for description selection), its title and
-	headings are folded in too, since that page far more often states what the
-	company actually does. Returns (industry, confidence 0-1), or ("", 0.0) when
-	the signal is too weak.
+	Runs ``apply_keyword_rules`` over Industry rules (seeded ``match_scope='Headline'``,
+	so they match company name/description/title/headings, never body/footer). The
+	homepage alone is often thin (stylized brand copy, no meta description), so a
+	crawled About page's title/headings are folded in too. Returns
+	(industry, confidence 0-1), or ("", 0.0) when the signal is too weak.
 	"""
 	if not industry_rules:
 		return "", 0.0
@@ -694,8 +644,8 @@ def classify_industry(pages, company_info, industry_rules):
 			headline_parts.append(" ".join(about.headings))
 	headline = " ".join(p for p in headline_parts if p).lower()
 
-	# Provide the same corpus under common scopes so admins can re-scope rules
-	# without code changes; default seed uses Headline.
+	# Same corpus under multiple scope keys so admins can re-scope rules without
+	# code changes; default seed uses Headline.
 	full_text = " ".join((p.text or "") for p in pages).lower()
 	text_by_scope = {
 		SCOPE_HEADLINE: headline,

--- a/crm/domain_enrichment/extractors.py
+++ b/crm/domain_enrichment/extractors.py
@@ -350,8 +350,10 @@ _ORG_TYPES = {
 	"softwareapplication",
 }
 
+# Full-segment match, not a prefix: "about-our-reporting" (an ESG page) must not
+# qualify just because it starts with "about-".
 _ABOUT_SEGMENT_RE = re.compile(
-	r"^(about|about-us|aboutus|company|who-we-are|our-story|overview|mission)([-_]|$)",
+	r"^(about|about-us|aboutus|company|who-we-are|our-story|overview|mission)$",
 	re.I,
 )
 _NON_ABOUT_WORDS = (
@@ -440,32 +442,57 @@ def extract_company_info(homepage, soup):
 # hunting for a body paragraph.
 _NON_CONTENT_PARENTS = {"nav", "header", "footer", "aside", "form"}
 _MIN_PARAGRAPH_LEN = 80
+# How many qualifying paragraphs to score before picking a winner -- bounded so a
+# very long page doesn't turn this into a full scan.
+_MAX_PARAGRAPHS_SCANNED = 6
 
 
-def first_paragraph(soup):
-	"""First substantial body paragraph on a page (mechanics).
+def first_paragraph(soup, industry_rules=None):
+	"""Best substantial body paragraph on a page (mechanics).
 
-	Returns the cleaned text of the first ``<p>`` that holds sentence-like copy and is
-	not inside nav/header/footer/aside/form chrome, or ``""`` if none qualifies. Used
-	as a description fallback when a site exposes no description metadata. Read-only --
-	does not mutate ``soup``.
+	Scans up to ``_MAX_PARAGRAPHS_SCANNED`` qualifying ``<p>`` tags (sentence-like
+	copy, not inside nav/header/footer/aside/form chrome) and picks the one with the
+	most Industry-rule keyword hits -- the same keyword corpus ``classify_industry``
+	uses. A paragraph naming actual business/product terms ("chemicals", "adhesives")
+	is far more likely to be a genuine description than generic marketing filler
+	("customer-centric... quality and innovation..."), which typically scores zero.
+	Falls back to the first qualifying paragraph when no candidate has any keyword
+	hit, or when ``industry_rules`` is empty -- strictly backward compatible with the
+	old "just take the first one" behavior. Used as a description fallback when a
+	site exposes no description metadata. Read-only -- does not mutate ``soup``.
 	"""
+	candidates = []
 	for p in soup.find_all("p"):
 		if any(parent.name in _NON_CONTENT_PARENTS for parent in p.parents):
 			continue
 		text = " ".join((p.get_text(" ") or "").split())
-		if len(text) >= _MIN_PARAGRAPH_LEN and " " in text:
-			return text
-	return ""
+		if len(text) < _MIN_PARAGRAPH_LEN or " " not in text:
+			continue
+		candidates.append(text)
+		if len(candidates) >= _MAX_PARAGRAPHS_SCANNED:
+			break
+
+	if not candidates:
+		return ""
+	if not industry_rules:
+		return candidates[0]
+
+	# max() returns the first-encountered element on ties, so a paragraph earlier
+	# in document order still wins when nothing scores higher -- including the
+	# "every candidate has zero keyword hits" case, which naturally falls back to
+	# candidates[0] without needing to special-case it.
+	return max(candidates, key=lambda text: sum(rule.matches(text) for rule in industry_rules))
 
 
-def select_description(pages, soups_by_url):
+def select_description(pages, soups_by_url, industry_rules=None):
 	"""Pick the best *company* description across crawled pages (mechanics).
 
 	Priority (highest first): JSON-LD ``Organization.description`` → About-page body
 	paragraph → head ``og:description``/``<meta description>`` → home-page body
 	paragraph (last resort). The body-paragraph fallbacks let descriptions be derived
-	even when a site exposes no description metadata at all.
+	even when a site exposes no description metadata at all. ``industry_rules``, when
+	given, steers the body-paragraph fallbacks toward the most keyword-dense candidate
+	(see ``first_paragraph``).
 	"""
 	home_url = pages[0].url if pages else ""
 	best_key = None
@@ -495,7 +522,7 @@ def select_description(pages, soups_by_url):
 
 		# About-page body paragraph outranks head meta.
 		if is_about:
-			consider(Field(first_paragraph(soup), page.url, Method.BODY_TEXT), 5)
+			consider(Field(first_paragraph(soup, industry_rules), page.url, Method.BODY_TEXT), 5)
 
 		# Head description on the home or About page.
 		if is_home or is_about:
@@ -507,7 +534,7 @@ def select_description(pages, soups_by_url):
 
 		# Home-page body paragraph -- last resort.
 		if is_home:
-			consider(Field(first_paragraph(soup), page.url, Method.BODY_TEXT), 1)
+			consider(Field(first_paragraph(soup, industry_rules), page.url, Method.BODY_TEXT), 1)
 
 	return best_field or Field()
 
@@ -535,7 +562,15 @@ def extract_emails(pages):
 	return list(found.values())
 
 
+# TODO: Need to make this robust by adding proper mechanics or using a
+# thirdparty library like google/libphonenumbers
 def _valid_phone(raw):
+	# Require an explicit country-code prefix ("+..."). A number written without
+	# one is either a local/ambiguous format we can't verify, or noise (reference
+	# numbers, stats) that happens to fall in a phone-shaped digit range -- only
+	# accept numbers a page author clearly intended as international.
+	if not raw.strip().startswith("+"):
+		return False
 	digits = re.sub(r"\D", "", raw)
 	return 7 <= len(digits) <= 15
 
@@ -605,12 +640,18 @@ def extract_social_profiles(pages, soups_by_url, social_rules, extra_links=None)
 # Industry classification (config-driven via Industry rules)
 # --------------------------------------------------------------------------- #
 def classify_industry(pages, company_info, industry_rules):
-	"""Rule-based industry from the homepage's headline corpus only.
+	"""Rule-based industry from the homepage's (and, when crawled, the About page's)
+	headline corpus.
 
 	Builds a per-scope text map and runs ``apply_keyword_rules`` over Industry
 	rules. Industry rules are seeded with ``match_scope='Headline'`` so they match
 	the company name + description + homepage title/headings, never body/footer.
-	Returns (industry, confidence 0-1), or ("", 0.0) when the signal is too weak.
+	The homepage alone is frequently thin on plain descriptive language (stylized
+	brand copy, no meta description) -- when a genuine About page was crawled
+	(``_is_about_page``, already vetted for description selection), its title and
+	headings are folded in too, since that page far more often states what the
+	company actually does. Returns (industry, confidence 0-1), or ("", 0.0) when
+	the signal is too weak.
 	"""
 	if not industry_rules:
 		return "", 0.0
@@ -624,6 +665,10 @@ def classify_industry(pages, company_info, industry_rules):
 		home = pages[0]
 		headline_parts.append(home.title or "")
 		headline_parts.append(" ".join(home.headings))
+		about = next((p for p in pages[1:] if _is_about_page(p.url)), None)
+		if about:
+			headline_parts.append(about.title or "")
+			headline_parts.append(" ".join(about.headings))
 	headline = " ".join(p for p in headline_parts if p).lower()
 
 	# Provide the same corpus under common scopes so admins can re-scope rules

--- a/crm/domain_enrichment/extractors.py
+++ b/crm/domain_enrichment/extractors.py
@@ -30,7 +30,6 @@ from .result import (
 # --------------------------------------------------------------------------- #
 EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
-# Loosely international phone numbers.
 PHONE_RE = re.compile(
 	r"""(?<!\w)
     (\+?\d{1,3}[\s.-]?)?      # optional country code
@@ -70,10 +69,8 @@ SCOPE_URL = "URL"
 
 
 def apply_keyword_rules(text_by_scope: dict, rules: list) -> dict:
-	"""Score keyword/regex rules against scoped text; each rule matches only its own
-	``match_scope``. Returns ``{label: weighted_score}`` -- ``label`` is the rule's
-	industry (Industry rules) or target_value (everything else), score is
-	``pattern_hits * weight`` summed per label."""
+	"""Returns ``{label: weighted_score}`` -- ``label`` is the rule's industry
+	(Industry rules) or target_value (everything else)."""
 	scores: dict = {}
 	for rule in rules:
 		text = text_by_scope.get(rule.match_scope, "")
@@ -87,7 +84,6 @@ def apply_keyword_rules(text_by_scope: dict, rules: list) -> dict:
 # JSON-LD (mechanics)
 # --------------------------------------------------------------------------- #
 def parse_json_ld(soup):
-	"""Return a flat list of JSON-LD dicts found on the page (handles @graph)."""
 	blocks = []
 	for tag in soup.find_all("script", attrs={"type": "application/ld+json"}):
 		raw = tag.string or tag.get_text() or ""
@@ -116,9 +112,6 @@ def _ld_type_matches(block, wanted):
 # --------------------------------------------------------------------------- #
 # Readability diagnosis (mechanics)
 # --------------------------------------------------------------------------- #
-# WAF/bot-protection markers. Strong markers alone mean "blocked". Weak markers
-# (also legitimate on content-rich pages, e.g. a reCAPTCHA contact form) only
-# count when the page is also nearly devoid of text.
 WAF_MARKERS_STRONG = (
 	"_incapsula_resource",
 	"incapsula",
@@ -175,7 +168,6 @@ def diagnose_readability(pages):
 # Company information (mechanics)
 # --------------------------------------------------------------------------- #
 def _meta_with_method(soup, *names):
-	"""Return (content, matched_name) for the first present meta tag."""
 	for name in names:
 		tag = soup.find("meta", attrs={"property": name}) or soup.find("meta", attrs={"name": name})
 		if tag and tag.get("content"):
@@ -254,7 +246,7 @@ def _safe_url(base_url, raw):
 
 def _best_icon(soup, base_url):
 	"""Best ``<link rel=icon>`` candidate: scalable SVG beats any raster, then
-	largest declared size wins. Returns ``""`` if no icon is declared."""
+	largest declared size wins."""
 	candidates = []
 	for tag in soup.find_all("link", href=True):
 		rel = tag.get("rel") or []
@@ -370,7 +362,6 @@ def _is_about_page(url):
 
 
 def extract_company_info(homepage, soup):
-	"""Extract company identity with full provenance (mechanics)."""
 	url = homepage.url
 	info = {
 		"company_name": Field(),
@@ -412,14 +403,12 @@ def extract_company_info(homepage, soup):
 	return info
 
 
-# Chrome tags skipped when hunting for a body paragraph.
 _NON_CONTENT_PARENTS = {"nav", "header", "footer", "aside", "form"}
 _MIN_PARAGRAPH_LEN = 80
-_MAX_PARAGRAPHS_SCANNED = 6  # bounded so a very long page isn't a full scan
+_MAX_PARAGRAPHS_SCANNED = 6
 
 
 def _company_name_hits(text, company_name):
-	"""Count case-insensitive, whole-word mentions of ``company_name`` in ``text``."""
 	name = (company_name or "").strip()
 	if not name:
 		return 0
@@ -427,13 +416,10 @@ def _company_name_hits(text, company_name):
 
 
 def first_paragraph(soup, industry_rules=None, company_name=""):
-	"""Best substantial body paragraph on a page (mechanics).
-
-	Scores up to ``_MAX_PARAGRAPHS_SCANNED`` qualifying ``<p>`` tags by Industry-rule
-	keyword hits (the same corpus ``classify_industry`` uses); ``company_name``
-	mentions only break ties, never outrank keyword signal. Falls back to the first
-	qualifying paragraph when nothing scores or ``industry_rules`` is empty.
-	Read-only -- does not mutate ``soup``.
+	"""Best substantial body paragraph on a page. Scores up to
+	``_MAX_PARAGRAPHS_SCANNED`` qualifying ``<p>`` tags by Industry-rule keyword hits
+	(the same corpus ``classify_industry`` uses); ``company_name`` mentions only
+	break ties, never outrank keyword signal. Read-only -- does not mutate ``soup``.
 	"""
 	candidates = []
 	for p in soup.find_all("p"):
@@ -465,7 +451,7 @@ def first_paragraph(soup, industry_rules=None, company_name=""):
 
 
 def select_description(pages, soups_by_url, industry_rules=None, company_name=""):
-	"""Pick the best *company* description across crawled pages (mechanics).
+	"""Pick the best *company* description across crawled pages.
 
 	Priority: JSON-LD ``Organization.description`` -> About-page body paragraph ->
 	head ``og:description``/``<meta description>`` -> home-page body paragraph
@@ -528,7 +514,6 @@ def _clean_email(email):
 
 
 def extract_emails(pages):
-	"""pages: list[CrawledPage] -> list[Email] (deduped, first source kept)."""
 	found = {}
 	for page in pages:
 		if not page.html:
@@ -553,7 +538,6 @@ def _valid_phone(raw):
 
 
 def extract_phones(pages):
-	"""Extract phone numbers, preferring tel: links, then visible text."""
 	found = {}
 	for page in pages:
 		if not page.html:
@@ -583,12 +567,8 @@ def extract_phones(pages):
 # Social profiles (config-driven via Social rules)
 # --------------------------------------------------------------------------- #
 def extract_social_profiles(pages, soups_by_url, social_rules, extra_links=None):
-	"""Return dict network -> SocialProfile(value, source, method).
-
-	Each Social rule's ``target_value`` is the network name; its patterns match
-	host/path. JSON-LD ``sameAs`` links are considered before anchor hrefs found
-	while crawling.
-	"""
+	"""Return dict network -> SocialProfile(value, source, method); each Social
+	rule's ``target_value`` is the network name."""
 	profiles = {rule.target_value: SocialProfile() for rule in social_rules}
 
 	home_url = pages[0].url if pages else ""
@@ -618,13 +598,11 @@ def extract_social_profiles(pages, soups_by_url, social_rules, extra_links=None)
 # --------------------------------------------------------------------------- #
 def classify_industry(pages, company_info, industry_rules):
 	"""Rule-based industry from the homepage's (and, when crawled, the About page's)
-	headline corpus.
-
-	Runs ``apply_keyword_rules`` over Industry rules (seeded ``match_scope='Headline'``,
-	so they match company name/description/title/headings, never body/footer). The
-	homepage alone is often thin (stylized brand copy, no meta description), so a
-	crawled About page's title/headings are folded in too. Returns
-	(industry, confidence 0-1), or ("", 0.0) when the signal is too weak.
+	headline corpus. Industry rules are typically seeded with ``match_scope='Headline'``
+	(company name/description/title/headings, never body/footer). The homepage alone
+	is often thin (stylized brand copy, no meta description), so a crawled About
+	page's title/headings are folded in too. Returns (industry, confidence 0-1), or
+	("", 0.0) when the signal is too weak.
 	"""
 	if not industry_rules:
 		return "", 0.0

--- a/crm/domain_enrichment/extractors.py
+++ b/crm/domain_enrichment/extractors.py
@@ -447,7 +447,15 @@ _MIN_PARAGRAPH_LEN = 80
 _MAX_PARAGRAPHS_SCANNED = 6
 
 
-def first_paragraph(soup, industry_rules=None):
+def _company_name_hits(text, company_name):
+	"""Count case-insensitive, whole-word mentions of ``company_name`` in ``text``."""
+	name = (company_name or "").strip()
+	if not name:
+		return 0
+	return len(re.findall(rf"\b{re.escape(name)}\b", text, re.IGNORECASE))
+
+
+def first_paragraph(soup, industry_rules=None, company_name=""):
 	"""Best substantial body paragraph on a page (mechanics).
 
 	Scans up to ``_MAX_PARAGRAPHS_SCANNED`` qualifying ``<p>`` tags (sentence-like
@@ -456,6 +464,9 @@ def first_paragraph(soup, industry_rules=None):
 	uses. A paragraph naming actual business/product terms ("chemicals", "adhesives")
 	is far more likely to be a genuine description than generic marketing filler
 	("customer-centric... quality and innovation..."), which typically scores zero.
+	Mentions of ``company_name`` only break ties between paragraphs already tied on
+	keyword hits -- narrows down options further without letting a paragraph that
+	just happens to repeat the company name outrank one with real industry signal.
 	Falls back to the first qualifying paragraph when no candidate has any keyword
 	hit, or when ``industry_rules`` is empty -- strictly backward compatible with the
 	old "just take the first one" behavior. Used as a description fallback when a
@@ -480,19 +491,27 @@ def first_paragraph(soup, industry_rules=None):
 	# max() returns the first-encountered element on ties, so a paragraph earlier
 	# in document order still wins when nothing scores higher -- including the
 	# "every candidate has zero keyword hits" case, which naturally falls back to
-	# candidates[0] without needing to special-case it.
-	return max(candidates, key=lambda text: sum(rule.matches(text) for rule in industry_rules))
+	# candidates[0] without needing to special-case it. Company-name hits are a
+	# second tuple element, not added into the same number, so they can only ever
+	# decide between paragraphs already tied on industry hits.
+	return max(
+		candidates,
+		key=lambda text: (
+			sum(rule.matches(text) for rule in industry_rules),
+			_company_name_hits(text, company_name),
+		),
+	)
 
 
-def select_description(pages, soups_by_url, industry_rules=None):
+def select_description(pages, soups_by_url, industry_rules=None, company_name=""):
 	"""Pick the best *company* description across crawled pages (mechanics).
 
 	Priority (highest first): JSON-LD ``Organization.description`` → About-page body
 	paragraph → head ``og:description``/``<meta description>`` → home-page body
 	paragraph (last resort). The body-paragraph fallbacks let descriptions be derived
-	even when a site exposes no description metadata at all. ``industry_rules``, when
-	given, steers the body-paragraph fallbacks toward the most keyword-dense candidate
-	(see ``first_paragraph``).
+	even when a site exposes no description metadata at all. ``industry_rules`` and
+	``company_name``, when given, steer the body-paragraph fallbacks toward the most
+	keyword-dense candidate (see ``first_paragraph``).
 	"""
 	home_url = pages[0].url if pages else ""
 	best_key = None
@@ -522,7 +541,9 @@ def select_description(pages, soups_by_url, industry_rules=None):
 
 		# About-page body paragraph outranks head meta.
 		if is_about:
-			consider(Field(first_paragraph(soup, industry_rules), page.url, Method.BODY_TEXT), 5)
+			consider(
+				Field(first_paragraph(soup, industry_rules, company_name), page.url, Method.BODY_TEXT), 5
+			)
 
 		# Head description on the home or About page.
 		if is_home or is_about:
@@ -534,7 +555,9 @@ def select_description(pages, soups_by_url, industry_rules=None):
 
 		# Home-page body paragraph -- last resort.
 		if is_home:
-			consider(Field(first_paragraph(soup, industry_rules), page.url, Method.BODY_TEXT), 1)
+			consider(
+				Field(first_paragraph(soup, industry_rules, company_name), page.url, Method.BODY_TEXT), 1
+			)
 
 	return best_field or Field()
 

--- a/crm/domain_enrichment/extractors.py
+++ b/crm/domain_enrichment/extractors.py
@@ -319,7 +319,7 @@ _ORG_TYPES = {
 # Full-segment match, not a prefix: "about-our-reporting" (an ESG page) must not
 # qualify just because it starts with "about-".
 _ABOUT_SEGMENT_RE = re.compile(
-	r"^(about|about-us|aboutus|company|who-we-are|our-story|overview|mission)$",
+	r"^(about|about-us|about_us|aboutus|company|who-we-are|our-story|overview|mission)$",
 	re.I,
 )
 _NON_ABOUT_WORDS = (

--- a/crm/domain_enrichment/pipeline.py
+++ b/crm/domain_enrichment/pipeline.py
@@ -164,7 +164,12 @@ def run(website: str, cfg: EnrichmentConfig = None, progress=None) -> Enrichment
 		result.logo = company.get("logo") or Field()
 		result.image = company.get("image") or Field()
 		result.description = (
-			extractors.select_description(pages, soups_by_url, industry_rules=cfg.rules("Industry"))
+			extractors.select_description(
+				pages,
+				soups_by_url,
+				industry_rules=cfg.rules("Industry"),
+				company_name=result.company_name.value,
+			)
 			or company.get("description")
 			or Field()
 		)

--- a/crm/domain_enrichment/pipeline.py
+++ b/crm/domain_enrichment/pipeline.py
@@ -164,7 +164,9 @@ def run(website: str, cfg: EnrichmentConfig = None, progress=None) -> Enrichment
 		result.logo = company.get("logo") or Field()
 		result.image = company.get("image") or Field()
 		result.description = (
-			extractors.select_description(pages, soups_by_url) or company.get("description") or Field()
+			extractors.select_description(pages, soups_by_url, industry_rules=cfg.rules("Industry"))
+			or company.get("description")
+			or Field()
 		)
 
 		# 4. Contacts: emails, phones, social.

--- a/crm/domain_enrichment/tests/fixtures.py
+++ b/crm/domain_enrichment/tests/fixtures.py
@@ -172,6 +172,20 @@ def fake_fetch(responses):
 	return fake
 
 
+def fake_fetch_with_redirects(responses, redirects):
+	"""Like ``fake_fetch``, but ``redirects`` maps a requested URL to the resolved
+	(post-redirect) URL returned as ``final_url`` -- simulates a 301/302 hop without
+	modeling the actual redirect chain, since callers only ever look at the result.
+	"""
+	base = fake_fetch(responses)
+
+	def fake(url, cfg, session=None, html_only=True):
+		status, body, error, final_url = base(url, cfg, session=session, html_only=html_only)
+		return status, body, error, redirects.get(url, final_url)
+
+	return fake
+
+
 # --------------------------------------------------------------------------- #
 # Page helper
 # --------------------------------------------------------------------------- #

--- a/crm/domain_enrichment/tests/fixtures.py
+++ b/crm/domain_enrichment/tests/fixtures.py
@@ -129,6 +129,48 @@ BROKEN_JSON_LD = """
 </head><body><h1>Broken</h1></body></html>
 """
 
+# --------------------------------------------------------------------------- #
+# Sitemap fixtures
+# --------------------------------------------------------------------------- #
+URLSET_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://acme.example/about</loc></url>
+  <url><loc>https://acme.example/contact</loc></url>
+  <url><loc>https://acme.example/blog/post-1</loc></url>
+</urlset>"""
+
+SITEMAP_INDEX_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://acme.example/sitemap-pages.xml</loc></sitemap>
+  <sitemap><loc>https://acme.example/sitemap-blog.xml</loc></sitemap>
+</sitemapindex>"""
+
+# A sitemap trying to smuggle a DTD entity-expansion payload -- must be rejected
+# outright by _parse_sitemap before ET.fromstring ever sees it.
+MALICIOUS_DOCTYPE_XML = """<?xml version="1.0"?>
+<!DOCTYPE foo [<!ENTITY xxe "boom">]>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://acme.example/&xxe;</loc></url>
+</urlset>"""
+
+
+def fake_fetch(responses):
+	"""Build a ``fetch(url, cfg, session=None, html_only=True)`` stub keyed by exact URL.
+
+	``responses`` maps url -> (status, body) for a 200-shaped response. A URL absent
+	from the map behaves like a 404 (mirrors a missing sitemap/robots.txt), so tests
+	only need to declare the endpoints they care about.
+	"""
+
+	def fake(url, cfg, session=None, html_only=True):
+		entry = responses.get(url)
+		if entry is None:
+			return 404, "", "not found", url
+		status, body = entry
+		return status, body, "", url
+
+	return fake
+
 
 # --------------------------------------------------------------------------- #
 # Page helper

--- a/crm/domain_enrichment/tests/test_config.py
+++ b/crm/domain_enrichment/tests/test_config.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+"""Pure unit tests for config-layer pattern compilation (``config._compile_pattern``).
+
+Fully offline: no DB, no network. Covers the word-boundary fix -- an un-anchored
+short substring keyword like "erp" or "api" previously matched inside unrelated
+words ("waterproofing", "capital"), causing false industry-classification hits.
+"""
+
+from __future__ import annotations
+
+from frappe.tests import UnitTestCase
+
+from crm.domain_enrichment.config import _compile_pattern
+
+
+class CompilePatternTest(UnitTestCase):
+	def test_substring_pattern_does_not_match_inside_unrelated_word(self):
+		erp_rx = _compile_pattern("erp", is_regex=0)
+		self.assertIsNone(erp_rx.search("Industrial Adhesives, Paints and Waterproofing Solutions"))
+		self.assertIsNone(erp_rx.search("enterprise value creation"))
+
+	def test_substring_pattern_still_matches_standalone_word(self):
+		erp_rx = _compile_pattern("erp", is_regex=0)
+		self.assertIsNotNone(erp_rx.search("Our ERP rollout finished on schedule"))
+
+	def test_api_pattern_does_not_match_inside_capital_or_rapid(self):
+		api_rx = _compile_pattern("api", is_regex=0)
+		self.assertIsNone(api_rx.search("venture capital and rapid growth"))
+		self.assertIsNotNone(api_rx.search("a public REST API for developers"))
+
+	def test_multi_word_phrase_pattern_still_matches(self):
+		rx = _compile_pattern("enterprise resource planning", is_regex=0)
+		self.assertIsNotNone(rx.search("our Enterprise Resource Planning suite"))
+
+	def test_is_regex_patterns_are_left_unanchored(self):
+		# An admin-authored regex (is_regex=1) is compiled as-is -- no word-boundary
+		# wrapping, so existing admin patterns (e.g. social-profile URL regexes) keep
+		# their exact intended behavior.
+		rx = _compile_pattern(r"linkedin\.com/(company|in|school)/", is_regex=1)
+		self.assertIsNotNone(rx.search("https://www.linkedin.com/company/acme"))

--- a/crm/domain_enrichment/tests/test_crawler.py
+++ b/crm/domain_enrichment/tests/test_crawler.py
@@ -10,8 +10,11 @@ rejection) and ``extract_content`` (title/headings/visible text).
 
 from __future__ import annotations
 
+from unittest import mock
+
 from frappe.tests import UnitTestCase
 
+from crm.domain_enrichment import crawler
 from crm.domain_enrichment.crawler import (
 	_is_crawlable,
 	_link_priority,
@@ -21,6 +24,7 @@ from crm.domain_enrichment.crawler import (
 	same_site,
 )
 from crm.domain_enrichment.tests import fixtures
+from crm.domain_enrichment.tests.fixtures import make_config
 
 # The default BFS priority keywords used by the engine when Settings has none.
 PRIORITY = [
@@ -144,3 +148,183 @@ class ExtractContentTest(UnitTestCase):
 		content = extract_content(soup)
 		self.assertIn("Visible", content["text"])
 		self.assertNotIn("var x", content["text"])
+
+
+class ParseSitemapTest(UnitTestCase):
+	def test_parses_urlset(self):
+		kind, locs = crawler._parse_sitemap(fixtures.URLSET_XML)
+		self.assertEqual(kind, "urlset")
+		self.assertIn("https://acme.example/about", locs)
+		self.assertIn("https://acme.example/contact", locs)
+		self.assertIn("https://acme.example/blog/post-1", locs)
+
+	def test_parses_sitemapindex(self):
+		kind, locs = crawler._parse_sitemap(fixtures.SITEMAP_INDEX_XML)
+		self.assertEqual(kind, "sitemapindex")
+		self.assertEqual(
+			locs,
+			["https://acme.example/sitemap-pages.xml", "https://acme.example/sitemap-blog.xml"],
+		)
+
+	def test_malformed_xml_returns_none_kind(self):
+		kind, locs = crawler._parse_sitemap("<urlset><url><loc>unclosed")
+		self.assertIsNone(kind)
+		self.assertEqual(locs, [])
+
+	def test_doctype_rejected_before_parsing(self):
+		# Must never reach ET.fromstring with a DTD payload.
+		kind, locs = crawler._parse_sitemap(fixtures.MALICIOUS_DOCTYPE_XML)
+		self.assertIsNone(kind)
+		self.assertEqual(locs, [])
+
+	def test_unrelated_root_element_ignored(self):
+		kind, locs = crawler._parse_sitemap("<rss><channel></channel></rss>")
+		self.assertIsNone(kind)
+		self.assertEqual(locs, [])
+
+
+class DiscoverSitemapUrlsTest(UnitTestCase):
+	def setUp(self):
+		self.cfg = make_config()
+
+	def test_uses_robots_declared_sitemap(self):
+		robots = mock.Mock()
+		robots.site_maps.return_value = ["https://acme.example/my-sitemap.xml"]
+		responses = {"https://acme.example/my-sitemap.xml": (200, fixtures.URLSET_XML)}
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(responses)):
+			urls = crawler.discover_sitemap_urls("https://acme.example", self.cfg, None, robots)
+		self.assertIn("https://acme.example/about", urls)
+		self.assertIn("https://acme.example/contact", urls)
+
+	def test_falls_back_to_conventional_path_when_robots_declares_none(self):
+		robots = mock.Mock()
+		robots.site_maps.return_value = None
+		responses = {"https://acme.example/sitemap.xml": (200, fixtures.URLSET_XML)}
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(responses)):
+			urls = crawler.discover_sitemap_urls("https://acme.example", self.cfg, None, robots)
+		self.assertIn("https://acme.example/about", urls)
+
+	def test_falls_back_when_robots_is_none(self):
+		responses = {"https://acme.example/sitemap.xml": (200, fixtures.URLSET_XML)}
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(responses)):
+			urls = crawler.discover_sitemap_urls("https://acme.example", self.cfg, None, None)
+		self.assertIn("https://acme.example/about", urls)
+
+	def test_missing_sitemap_returns_empty_without_raising(self):
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch({})):
+			urls = crawler.discover_sitemap_urls("https://acme.example", self.cfg, None, None)
+		self.assertEqual(urls, [])
+
+	def test_malformed_xml_returns_empty(self):
+		responses = {"https://acme.example/sitemap.xml": (200, "not xml at all")}
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(responses)):
+			urls = crawler.discover_sitemap_urls("https://acme.example", self.cfg, None, None)
+		self.assertEqual(urls, [])
+
+	def test_follows_one_level_of_sitemap_index(self):
+		responses = {
+			"https://acme.example/sitemap.xml": (200, fixtures.SITEMAP_INDEX_XML),
+			"https://acme.example/sitemap-pages.xml": (200, fixtures.URLSET_XML),
+			"https://acme.example/sitemap-blog.xml": (
+				200,
+				'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+				"<url><loc>https://acme.example/blog/hello</loc></url></urlset>",
+			),
+		}
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(responses)):
+			urls = crawler.discover_sitemap_urls("https://acme.example", self.cfg, None, None)
+		self.assertIn("https://acme.example/about", urls)
+		self.assertIn("https://acme.example/blog/hello", urls)
+
+	def test_rejects_cross_site_sitemap(self):
+		# The sitemap FILE lives on a different site than the one we're enriching --
+		# must never be fetched, regardless of what its <loc> entries claim. Uses
+		# real-style ".com" hosts (not "*.example") so registrable_domain() actually
+		# differentiates them -- ".example" isn't in the bundled Public Suffix List,
+		# so acme.example/evil.example would collapse to the same registrable domain.
+		robots = mock.Mock()
+		robots.site_maps.return_value = ["https://evil-corp.com/sitemap.xml"]
+		responses = {
+			"https://evil-corp.com/sitemap.xml": (
+				200,
+				'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+				"<url><loc>https://evil-corp.com/about</loc></url></urlset>",
+			)
+		}
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(responses)):
+			urls = crawler.discover_sitemap_urls("https://acme-corp.com", self.cfg, None, robots)
+		self.assertEqual(urls, [])
+
+
+class CrawlSitemapSeedingTest(UnitTestCase):
+	"""End-to-end: crawl() seeded from a robots.txt-declared sitemap.
+
+	Sitemap discovery must be a pure addition on top of the ordinary BFS: it should
+	surface a page that isn't linked from the homepage, without displacing the
+	homepage as the first crawled result, and it must disappear cleanly (no error)
+	when disabled or when the site has no sitemap at all.
+	"""
+
+	HOMEPAGE_HTML = '<html><head><title>Acme</title></head><body><a href="/contact">Contact</a></body></html>'
+	CONTACT_HTML = "<html><body>Contact us</body></html>"
+	HIDDEN_ABOUT_HTML = "<html><head><title>Hidden About</title></head><body><h1>About</h1></body></html>"
+	ROBOTS_TXT = "Sitemap: https://acme.example/sitemap.xml"
+	SITEMAP_XML = (
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+		"<url><loc>https://acme.example/hidden-about</loc></url></urlset>"
+	)
+
+	def _responses(self, **overrides):
+		base = {
+			"https://acme.example": (200, self.HOMEPAGE_HTML),
+			"https://acme.example/robots.txt": (200, self.ROBOTS_TXT),
+			"https://acme.example/sitemap.xml": (200, self.SITEMAP_XML),
+			"https://acme.example/contact": (200, self.CONTACT_HTML),
+			"https://acme.example/hidden-about": (200, self.HIDDEN_ABOUT_HTML),
+		}
+		base.update(overrides)
+		return base
+
+	def test_sitemap_only_page_is_crawled_homepage_stays_first(self):
+		cfg = make_config(
+			settings={"max_pages": 10, "max_depth": 1, "use_sitemap": 1},
+			link_priority=PRIORITY,
+			skip_patterns=[],
+		)
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(self._responses())):
+			results = crawler.crawl("https://acme.example", cfg)
+		urls = [page.url for page, _soup in results]
+		self.assertEqual(urls[0], "https://acme.example")
+		self.assertIn("https://acme.example/hidden-about", urls)
+		self.assertIn("https://acme.example/contact", urls)
+
+	def test_use_sitemap_disabled_never_fetches_sitemap(self):
+		cfg = make_config(
+			settings={"max_pages": 10, "max_depth": 1, "use_sitemap": 0},
+			link_priority=PRIORITY,
+			skip_patterns=[],
+		)
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(self._responses())):
+			results = crawler.crawl("https://acme.example", cfg)
+		urls = [page.url for page, _soup in results]
+		self.assertEqual(urls[0], "https://acme.example")
+		self.assertNotIn("https://acme.example/hidden-about", urls)
+		self.assertIn("https://acme.example/contact", urls)
+
+	def test_no_sitemap_falls_through_to_plain_link_following(self):
+		# robots.txt exists but declares no sitemap, and /sitemap.xml 404s -- the
+		# crawl must proceed exactly as ordinary link-following, no error surfaced.
+		responses = self._responses(**{"https://acme.example/robots.txt": (200, "User-agent: *")})
+		del responses["https://acme.example/sitemap.xml"]
+		cfg = make_config(
+			settings={"max_pages": 10, "max_depth": 1, "use_sitemap": 1},
+			link_priority=PRIORITY,
+			skip_patterns=[],
+		)
+		with mock.patch.object(crawler, "fetch", side_effect=fixtures.fake_fetch(responses)):
+			results = crawler.crawl("https://acme.example", cfg)
+		urls = [page.url for page, _soup in results]
+		self.assertEqual(urls[0], "https://acme.example")
+		self.assertIn("https://acme.example/contact", urls)
+		self.assertNotIn("https://acme.example/hidden-about", urls)
+		self.assertEqual(len(results), 2)  # homepage + contact only, no crash, no phantom pages

--- a/crm/domain_enrichment/tests/test_crawler.py
+++ b/crm/domain_enrichment/tests/test_crawler.py
@@ -48,6 +48,16 @@ class NormalizeUrlTest(UnitTestCase):
 		# A bare root "/" must not be stripped (path length 1).
 		self.assertEqual(normalize_url("https://x.com/"), "https://x.com/")
 
+	def test_strips_query_string(self):
+		# Query-string variants of the same page (tracking params, product-variant
+		# params) must collapse to one dedupe key -- otherwise the same page gets
+		# queued and fetched multiple times under different query strings.
+		self.assertEqual(normalize_url("https://x.com/w/book/1?ean=123"), "https://x.com/w/book/1")
+		self.assertEqual(
+			normalize_url("https://x.com/w/book/1?terms=free-shipping"), "https://x.com/w/book/1"
+		)
+		self.assertEqual(normalize_url("https://x.com/w/book/1"), "https://x.com/w/book/1")
+
 
 class RegistrableDomainTest(UnitTestCase):
 	def test_strips_www_and_port(self):
@@ -106,6 +116,15 @@ class LinkPriorityTest(UnitTestCase):
 	def test_non_priority_sorts_last(self):
 		generic = _link_priority("https://x.com/random", "", PRIORITY)
 		self.assertEqual(generic, len(PRIORITY) + 1)
+
+	def test_ancestor_segment_does_not_leak_priority_to_unrelated_leaf(self):
+		# A news article nested under "/about-us/..." must not inherit "about-us"'s
+		# priority from an ancestor path segment alone -- only the leaf segment counts.
+		news_article = _link_priority("https://x.com/about-us/corporate-news/2023/some-award", "", PRIORITY)
+		generic = _link_priority("https://x.com/blog/post", "", PRIORITY)
+		about_page = _link_priority("https://x.com/about-us", "", PRIORITY)
+		self.assertEqual(news_article, generic)
+		self.assertLess(about_page, news_article)
 
 
 class IsCrawlableTest(UnitTestCase):
@@ -328,3 +347,121 @@ class CrawlSitemapSeedingTest(UnitTestCase):
 		self.assertIn("https://acme.example/contact", urls)
 		self.assertNotIn("https://acme.example/hidden-about", urls)
 		self.assertEqual(len(results), 2)  # homepage + contact only, no crash, no phantom pages
+
+
+class RedirectDedupTest(UnitTestCase):
+	"""A redirect can land two different *requested* URLs on the same resolved page
+	(e.g. /contact.html -> /contact) -- the pre-fetch `visited` check can't catch
+	this since the requested URLs genuinely differ. crawl() must collapse the
+	duplicate after the fact and not let it consume a page-budget slot.
+	"""
+
+	def test_redirect_collapsed_duplicate_does_not_consume_budget(self):
+		homepage_html = (
+			'<html><body><a href="/contact">Contact</a>'
+			'<a href="/contact.html">Contact (alt)</a>'
+			'<a href="/team">Team</a></body></html>'
+		)
+		responses = {
+			"https://acme.example": (200, homepage_html),
+			"https://acme.example/contact": (200, "<html><body>Contact page</body></html>"),
+			"https://acme.example/contact.html": (200, "<html><body>Contact page</body></html>"),
+			"https://acme.example/team": (200, "<html><body>Team page</body></html>"),
+		}
+		# /contact.html resolves (redirects) to the same page as /contact.
+		redirects = {"https://acme.example/contact.html": "https://acme.example/contact"}
+		cfg = make_config(
+			settings={"max_pages": 10, "max_depth": 1, "use_sitemap": 0},
+			link_priority=PRIORITY,
+			skip_patterns=[],
+		)
+		with mock.patch.object(
+			crawler, "fetch", side_effect=fixtures.fake_fetch_with_redirects(responses, redirects)
+		):
+			results = crawler.crawl("https://acme.example", cfg)
+		urls = [page.url for page, _soup in results]
+		self.assertEqual(urls.count("https://acme.example/contact"), 1)
+		# The freed budget slot means /team -- otherwise starved by the wasted
+		# duplicate fetch -- still gets crawled.
+		self.assertIn("https://acme.example/team", urls)
+
+
+class OffSiteRedirectScopeTest(UnitTestCase):
+	"""A same-site link that redirects off-domain must not be treated as an
+	in-scope crawled page: fetch()'s redirect loop only re-validates SSRF safety
+	per hop, never registrable-domain scope.
+	"""
+
+	def test_offsite_redirect_marked_out_of_scope(self):
+		homepage_html = (
+			'<html><body><a href="/investor-relations">IR</a><a href="/team">Team</a></body></html>'
+		)
+		responses = {
+			"https://jpm-test.com": (200, homepage_html),
+			"https://jpm-test.com/investor-relations": (200, "<html><body>redirected content</body></html>"),
+			"https://jpm-test.com/team": (200, "<html><body>Team page</body></html>"),
+		}
+		redirects = {
+			"https://jpm-test.com/investor-relations": "https://reports.jpmchase-test.com/ir/2022.htm"
+		}
+		cfg = make_config(
+			settings={"max_pages": 10, "max_depth": 1, "use_sitemap": 0},
+			link_priority=PRIORITY,
+			skip_patterns=[],
+		)
+		with mock.patch.object(
+			crawler, "fetch", side_effect=fixtures.fake_fetch_with_redirects(responses, redirects)
+		):
+			results = crawler.crawl("https://jpm-test.com", cfg)
+		offsite = next(
+			page for page, _soup in results if page.url == "https://reports.jpmchase-test.com/ir/2022.htm"
+		)
+		self.assertTrue(offsite.error)
+		self.assertEqual(offsite.html, "")
+		self.assertEqual(offsite.text, "")
+
+	def test_offsite_redirect_clears_title_and_headings(self):
+		# title/headings are parsed by crawl_page() before the off-site check runs,
+		# so clearing html/text/soup alone isn't enough -- extractors that read
+		# title/headings straight off the CrawledPage (e.g. classify_industry's
+		# About-page lookup) would otherwise still see off-site content.
+		homepage_html = '<html><body><a href="/about">About</a></body></html>'
+		responses = {
+			"https://jpm-test.com": (200, homepage_html),
+			"https://jpm-test.com/about": (
+				200,
+				"<html><head><title>Global Widget Manufacturing Co</title></head>"
+				"<body><h1>Leading widget manufacturer since 1900</h1></body></html>",
+			),
+		}
+		redirects = {"https://jpm-test.com/about": "https://widgetco-test.com/about"}
+		cfg = make_config(
+			settings={"max_pages": 10, "max_depth": 1, "use_sitemap": 0},
+			link_priority=PRIORITY,
+			skip_patterns=[],
+		)
+		with mock.patch.object(
+			crawler, "fetch", side_effect=fixtures.fake_fetch_with_redirects(responses, redirects)
+		):
+			results = crawler.crawl("https://jpm-test.com", cfg)
+		offsite = next(page for page, _soup in results if page.url == "https://widgetco-test.com/about")
+		self.assertTrue(offsite.error)
+		self.assertEqual(offsite.title, "")
+		self.assertEqual(offsite.headings, [])
+
+	def test_homepage_redirect_is_still_adopted_not_flagged(self):
+		# The existing "homepage moved to a new host" behavior must be unaffected --
+		# only NON-homepage pages get the off-site-scope check.
+		responses = {"https://old-home-test.com": (200, "<html><body>hi</body></html>")}
+		redirects = {"https://old-home-test.com": "https://new-home-test.com"}
+		cfg = make_config(
+			settings={"max_pages": 1, "max_depth": 0, "use_sitemap": 0},
+			link_priority=PRIORITY,
+			skip_patterns=[],
+		)
+		with mock.patch.object(
+			crawler, "fetch", side_effect=fixtures.fake_fetch_with_redirects(responses, redirects)
+		):
+			results = crawler.crawl("https://old-home-test.com", cfg)
+		self.assertEqual(results[0][0].url, "https://new-home-test.com")
+		self.assertFalse(results[0][0].error)

--- a/crm/domain_enrichment/tests/test_extractors.py
+++ b/crm/domain_enrichment/tests/test_extractors.py
@@ -419,7 +419,15 @@ class FirstParagraphTest(UnitTestCase):
 
 class AboutPageDetectionTest(UnitTestCase):
 	def test_canonical_about_slugs_match(self):
-		for path in ("/about", "/about-us", "/aboutus", "/company", "/our-story", "/en/about-us"):
+		for path in (
+			"/about",
+			"/about-us",
+			"/about_us",
+			"/aboutus",
+			"/company",
+			"/our-story",
+			"/en/about-us",
+		):
 			self.assertTrue(extractors._is_about_page(f"https://x.example{path}"), path)
 
 	def test_prefix_match_no_longer_qualifies(self):

--- a/crm/domain_enrichment/tests/test_extractors.py
+++ b/crm/domain_enrichment/tests/test_extractors.py
@@ -381,6 +381,41 @@ class FirstParagraphTest(UnitTestCase):
 			extractors.first_paragraph(soup, industry_rules=None).startswith("Putting our long-tenured")
 		)
 
+	def test_company_name_breaks_tie_between_equal_keyword_hits(self):
+		# Both paragraphs mention "banking" exactly once (tied on industry hits) --
+		# only the one that also names the company should win.
+		finance_rules = [fixtures.keyword_rule("Industry", ["banking"], industry="Finance")]
+		html = (
+			"<html><body><main>"
+			"<p>Our roots trace back decades of steady growth in commercial banking "
+			"and long-term client relationships across every region we serve.</p>"
+			"<p>Acme Bank has led the market in retail banking with award-winning "
+			"service for individuals, families and small businesses nationwide.</p>"
+			"</main></body></html>"
+		)
+		_page, soup = fixtures.make_page("https://acmebank.example", html)
+		result = extractors.first_paragraph(soup, industry_rules=finance_rules, company_name="Acme Bank")
+		self.assertTrue(result.startswith("Acme Bank has led the market"))
+
+	def test_company_name_mentions_cannot_outrank_more_industry_hits(self):
+		# The first paragraph scores 2 industry hits and never names the company; the
+		# second scores only 1 industry hit despite repeating the company name three
+		# times. Industry hits must still decide -- company name is tiebreak-only.
+		finance_rules = [
+			fixtures.keyword_rule("Industry", ["financial institution", "banking"], industry="Finance")
+		]
+		html = (
+			"<html><body><main>"
+			"<p>A full-service financial institution built on decades of trusted "
+			"commercial and retail banking relationships across every market.</p>"
+			"<p>Acme Bank, Acme Bank, Acme Bank -- proud to serve local businesses "
+			"with award-winning retail banking and community-first values.</p>"
+			"</main></body></html>"
+		)
+		_page, soup = fixtures.make_page("https://acmebank.example", html)
+		result = extractors.first_paragraph(soup, industry_rules=finance_rules, company_name="Acme Bank")
+		self.assertTrue(result.startswith("A full-service financial institution"))
+
 
 class AboutPageDetectionTest(UnitTestCase):
 	def test_canonical_about_slugs_match(self):

--- a/crm/domain_enrichment/tests/test_extractors.py
+++ b/crm/domain_enrichment/tests/test_extractors.py
@@ -289,6 +289,28 @@ class DescriptionSelectionTest(UnitTestCase):
 		self.assertEqual(desc.value, "Acme makes developer tools.")
 		self.assertEqual(desc.method, Method.META_TAG)
 
+	def test_industry_keyword_density_steers_about_paragraph_choice(self):
+		finance_rules = [
+			fixtures.keyword_rule("Industry", ["financial institution", "banking"], industry="Finance")
+		]
+		pages, soups = _pages(
+			(
+				"https://acmebank.example",
+				"<html><head><title>Acme Bank</title></head><body></body></html>",
+			),
+			(
+				"https://acmebank.example/about",
+				"<html><body><main>"
+				"<p>Putting our long-tenured investment teams on the line to earn the "
+				"trust of institutional investors across every market we serve.</p>"
+				"<p>Acme Bank is a full-service financial institution serving corporations, "
+				"institutions and private clients across commercial and investment banking.</p>"
+				"</main></body></html>",
+			),
+		)
+		desc = extractors.select_description(pages, soups, industry_rules=finance_rules)
+		self.assertTrue(desc.value.startswith("Acme Bank is a full-service"))
+
 
 class FirstParagraphTest(UnitTestCase):
 	def test_skips_nav_and_returns_first_substantial_paragraph(self):
@@ -306,6 +328,74 @@ class FirstParagraphTest(UnitTestCase):
 	def test_returns_empty_when_no_substantial_paragraph(self):
 		_page, soup = fixtures.make_page("https://x.example", "<html><body><p>Hi.</p></body></html>")
 		self.assertEqual(extractors.first_paragraph(soup), "")
+
+	def test_prefers_paragraph_with_more_keyword_hits_over_first_qualifying_one(self):
+		# A narrow pull-quote with zero industry-keyword hits precedes a genuine
+		# descriptive paragraph -- the keyword-denser paragraph should win.
+		finance_rules = [
+			fixtures.keyword_rule("Industry", ["financial institution", "banking"], industry="Finance")
+		]
+		html = (
+			"<html><body><main>"
+			"<p>Putting our long-tenured investment teams on the line to earn the "
+			"trust of institutional investors across every market we serve.</p>"
+			"<p>Acme Bank is a full-service financial institution serving corporations, "
+			"institutions and private clients across commercial and investment banking.</p>"
+			"</main></body></html>"
+		)
+		_page, soup = fixtures.make_page("https://acmebank.example", html)
+		result = extractors.first_paragraph(soup, industry_rules=finance_rules)
+		self.assertTrue(result.startswith("Acme Bank is a full-service"))
+
+	def test_falls_back_to_first_paragraph_when_no_keyword_hits(self):
+		finance_rules = [
+			fixtures.keyword_rule("Industry", ["financial institution", "banking"], industry="Finance")
+		]
+		html = (
+			"<html><body><main>"
+			"<p>Putting our long-tenured investment teams on the line to earn the "
+			"trust of institutional investors across every market we serve.</p>"
+			"</main></body></html>"
+		)
+		_page, soup = fixtures.make_page("https://acmebank.example", html)
+		result = extractors.first_paragraph(soup, industry_rules=finance_rules)
+		self.assertTrue(result.startswith("Putting our long-tenured"))
+
+	def test_falls_back_to_first_paragraph_when_no_industry_rules_given(self):
+		# No rules configured at all (industry_rules=None or []) -- must behave
+		# exactly like the plain "take the first qualifying paragraph" default.
+		html = (
+			"<html><body><main>"
+			"<p>Putting our long-tenured investment teams on the line to earn the "
+			"trust of institutional investors across every market we serve.</p>"
+			"<p>Acme Bank is a full-service financial institution serving corporations, "
+			"institutions and private clients across commercial and investment banking.</p>"
+			"</main></body></html>"
+		)
+		_page, soup = fixtures.make_page("https://acmebank.example", html)
+		self.assertTrue(extractors.first_paragraph(soup).startswith("Putting our long-tenured"))
+		self.assertTrue(
+			extractors.first_paragraph(soup, industry_rules=[]).startswith("Putting our long-tenured")
+		)
+		self.assertTrue(
+			extractors.first_paragraph(soup, industry_rules=None).startswith("Putting our long-tenured")
+		)
+
+
+class AboutPageDetectionTest(UnitTestCase):
+	def test_canonical_about_slugs_match(self):
+		for path in ("/about", "/about-us", "/aboutus", "/company", "/our-story", "/en/about-us"):
+			self.assertTrue(extractors._is_about_page(f"https://x.example{path}"), path)
+
+	def test_prefix_match_no_longer_qualifies(self):
+		# Regression guard: "about-our-reporting" (an ESG page) starts with "about-"
+		# but is not itself a canonical About-page slug.
+		self.assertFalse(extractors._is_about_page("https://x.example/esg-topics/about-our-reporting"))
+		self.assertFalse(extractors._is_about_page("https://x.example/about-cookies"))
+
+	def test_non_about_words_still_rejected(self):
+		self.assertFalse(extractors._is_about_page("https://x.example/about/careers"))
+		self.assertFalse(extractors._is_about_page("https://x.example/about-us/contact"))
 
 
 # --------------------------------------------------------------------------- #
@@ -346,6 +436,28 @@ class PhoneExtractionTest(UnitTestCase):
 		phones = extractors.extract_phones(self.pages)
 		self.assertIn(Method.TEL_LINK, {p.method for p in phones})
 		self.assertTrue(any("4155550142" in p.value.replace("+", "") for p in phones))
+
+	def test_international_number_captured(self):
+		pages, _ = _pages(
+			("https://x.example/contact", "<html><body><p>Call us: +612 9003 8888</p></body></html>")
+		)
+		phones = extractors.extract_phones(pages)
+		self.assertTrue(any("61290038888" in p.value.replace("+", "") for p in phones))
+
+	def test_number_without_country_code_rejected(self):
+		# Deliberate precision-over-recall call: a number with no "+" is either a
+		# local/ambiguous format or noise (reference numbers, stats) that happens to
+		# fall in a phone-shaped digit range -- only accept explicit international
+		# numbers, even though this means dropping some real local-format numbers.
+		pages, _ = _pages(
+			(
+				"https://x.example/contact",
+				"<html><body><p>Local line: 2165703. Toll-free: 1800-266-6066.</p>"
+				'<a href="tel:18002666066">Call</a></body></html>',
+			)
+		)
+		phones = extractors.extract_phones(pages)
+		self.assertEqual(phones, [])
 
 
 # --------------------------------------------------------------------------- #
@@ -434,6 +546,52 @@ class IndustryTest(UnitTestCase):
 			)[0],
 			"Manufacturing",
 		)
+
+	def test_about_page_headline_supplements_thin_homepage(self):
+		# A homepage with no meta description and abstract brand-voice headings
+		# carries no classification signal on its own -- a crawled About page's
+		# title/headings should still let the classifier find a match.
+		finance_rules = [
+			fixtures.keyword_rule(
+				"Industry",
+				["banking", "financial services"],
+				industry="Finance",
+				match_scope="Headline",
+			)
+		]
+		home, _ = fixtures.make_page(
+			"https://acmebank.example",
+			"<html><head><title>Acme | Official Website</title></head>"
+			"<body><h1>Acme home</h1><h2>What problem can we solve together?</h2></body></html>",
+		)
+		about, _ = fixtures.make_page(
+			"https://acmebank.example/about",
+			"<html><head><title>About Acme</title></head>"
+			"<body><h2>A leader in financial services and banking</h2></body></html>",
+		)
+		company = {"company_name": "Acme", "description": ""}
+		industry, conf = extractors.classify_industry([home, about], company, finance_rules)
+		self.assertEqual(industry, "Finance")
+		self.assertGreater(conf, 0.0)
+
+	def test_homepage_only_still_returns_nothing_when_thin(self):
+		finance_rules = [
+			fixtures.keyword_rule(
+				"Industry",
+				["banking", "financial services"],
+				industry="Finance",
+				match_scope="Headline",
+			)
+		]
+		home, _ = fixtures.make_page(
+			"https://acmebank.example",
+			"<html><head><title>Acme | Official Website</title></head>"
+			"<body><h1>Acme home</h1><h2>What problem can we solve together?</h2></body></html>",
+		)
+		company = {"company_name": "Acme", "description": ""}
+		industry, conf = extractors.classify_industry([home], company, finance_rules)
+		self.assertEqual(industry, "")
+		self.assertEqual(conf, 0.0)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- **Sitemap-based page discovery**: seeds the crawl queue from the site's sitemap(s) -- robots.txt-declared `Sitemap:` first, else the conventional `/sitemap.xml`, following nested `<sitemapindex>` files up to a fetch budget (`SITEMAP_MAX_SITEMAPS`/`SITEMAP_MAX_URLS`). Sitemap-derived URLs are seeded at depth 1 (never depth 0), so the homepage always still wins the first pop. A missing, unreadable, or malformed sitemap falls straight through to plain link-following with no error. A `<!DOCTYPE` in the sitemap body is rejected before parsing, as a guard against XML entity-expansion abuse. New "Use Sitemap" checkbox on CRM Enrichment Settings (Crawl tab), on by default.
- **Rule pattern matching**: substring keyword rules (Industry/Social) are now word-boundary anchored, fixing false positives like `"api"` matching inside `"rapid"` or `"erp"` inside `"waterproofing"`.
- **Crawler correctness**:
  - `normalize_url` now also strips query strings (tracking params), preventing the same page from being queued and fetched multiple times under different `?utm_*`-style variants.
  - Link-priority scoring now matches only the leaf path segment, not the whole path, so an unrelated page nested under e.g. `/about-us/corporate-news/...` no longer inherits `about-us`'s priority.
  - Redirect handling reworked: a redirect landing on an already-crawled page (e.g. `/contact.html` -> `/contact`) is deduped without spending a page-budget slot. A same-site link that redirects off-domain mid-crawl is now treated as out of scope -- visible as an error, but with every parsed field (including title/headings) cleared so its content can't leak into extraction.
- **Extraction accuracy**:
  - About-page detection now requires a full path-segment match instead of a prefix match, so pages like `/about-our-reporting` (an ESG page) no longer false-positive as an About page.
  - `classify_industry` now also considers a crawled About page's title/headings, not just the homepage's, since the homepage alone is frequently too thin (stylized brand copy, no meta description) to classify from.
  - Description-paragraph selection now scores candidate paragraphs by Industry-rule keyword density instead of blindly taking the first substantial `<p>`, with company-name mentions used only as a tie-breaker -- never enough on their own to outrank real keyword signal.
  - Phone extraction now requires an explicit `+` country-code prefix, rejecting local/ambiguous numbers and digit-shaped noise (precision over recall). A `TODO` flags proper validation via a library like `phonenumbers` as follow-up work.

## Test plan
- [x] Extensive offline unit test coverage added across all of the above (`tests/test_crawler.py`, `tests/test_extractors.py`, new `tests/test_config.py`): sitemap parsing/discovery/seeding, redirect dedup and off-site scoping, link-priority leaf matching, About-page detection, description keyword-density scoring, phone validation, rule pattern anchoring.
- [x] Verified offline directly against the module code (no network, no DB) for fast iteration.
- [x] `bench run-tests` on a live site (not run by me in this environment -- flagging for reviewer/CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
