### PR TITLE
fix(forms): description rendering — preserve line breaks + reliable auto-size

### DIFF
--- a/crm/www/crm_form.html
+++ b/crm/www/crm_form.html
@@ -62,7 +62,7 @@
       .title { font-size: 20px; font-weight: 600; color: var(--ink-strong); margin: 0 0 14px; letter-spacing: -0.01em; line-height: 1.3; }
       /* with no description, the title supplies the gap the subtitle normally would */
       .title.title-only { margin-bottom: 22px; }
-      .subtitle { font-size: 14px; color: var(--muted); margin: 0 0 22px; line-height: 1.5; }
+      .subtitle { font-size: 14px; color: var(--muted); margin: 0 0 22px; line-height: 1.5; white-space: pre-wrap; }
       .section { margin-bottom: 4px; }
       .section-title { font-size: 15px; font-weight: 600; color: var(--ink-strong); margin: 20px 0 12px; }
       .section:first-child .section-title { margin-top: 0; }

--- a/frontend/src/components/Settings/Forms/FormBuilderPanel.vue
+++ b/frontend/src/components/Settings/Forms/FormBuilderPanel.vue
@@ -519,7 +519,10 @@
             <div class="text-xl font-semibold text-ink-gray-9">
               {{ form.title || __('Form title') }}
             </div>
-            <div v-if="form.description" class="mt-3.5 text-sm text-ink-gray-6">
+            <div
+              v-if="form.description"
+              class="mt-3.5 whitespace-pre-wrap text-sm text-ink-gray-6"
+            >
               {{ form.description }}
             </div>
             <div class="mt-5 flex flex-col gap-5">
@@ -709,6 +712,18 @@ function autoGrow(el) {
   el.style.height = 'auto'
   el.style.height = el.scrollHeight + 'px'
 }
+// Robustly size the description box: measure on an animation frame (after layout),
+// and if the box isn't laid out yet — it lives in a lazily-rendered Tabs panel, so
+// on re-navigation it can be briefly zero-width/hidden — retry on the next frame.
+// Without this, opening a saved multi-line description shows only the first line.
+function sizeDescription(tries = 0) {
+  requestAnimationFrame(() => {
+    const el = descInput.value
+    if (!el) return
+    if (!el.clientWidth && tries < 20) return sizeDescription(tries + 1)
+    autoGrow(el)
+  })
+}
 const dragging = ref(false)
 
 // Editing model: form.fields (flat) is the source of truth, derived into a
@@ -875,11 +890,11 @@ const form = reactive({
 // settles, so it fires whenever the textarea actually mounts (initial load, or
 // re-entering Edit — it lives inside a lazily-rendered Tabs panel) or its content
 // changes — no more 1-row box scrolled to the last line.
-watch([descInput, () => form.description], () => autoGrow(descInput.value), {
+watch([descInput, () => form.description], () => sizeDescription(), {
   flush: 'post',
 })
 // re-measure once web fonts load: scrollHeight with the fallback font wraps wrong
-onMounted(() => document.fonts?.ready?.then(() => autoGrow(descInput.value)))
+onMounted(() => document.fonts?.ready?.then(() => sizeDescription()))
 
 const publicUrl = computed(
   () => `${window.location.origin}/crm-form/${form.route}`,


### PR DESCRIPTION
Render the form description with white-space: pre-wrap on the public page (.subtitle) and builder preview so newlines/spacing show as typed, and reliably auto-size the editor's description textarea on load/navigation (measure on an animation frame + retry until laid out) so a saved multi-line description no longer opens collapsed.