### PR TITLE
feat: refactor ERPNext product sync settings

### DIFF
--- a/crm/fcrm/doctype/crm_product/crm_product.py
+++ b/crm/fcrm/doctype/crm_product/crm_product.py
@@ -9,7 +9,7 @@ from crm.fcrm.doctype.crm_product.sync_utils import payload_differs
 from crm.integrations.erpnext.utils import (
 	cascade_rename,
 	in_cascade,
-	should_sync,
+	should_push_to_erpnext,
 	validate_rename_conflict,
 )
 
@@ -37,7 +37,7 @@ class CRMProduct(Document):
 	def before_insert(self):
 		if self.flags.get("ignore_erpnext_sync"):
 			return
-		if should_sync():
+		if should_push_to_erpnext():
 			frappe.throw(
 				_(
 					"ERPNext integration is active. Create an Item in ERPNext and it will appear in CRM Product automatically."
@@ -56,7 +56,7 @@ class CRMProduct(Document):
 			return
 		if not self.get("erpnext_item_code"):
 			return
-		if not should_sync():
+		if not should_push_to_erpnext():
 			return
 		_push_to_item(self)
 
@@ -71,7 +71,7 @@ class CRMProduct(Document):
 			return
 		if not self.get("erpnext_item_code"):
 			return
-		if not should_sync():
+		if not should_push_to_erpnext():
 			return
 		if frappe.db.sql(
 			"SELECT 1 FROM `tabQuotation Item` WHERE item_code=%s LIMIT 1",

--- a/crm/fcrm/doctype/crm_product/reconcile_job.py
+++ b/crm/fcrm/doctype/crm_product/reconcile_job.py
@@ -19,7 +19,8 @@ def enqueue_reconciliation():
 
 
 def run_reconciliation() -> dict:
-	skip_reason = _get_skip_reason()
+	settings = frappe.get_single("ERPNext CRM Settings")
+	skip_reason = _get_skip_reason(settings)
 	if skip_reason:
 		return {"skipped": skip_reason}
 
@@ -28,7 +29,6 @@ def run_reconciliation() -> dict:
 	products = _get_products_by_code()
 	_sync_items_to_products(items, products, summary)
 
-	settings = frappe.get_single("ERPNext CRM Settings")
 	issues = _sync_products_to_items(products, set(items.keys()), summary, settings)
 	_record_issues(settings, issues)
 	_sync_framework_mirrors()
@@ -82,11 +82,9 @@ def _unlink_orphan(product, existing_item_codes, issues):
 	return True
 
 
-def _get_skip_reason():
+def _get_skip_reason(settings):
 	if not frappe.db.exists("DocType", "Item"):
 		return "erpnext_not_installed"
-
-	settings = frappe.get_single("ERPNext CRM Settings")
 	if not settings.enabled:
 		return "integration_disabled"
 	if settings.is_erpnext_in_different_site:

--- a/crm/fcrm/doctype/crm_product/reconcile_job.py
+++ b/crm/fcrm/doctype/crm_product/reconcile_job.py
@@ -19,18 +19,26 @@ def enqueue_reconciliation():
 
 
 def run_reconciliation() -> dict:
-	if not frappe.db.exists("DocType", "Item"):
-		return {"skipped": "erpnext_not_installed"}
+	skip_reason = _get_skip_reason()
+	if skip_reason:
+		return {"skipped": skip_reason}
+
+	summary = _initial_summary()
+	items = _get_items_by_code()
+	products = _get_products_by_code()
+	_sync_items_to_products(items, products, summary)
 
 	settings = frappe.get_single("ERPNext CRM Settings")
-	if not settings.enabled:
-		return {"skipped": "integration_disabled"}
-	if settings.is_erpnext_in_different_site:
-		return {"skipped": "cross_site_not_supported"}
-	if not settings.sync_products:
-		return {"skipped": "product_sync_disabled"}
+	issues = _sync_products_to_items(products, set(items.keys()), summary, settings)
+	_record_issues(settings, issues)
+	_sync_framework_mirrors()
+	frappe.publish_realtime("crm_product_sync_complete", user=frappe.session.user)
+	frappe.log_error(message=frappe.as_json(summary), title="CRM Product Reconciliation")
+	return summary
 
-	summary = {
+
+def _initial_summary():
+	return {
 		"already_linked": 0,
 		"linked_by_exact_code": 0,
 		"created_in_crm": 0,
@@ -38,7 +46,55 @@ def run_reconciliation() -> dict:
 		"unlinked_orphans": 0,
 	}
 
-	items = {
+
+def _sync_items_to_products(items, products, summary):
+	for code, item in items.items():
+		_sync_item_to_product(item, products.get(code), summary)
+
+
+def _sync_products_to_items(products, existing_item_codes, summary, settings):
+	issues = []
+	for code, product in products.items():
+		if code in existing_item_codes:
+			continue
+		if _unlink_orphan(product, existing_item_codes, issues):
+			summary["unlinked_orphans"] += 1
+			continue
+		if product.get("erpnext_item_code") or not settings.sync_products:
+			continue
+		doc = frappe.get_doc("CRM Product", product["name"])
+		_create_item_from_product(doc)
+		summary["created_in_erpnext"] += 1
+	return issues
+
+
+def _unlink_orphan(product, existing_item_codes, issues):
+	if not detect_orphan(product, existing_item_codes):
+		return False
+	frappe.db.set_value("CRM Product", product["name"], "erpnext_item_code", None)
+	issues.append(
+		{
+			"product": product["name"],
+			"kind": "unlinked_orphan",
+			"detail": _("Linked Item {0} no longer exists").format(product["erpnext_item_code"]),
+		}
+	)
+	return True
+
+
+def _get_skip_reason():
+	if not frappe.db.exists("DocType", "Item"):
+		return "erpnext_not_installed"
+
+	settings = frappe.get_single("ERPNext CRM Settings")
+	if not settings.enabled:
+		return "integration_disabled"
+	if settings.is_erpnext_in_different_site:
+		return "cross_site_not_supported"
+
+
+def _get_items_by_code():
+	return {
 		i["item_code"]: i
 		for i in frappe.db.get_all(
 			"Item",
@@ -53,7 +109,10 @@ def run_reconciliation() -> dict:
 			],
 		)
 	}
-	products = {
+
+
+def _get_products_by_code():
+	return {
 		p["product_code"]: p
 		for p in frappe.db.get_all(
 			"CRM Product",
@@ -70,51 +129,22 @@ def run_reconciliation() -> dict:
 		)
 	}
 
-	issues = []
 
-	for code, item in items.items():
-		product = products.get(code)
-		if not product:
-			_create_crm_product_from_item(item)
-			summary["created_in_crm"] += 1
-			continue
-		action = classify_pair(item, product)
-		if action.rule == "already_linked":
-			summary["already_linked"] += 1
-		else:
-			summary["linked_by_exact_code"] += 1
-		if action.crm_updates:
-			frappe.db.set_value("CRM Product", product["name"], action.crm_updates)
-		if action.item_updates:
-			frappe.db.set_value("Item", item["item_code"], action.item_updates)
+def _sync_item_to_product(item, product, summary):
+	if not product:
+		_create_crm_product_from_item(item)
+		summary["created_in_crm"] += 1
+		return
 
-	existing_item_codes = set(items.keys())
-
-	for code, product in products.items():
-		if code in existing_item_codes:
-			continue
-		if detect_orphan(product, existing_item_codes):
-			frappe.db.set_value("CRM Product", product["name"], "erpnext_item_code", None)
-			issues.append(
-				{
-					"product": product["name"],
-					"kind": "unlinked_orphan",
-					"detail": _("Linked Item {0} no longer exists").format(product["erpnext_item_code"]),
-				}
-			)
-			summary["unlinked_orphans"] += 1
-			continue
-		if product.get("erpnext_item_code"):
-			continue
-		doc = frappe.get_doc("CRM Product", product["name"])
-		_create_item_from_product(doc)
-		summary["created_in_erpnext"] += 1
-
-	_record_issues(settings, issues)
-	_sync_framework_mirrors()
-	frappe.publish_realtime("crm_product_sync_complete", user=frappe.session.user)
-	frappe.log_error(message=frappe.as_json(summary), title="CRM Product Reconciliation")
-	return summary
+	action = classify_pair(item, product)
+	if action.rule == "already_linked":
+		summary["already_linked"] += 1
+	else:
+		summary["linked_by_exact_code"] += 1
+	if action.crm_updates:
+		frappe.db.set_value("CRM Product", product["name"], action.crm_updates)
+	if action.item_updates:
+		frappe.db.set_value("Item", item["item_code"], action.item_updates)
 
 
 def _sync_framework_mirrors():

--- a/crm/fcrm/doctype/crm_product/test_product_item_sync.py
+++ b/crm/fcrm/doctype/crm_product/test_product_item_sync.py
@@ -21,6 +21,11 @@ def enable_product_sync():
 	execute()
 
 
+def set_bidirectional_product_sync(value):
+	frappe.db.set_single_value("ERPNext CRM Settings", "sync_products", value)
+	frappe.clear_document_cache("ERPNext CRM Settings", "ERPNext CRM Settings")
+
+
 class TestReverseLinkField(FrappeTestCase):
 	def test_item_has_crm_product_code_field(self):
 		if not frappe.db.exists("DocType", "Item"):
@@ -115,6 +120,13 @@ class TestItemHooks(FrappeTestCase):
 		).insert()
 		self.assertTrue(frappe.db.exists("CRM Product", {"erpnext_item_code": "HOOK-1"}))
 		self.assertEqual(frappe.db.get_value("Item", "HOOK-1", "crm_product_code"), "HOOK-1")
+
+	def test_item_insert_syncs_to_crm_when_bidirectional_sync_is_off(self):
+		set_bidirectional_product_sync(0)
+		frappe.get_doc(
+			{"doctype": "Item", "item_code": "HOOK-PULL", "item_name": "Pull", "item_group": ITEM_GROUP}
+		).insert()
+		self.assertTrue(frappe.db.exists("CRM Product", {"erpnext_item_code": "HOOK-PULL"}))
 
 	def test_item_rename_updates_crm_product_link(self):
 		frappe.get_doc(
@@ -244,6 +256,15 @@ class TestCRMToERPNextCreate(FrappeTestCase):
 		self.assertEqual(frappe.db.get_value("Item", "PUSH-2", "standard_rate"), 25)
 		self.assertEqual(frappe.db.get_value("Item", "PUSH-2", "crm_product_code"), "PUSH-2")
 		self.assertEqual(frappe.db.get_value("CRM Product", "PUSH-2", "erpnext_item_code"), "PUSH-2")
+
+	def test_reconciliation_does_not_create_item_when_bidirectional_sync_is_off(self):
+		from crm.fcrm.doctype.crm_product.reconcile_job import run_reconciliation
+
+		set_bidirectional_product_sync(0)
+		frappe.get_doc({"doctype": "CRM Product", "product_code": "PUSH-OFF", "product_name": "Off"}).insert()
+
+		run_reconciliation()
+		self.assertFalse(frappe.db.exists("Item", "PUSH-OFF"))
 
 	def test_update_to_linked_product_pushes_to_item(self):
 		from crm.fcrm.doctype.crm_product.reconcile_job import run_reconciliation

--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.json
@@ -89,7 +89,7 @@
    "depends_on": "eval:doc.enabled && !doc.is_erpnext_in_different_site",
    "fieldname": "sync_products",
    "fieldtype": "Check",
-   "label": "Sync Products with ERPNext"
+   "label": "Bidirectional Product Sync"
   },
   {
    "fieldname": "section_break_jnbn",

--- a/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
+++ b/crm/fcrm/doctype/erpnext_crm_settings/erpnext_crm_settings.py
@@ -60,7 +60,7 @@ class ERPNextCRMSettings(Document):
 			self.create_custom_fields()
 			self.create_crm_form_script()
 			self.grant_item_access_to_sales_roles()
-			if not was_active and not self.is_erpnext_in_different_site and self.sync_products:
+			if not was_active and not self.is_erpnext_in_different_site:
 				from crm.fcrm.doctype.crm_product.reconcile_job import enqueue_reconciliation
 
 				enqueue_reconciliation()
@@ -219,8 +219,6 @@ class ERPNextCRMSettings(Document):
 	def run_product_sync(self):
 		if not self.enabled or self.is_erpnext_in_different_site:
 			frappe.throw(_("ERPNext integration must be enabled on the same site"))
-		if not self.sync_products:
-			frappe.throw(_("Product synchronization is turned off"))
 		from crm.fcrm.doctype.crm_product.reconcile_job import enqueue_reconciliation
 
 		enqueue_reconciliation()
@@ -254,6 +252,82 @@ def dismiss_sync_issue(issue_name: str):
 			settings.save()
 			return True
 	return False
+
+
+@frappe.whitelist()
+def get_product_sync_status():
+	if not frappe.has_permission("CRM Product", "read"):
+		return {}
+	return {
+		"products": _get_products(),
+		"items": _get_synced_items(),
+		"failed": get_open_sync_issues(),
+		"unsynced": _get_unsynced_counts(),
+	}
+
+
+def _get_unsynced_counts():
+	settings = frappe.get_single("ERPNext CRM Settings")
+	items = _count_linked("Item", "crm_product_code", is_set=False) if _can_read_items() else 0
+	return {
+		"items": items,
+		"products": frappe.db.count("CRM Product", filters={"erpnext_item_code": ["is", "not set"]}),
+		"sync_products": bool(settings.sync_products),
+	}
+
+
+def _get_products():
+	rows = frappe.get_all(
+		"CRM Product",
+		fields=["name", "product_code", "product_name", "erpnext_item_code"],
+		limit=20,
+		order_by="modified desc",
+	)
+	_set_product_item_groups(rows)
+	return {
+		"count": frappe.db.count("CRM Product"),
+		"rows": rows,
+	}
+
+
+def _get_synced_items():
+	if not _can_read_items():
+		return {"count": 0, "rows": []}
+	return {
+		"count": _count_linked("Item", "crm_product_code"),
+		"rows": frappe.get_all(
+			"Item",
+			fields=["name", "item_code", "item_name", "item_group", "crm_product_code"],
+			filters={"crm_product_code": ["is", "set"]},
+			limit=20,
+			order_by="modified desc",
+		),
+	}
+
+
+def _set_product_item_groups(rows):
+	item_codes = [row.erpnext_item_code for row in rows if row.erpnext_item_code]
+	if not item_codes or not _can_read_items():
+		return
+	item_groups = frappe.get_all(
+		"Item",
+		fields=["name", "item_group"],
+		filters={"name": ["in", item_codes]},
+	)
+	item_groups = {row.name: row.item_group for row in item_groups}
+	for row in rows:
+		row["item_group"] = item_groups.get(row.erpnext_item_code)
+
+
+def _count_linked(doctype: str, fieldname: str, is_set: bool = True):
+	if not frappe.db.has_column(doctype, fieldname):
+		return 0
+	operator = "set" if is_set else "not set"
+	return frappe.db.count(doctype, filters={fieldname: ["is", operator]})
+
+
+def _can_read_items():
+	return frappe.db.exists("DocType", "Item") and frappe.has_permission("Item", "read")
 
 
 def get_erpnext_site_client(erpnext_crm_settings):

--- a/crm/integrations/erpnext/utils.py
+++ b/crm/integrations/erpnext/utils.py
@@ -7,13 +7,19 @@ ALLOWED_DOCTYPES = ("CRM Product", "Item")
 
 
 def should_sync() -> bool:
-	"""Product sync runs only when integration is enabled, same-site AND product sync is on."""
+	"""ERPNext Item to CRM Product sync runs when same-site integration is enabled."""
 	if "erpnext" not in frappe.get_installed_apps():
 		return False
 	settings = frappe.get_cached_doc("ERPNext CRM Settings")
-	return (
-		bool(settings.enabled) and not settings.is_erpnext_in_different_site and bool(settings.sync_products)
-	)
+	return bool(settings.enabled) and not settings.is_erpnext_in_different_site
+
+
+def should_push_to_erpnext() -> bool:
+	"""CRM Product to ERPNext Item sync is optional until CRM supports ERPNext tax details."""
+	if not should_sync():
+		return False
+	settings = frappe.get_cached_doc("ERPNext CRM Settings")
+	return bool(settings.sync_products)
 
 
 def in_cascade() -> bool:
@@ -47,7 +53,7 @@ def find_target_for(doctype: str | None, value: str | None) -> tuple[str, str] |
 
 
 def validate_rename_conflict(self_doctype, olddn, newdn, merge):
-	if in_cascade() or not should_sync():
+	if in_cascade() or not _should_sync_direction(self_doctype):
 		return
 	other_doctype, other_link_field = _other_side(self_doctype)
 	linked = frappe.db.get_value(other_doctype, {other_link_field: olddn}, "name")
@@ -71,7 +77,7 @@ def validate_rename_conflict(self_doctype, olddn, newdn, merge):
 
 
 def cascade_rename(self_doctype, olddn, newdn, merge):
-	if in_cascade() or not should_sync():
+	if in_cascade() or not _should_sync_direction(self_doctype):
 		return
 	other_doctype, other_link_field = _other_side(self_doctype)
 	linked = frappe.db.get_value(other_doctype, {other_link_field: olddn}, "name")
@@ -106,3 +112,9 @@ def _resync_links(self_doctype, self_name, other_name):
 		frappe.db.set_value("CRM Product", prod, "erpnext_item_code", item, update_modified=False)
 	if frappe.db.exists("Item", item):
 		frappe.db.set_value("Item", item, "crm_product_code", prod, update_modified=False)
+
+
+def _should_sync_direction(self_doctype):
+	if self_doctype == "CRM Product":
+		return should_push_to_erpnext()
+	return should_sync()

--- a/frontend/src/components/Settings/ERPNextSettings.vue
+++ b/frontend/src/components/Settings/ERPNextSettings.vue
@@ -124,147 +124,302 @@
             "
             class="-mx-2"
           >
-            <div class="flex items-center justify-between pb-3 px-2">
-              <div class="flex flex-col">
-                <div class="text-p-base-medium text-ink-gray-7 truncate">
-                  {{ __('Company Name') }}
-                </div>
-                <div class="text-p-sm text-ink-gray-5 truncate">
-                  {{ __('Select your ERPNext company to connect with') }}
-                </div>
-              </div>
-              <div class="w-48">
-                <Autocomplete
-                  v-if="!erpnextCRMSettingsResource.isERPNextInstalled.data"
-                  :model-value="erpnextCRMSettingsResource.doc.erpnext_company"
-                  :options="
-                    erpnextCRMSettingsResource.getExternalCompanies.data?.map(
-                      (company) => ({
-                        label: company.company_name,
-                        value: company.company_name,
-                      }),
-                    ) || []
-                  "
-                  required
-                  class="pb-0.5"
-                  @update:modelValue="
-                    erpnextCRMSettingsResource.doc.erpnext_company =
-                      $event?.value
-                  "
-                >
-                  <template #footer>
-                    <Button
-                      :label="__('Refresh Companies')"
-                      theme="gray"
-                      variant="ghost"
-                      class="w-full"
-                      icon-left="lucide-refresh-cw"
-                      :loading="
-                        erpnextCRMSettingsResource.getExternalCompanies.loading
-                      "
-                      @click="
-                        erpnextCRMSettingsResource.getExternalCompanies.submit()
-                      "
-                    />
-                  </template>
-                </Autocomplete>
-                <Link
-                  v-else
-                  v-model="erpnextCRMSettingsResource.doc.erpnext_company"
-                  :doc="'Company'"
-                  :doctype="'Company'"
-                  :placeholder="__('Select Company')"
-                  class="w-48 flex-shrink-0"
-                />
-              </div>
-            </div>
             <div
               v-if="erpnextCRMSettingsResource.isERPNextInstalled.data"
-              class="h-px border-t border-outline-elevation-2"
-            />
-            <div
-              v-if="erpnextCRMSettingsResource.isERPNextInstalled.data"
-              class="flex items-center justify-between py-3 px-2"
+              class="flex gap-5 border-b border-outline-elevation-2 px-2 mb-3"
+              role="tablist"
             >
-              <div class="flex flex-col">
-                <div class="text-p-base-medium text-ink-gray-7 truncate">
-                  {{ __('Sync Products with ERPNext') }}
+              <button
+                v-for="tab in settingsTabs"
+                :key="tab.name"
+                class="border-b-2 pb-2 text-p-sm"
+                :class="
+                  activeSettingsTab === tab.name
+                    ? 'border-ink-gray-8 text-ink-gray-8'
+                    : 'border-transparent text-ink-gray-5'
+                "
+                role="tab"
+                :aria-selected="activeSettingsTab === tab.name"
+                @click="activeSettingsTab = tab.name"
+              >
+                {{ __(tab.label) }}
+              </button>
+            </div>
+            <div v-show="activeSettingsTab === 'general'">
+              <div class="flex items-center justify-between pb-3 px-2">
+                <div class="flex flex-col">
+                  <div class="text-p-base-medium text-ink-gray-7 truncate">
+                    {{ __('Company Name') }}
+                  </div>
+                  <div class="text-p-sm text-ink-gray-5 truncate">
+                    {{ __('Select your ERPNext company to connect with') }}
+                  </div>
                 </div>
-                <div class="text-p-sm text-ink-gray-5 truncate">
-                  {{
-                    __(
-                      'Bidirectional sync of existing CRM Products and ERPNext Items. Runs in the background.',
-                    )
-                  }}
+                <div class="w-48">
+                  <Autocomplete
+                    v-if="!erpnextCRMSettingsResource.isERPNextInstalled.data"
+                    :model-value="
+                      erpnextCRMSettingsResource.doc.erpnext_company
+                    "
+                    :options="
+                      erpnextCRMSettingsResource.getExternalCompanies.data?.map(
+                        (company) => ({
+                          label: company.company_name,
+                          value: company.company_name,
+                        }),
+                      ) || []
+                    "
+                    required
+                    class="pb-0.5"
+                    @update:modelValue="
+                      erpnextCRMSettingsResource.doc.erpnext_company =
+                        $event?.value
+                    "
+                  >
+                    <template #footer>
+                      <Button
+                        :label="__('Refresh Companies')"
+                        theme="gray"
+                        variant="ghost"
+                        class="w-full"
+                        icon-left="lucide-refresh-cw"
+                        :loading="
+                          erpnextCRMSettingsResource.getExternalCompanies
+                            .loading
+                        "
+                        @click="
+                          erpnextCRMSettingsResource.getExternalCompanies.submit()
+                        "
+                      />
+                    </template>
+                  </Autocomplete>
+                  <Link
+                    v-else
+                    v-model="erpnextCRMSettingsResource.doc.erpnext_company"
+                    :doc="'Company'"
+                    :doctype="'Company'"
+                    :placeholder="__('Select Company')"
+                    class="w-48 flex-shrink-0"
+                  />
                 </div>
               </div>
-              <div class="flex items-center gap-3">
+              <div
+                v-if="erpnextCRMSettingsResource.isERPNextInstalled.data"
+                class="h-px border-t border-outline-elevation-2"
+              />
+              <div
+                v-if="erpnextCRMSettingsResource.isERPNextInstalled.data"
+                class="flex items-center justify-between py-3 px-2 gap-4"
+              >
+                <div class="flex flex-col">
+                  <div class="text-p-base-medium text-ink-gray-7 truncate">
+                    {{ __('Bidirectional Product Sync') }}
+                  </div>
+                  <div class="text-p-sm text-ink-gray-5">
+                    {{
+                      __(
+                        'ERPNext Items always sync into CRM Products. Turn this on to also sync CRM Product changes back to ERPNext Items.',
+                      )
+                    }}
+                  </div>
+                </div>
+                <div>
+                  <Switch
+                    v-model="erpnextCRMSettingsResource.doc.sync_products"
+                    size="sm"
+                  />
+                </div>
+              </div>
+              <div
+                v-if="erpnextCRMSettingsResource.isERPNextInstalled.data"
+                class="h-px border-t border-outline-elevation-2"
+              />
+              <div
+                v-if="erpnextCRMSettingsResource.isERPNextInstalled.data"
+                class="flex items-center justify-between py-3 px-2 gap-4"
+              >
+                <div class="flex flex-col">
+                  <div class="text-p-base-medium text-ink-gray-7 truncate">
+                    {{ __('Manual Sync') }}
+                  </div>
+                  <div class="text-p-sm text-ink-gray-5">
+                    {{
+                      erpnextCRMSettingsResource.doc.sync_products
+                        ? __(
+                            'Run a manual bi-directional sync between ERPNext Items and CRM Products.',
+                          )
+                        : __(
+                            'Run a manual synchronization to pull the latest Items from ERPNext.',
+                          )
+                    }}
+                  </div>
+                </div>
                 <Button
-                  v-if="erpnextCRMSettingsResource.doc.sync_products"
                   variant="subtle"
+                  icon-left="lucide-refresh-cw"
                   :loading="erpnextCRMSettingsResource.runProductSync.loading"
                   @click="runProductSync"
                 >
                   {{ __('Sync Now') }}
                 </Button>
-                <Switch
-                  v-model="erpnextCRMSettingsResource.doc.sync_products"
-                  size="sm"
-                />
               </div>
-            </div>
-            <div class="h-px border-t border-outline-elevation-2" />
-            <div class="flex items-center justify-between py-3 px-2">
-              <div class="flex flex-col">
-                <div class="text-p-base-medium text-ink-gray-7 truncate">
-                  {{ __('Auto Create Customer') }}
-                </div>
-                <div class="text-p-sm text-ink-gray-5 truncate">
-                  {{
-                    __(
-                      'Create customer in ERPNext when the deal status is changed',
-                    )
-                  }}
-                </div>
-              </div>
-              <div>
-                <Switch
-                  v-model="
-                    erpnextCRMSettingsResource.doc
-                      .create_customer_on_status_change
-                  "
-                  size="sm"
-                />
-              </div>
-            </div>
-            <div
-              v-if="
-                erpnextCRMSettingsResource.doc.create_customer_on_status_change
-              "
-            >
-              <div class="flex items-center justify-between py-3 px-2 gap-4">
+              <div class="h-px border-t border-outline-elevation-2" />
+              <div class="flex items-center justify-between py-3 px-2">
                 <div class="flex flex-col">
-                  <div class="text-p-base-medium text-ink-gray-7">
-                    {{ __('Deal Status') }}
+                  <div class="text-p-base-medium text-ink-gray-7 truncate">
+                    {{ __('Auto Create Customer') }}
                   </div>
-                  <div class="text-p-sm text-ink-gray-5">
+                  <div class="text-p-sm text-ink-gray-5 truncate">
                     {{
                       __(
-                        'Select the deal status to trigger the auto customer creation in ERPNext',
+                        'Create customer in ERPNext when the deal status is changed',
                       )
                     }}
                   </div>
                 </div>
-                <Link
-                  v-model="erpnextCRMSettingsResource.doc.deal_status"
-                  doctype="CRM Deal Status"
-                  :placeholder="__('Won')"
-                  :disabled="
-                    !erpnextCRMSettingsResource.doc
-                      .create_customer_on_status_change
-                  "
-                  class="w-48 flex-shrink-0"
-                />
+                <div>
+                  <Switch
+                    v-model="
+                      erpnextCRMSettingsResource.doc
+                        .create_customer_on_status_change
+                    "
+                    size="sm"
+                  />
+                </div>
+              </div>
+              <div class="h-px border-t border-outline-elevation-2" />
+              <div
+                v-if="
+                  erpnextCRMSettingsResource.doc
+                    .create_customer_on_status_change
+                "
+              >
+                <div class="flex items-center justify-between py-3 px-2 gap-4">
+                  <div class="flex flex-col">
+                    <div class="text-p-base-medium text-ink-gray-7">
+                      {{ __('Deal Status') }}
+                    </div>
+                    <div class="text-p-sm text-ink-gray-5">
+                      {{
+                        __(
+                          'Select the deal status to trigger the auto customer creation in ERPNext',
+                        )
+                      }}
+                    </div>
+                  </div>
+                  <Link
+                    v-model="erpnextCRMSettingsResource.doc.deal_status"
+                    doctype="CRM Deal Status"
+                    :placeholder="__('Won')"
+                    :disabled="
+                      !erpnextCRMSettingsResource.doc
+                        .create_customer_on_status_change
+                    "
+                    class="w-48 flex-shrink-0"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              v-if="erpnextCRMSettingsResource.isERPNextInstalled.data"
+              v-show="activeSettingsTab === 'logs'"
+              class="px-2"
+            >
+              <div
+                v-if="productSyncStatus.loading"
+                class="flex items-center justify-center py-10"
+              >
+                <LoadingIndicator class="size-5" />
+              </div>
+              <div v-else class="flex flex-col gap-2">
+                <div
+                  class="flex gap-5 border-b border-outline-elevation-2 overflow-x-auto"
+                  role="tablist"
+                >
+                  <button
+                    v-for="section in productSyncSections"
+                    :key="section.name"
+                    class="flex items-center gap-1 whitespace-nowrap border-b-2 px-0 pb-2 text-p-sm"
+                    :class="
+                      activeProductSyncLogTab === section.name
+                        ? 'border-ink-gray-8 text-ink-gray-8'
+                        : 'border-transparent text-ink-gray-5'
+                    "
+                    role="tab"
+                    :aria-selected="activeProductSyncLogTab === section.name"
+                    @click="activeProductSyncLogTab = section.name"
+                  >
+                    <span>{{ __(section.label) }}</span>
+                    <span
+                      class="rounded bg-surface-gray-2 px-1.5 text-xs text-ink-gray-6"
+                    >
+                      {{ section.count }}
+                    </span>
+                  </button>
+                </div>
+                <div
+                  v-if="activeProductSyncLogTab === 'failed' && unsyncedSummary"
+                  class="rounded bg-surface-gray-2 px-3 py-2 text-p-sm text-ink-gray-6"
+                >
+                  {{ unsyncedSummary }}
+                </div>
+                <div
+                  v-if="!currentProductSyncRows.length"
+                  class="rounded border border-outline-elevation-2 px-3 py-2 text-p-sm text-ink-gray-5"
+                >
+                  {{ __(currentProductSyncSection.emptyLabel) }}
+                </div>
+                <div v-else class="flex flex-col">
+                  <div
+                    v-for="row in currentProductSyncRows"
+                    :key="row.name"
+                    class="flex items-start justify-between gap-2 border-b border-outline-elevation-2 py-2 last:border-b-0"
+                  >
+                    <div class="min-w-0">
+                      <a
+                        v-if="getDeskUrl(row)"
+                        :href="getDeskUrl(row)"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex max-w-full items-center gap-1 text-p-sm-medium text-ink-gray-8 hover:underline"
+                      >
+                        <span class="truncate">{{ getSyncRowName(row) }}</span>
+                        <lucide-square-arrow-out-up-right
+                          class="size-3.5 shrink-0 text-ink-gray-6"
+                        />
+                      </a>
+                      <div
+                        v-else
+                        class="truncate text-p-sm-medium text-ink-gray-8"
+                      >
+                        {{ getSyncRowName(row) }}
+                      </div>
+                      <div
+                        v-if="isSyncedDocumentLog"
+                        class="mt-0.5 flex flex-wrap gap-x-3 gap-y-1"
+                      >
+                        <span
+                          v-if="getSyncRowGroup(row)"
+                          class="text-p-sm text-ink-gray-5"
+                        >
+                          {{ __('Item Group') }}: {{ getSyncRowGroup(row) }}
+                        </span>
+                        <span class="text-p-sm text-ink-gray-5">
+                          {{ __('ID') }}: {{ getSyncRowId(row) }}
+                        </span>
+                      </div>
+                      <div v-else class="truncate text-p-sm text-ink-gray-5">
+                        {{ row.detail || row.kind }}
+                      </div>
+                    </div>
+                    <div
+                      v-if="!isSyncedDocumentLog"
+                      class="shrink-0 text-p-sm text-ink-gray-5"
+                    >
+                      {{ getSyncRowMeta(row) }}
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -305,6 +460,7 @@
 import {
   Button,
   createDocumentResource,
+  createResource,
   FormControl,
   LoadingIndicator,
   Switch,
@@ -312,9 +468,10 @@ import {
   Tooltip,
 } from 'frappe-ui'
 import SettingsLayoutBase from '@/components/Layouts/SettingsLayoutBase.vue'
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import Link from '../Controls/Link.vue'
 import { globalStore } from '@/stores/global'
+import { formatDate } from '@/utils'
 
 const { $dialog } = globalStore()
 
@@ -334,7 +491,8 @@ const erpnextCRMSettingsResource = createDocumentResource({
     runProductSync: {
       method: 'run_product_sync',
       onSuccess() {
-        toast.success(__('Product sync started. Items will appear shortly.'))
+        toast.success(__('Product sync started.'))
+        productSyncStatus.submit()
       },
       onError(error) {
         toast.error(error?.messages?.[0] || __('Failed to start sync'))
@@ -350,6 +508,62 @@ const erpnextCRMSettingsResource = createDocumentResource({
       toast.error(message)
     },
   },
+})
+
+const activeSettingsTab = ref('general')
+const activeProductSyncLogTab = ref('products')
+
+const settingsTabs = [
+  { name: 'general', label: 'General Settings' },
+  { name: 'logs', label: 'Logs' },
+]
+
+const productSyncStatus = createResource({
+  url: 'crm.fcrm.doctype.erpnext_crm_settings.erpnext_crm_settings.get_product_sync_status',
+})
+
+const productSyncSections = computed(() => {
+  const data = productSyncStatus.data || {}
+  return [
+    getProductSyncSection('products', 'Products', 'No CRM Products'),
+    getProductSyncSection('items', 'Items', 'No synced ERPNext Items'),
+    getProductSyncSection('failed', 'Failed Logs', 'No failed syncs'),
+  ].map((section) => ({
+    ...section,
+    rows: data[section.name]?.rows || data[section.name] || [],
+    count: data[section.name]?.count ?? data[section.name]?.length ?? 0,
+  }))
+})
+
+const currentProductSyncSection = computed(
+  () =>
+    productSyncSections.value.find(
+      (section) => section.name === activeProductSyncLogTab.value,
+    ) || productSyncSections.value[0],
+)
+
+const currentProductSyncRows = computed(
+  () => currentProductSyncSection.value?.rows || [],
+)
+
+const isSyncedDocumentLog = computed(() =>
+  ['products', 'items'].includes(activeProductSyncLogTab.value),
+)
+
+const unsyncedSummary = computed(() => {
+  const data = productSyncStatus.data?.unsynced
+  if (!data) return ''
+  const parts = []
+  if (data.items) {
+    parts.push(`${data.items} ${data.items === 1 ? __('item') : __('items')}`)
+  }
+  if (data.sync_products && data.products) {
+    parts.push(
+      `${data.products} ${data.products === 1 ? __('product') : __('products')}`,
+    )
+  }
+  if (!parts.length) return ''
+  return __('{0} not yet synced', [parts.join(__(' and '))])
 })
 
 const isDisabled = computed(() => {
@@ -461,8 +675,55 @@ const toggleEnable = (value) => {
   }
 }
 
-function runProductSync() {
-  erpnextCRMSettingsResource.runProductSync.submit()
+async function runProductSync() {
+  if (
+    erpnextCRMSettingsResource.originalDoc?.sync_products !==
+    erpnextCRMSettingsResource.doc.sync_products
+  ) {
+    await updateFields(
+      'sync_products',
+      erpnextCRMSettingsResource.doc.sync_products,
+    )
+  }
+  await erpnextCRMSettingsResource.runProductSync.submit()
+}
+
+function getProductSyncSection(name, label, emptyLabel) {
+  return { name, label, emptyLabel }
+}
+
+function getSyncRowName(row) {
+  return row.product_name || row.item_name || row.product || row.name
+}
+
+function getSyncRowMeta(row) {
+  if (activeProductSyncLogTab.value === 'products') return row.erpnext_item_code
+  if (activeProductSyncLogTab.value === 'items') return row.crm_product_code
+  return row.detected_on ? formatDate(row.detected_on) : row.kind || ''
+}
+
+function getSyncRowGroup(row) {
+  return row.item_group
+}
+
+function getSyncRowId(row) {
+  if (activeProductSyncLogTab.value === 'products')
+    return row.product_code || row.name
+  if (activeProductSyncLogTab.value === 'items')
+    return row.item_code || row.name
+  return row.product || row.name
+}
+
+function getDeskUrl(row) {
+  const doctype = getDeskDoctype()
+  if (!doctype || !row.name) return ''
+  return `${window.location.origin}/app/${doctype}/${encodeURIComponent(row.name)}`
+}
+
+function getDeskDoctype() {
+  if (activeProductSyncLogTab.value === 'products') return 'crm-product'
+  if (activeProductSyncLogTab.value === 'items') return 'item'
+  return ''
 }
 
 function verifyConnection() {
@@ -548,7 +809,7 @@ function updateFields(fields, value, options) {
     obj[fields] = value
   }
 
-  erpnextCRMSettingsResource.setValue.submit(obj, options)
+  return erpnextCRMSettingsResource.setValue.submit(obj, options)
 }
 
 onMounted(async () => {
@@ -567,5 +828,11 @@ onMounted(async () => {
       }
     },
   })
+  if (
+    erpnextCRMSettingsResource.isERPNextInstalled.data &&
+    erpnextCRMSettingsResource.doc.enabled
+  ) {
+    productSyncStatus.submit()
+  }
 })
 </script>

--- a/frontend/src/components/Settings/ERPNextSettings.vue
+++ b/frontend/src/components/Settings/ERPNextSettings.vue
@@ -468,7 +468,7 @@ import {
   Tooltip,
 } from 'frappe-ui'
 import SettingsLayoutBase from '@/components/Layouts/SettingsLayoutBase.vue'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import Link from '../Controls/Link.vue'
 import { globalStore } from '@/stores/global'
 import { formatDate } from '@/utils'
@@ -831,6 +831,17 @@ onMounted(async () => {
   if (
     erpnextCRMSettingsResource.isERPNextInstalled.data &&
     erpnextCRMSettingsResource.doc.enabled
+  ) {
+    productSyncStatus.submit()
+  }
+})
+
+// Fetch logs lazily when the tab is opened (e.g. after enabling in the same session)
+watch(activeSettingsTab, (tab) => {
+  if (
+    tab === 'logs' &&
+    erpnextCRMSettingsResource.isERPNextInstalled.data &&
+    !productSyncStatus.fetched
   ) {
     productSyncStatus.submit()
   }

--- a/frontend/src/components/Settings/ERPNextSettings.vue
+++ b/frontend/src/components/Settings/ERPNextSettings.vue
@@ -468,12 +468,12 @@ import {
   Tooltip,
 } from 'frappe-ui'
 import SettingsLayoutBase from '@/components/Layouts/SettingsLayoutBase.vue'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import Link from '../Controls/Link.vue'
 import { globalStore } from '@/stores/global'
 import { formatDate } from '@/utils'
 
-const { $dialog } = globalStore()
+const { $dialog, $socket } = globalStore()
 
 const erpnextCRMSettingsResource = createDocumentResource({
   doctype: 'ERPNext CRM Settings',
@@ -846,4 +846,13 @@ watch(activeSettingsTab, (tab) => {
     productSyncStatus.submit()
   }
 })
+
+// The sync runs in a background job; refresh logs when it signals completion
+function onSyncComplete() {
+  if (erpnextCRMSettingsResource.isERPNextInstalled.data) {
+    productSyncStatus.submit()
+  }
+}
+onMounted(() => $socket.on('crm_product_sync_complete', onSyncComplete))
+onBeforeUnmount(() => $socket.off('crm_product_sync_complete', onSyncComplete))
 </script>


### PR DESCRIPTION
- Splits ERPNext product sync into two directions: ERPNext Items always pull into CRM Products, while pushing CRM Product changes back to ERPNext Items is now opt-in via the "Bidirectional Product Sync" toggle.
- Adds a Manual Sync Now Button to ERPNext Settings, 
- Logs to see CRM Products, ERPNext Items and failed synced with unsynced items
- Items and Products in Logs are links upon clicking can open the said document in desk


https://github.com/user-attachments/assets/afbee8d5-a9cd-496b-b43e-31acb2743138





