### PR TITLE
refactor: prefill custom fields in lead to deal conversion form 

### DIFF
--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -15,6 +15,8 @@ from crm.fcrm.doctype.crm_status_change_log.crm_status_change_log import (
 )
 from crm.fcrm.doctype.utils import add_or_remove_lost_reason_section_in_sidepanel
 
+LEAD_DEAL_FIELD_MAP = {"lead_owner": "deal_owner"}
+
 
 class CRMLead(Document):
 	# begin: auto-generated types
@@ -335,10 +337,6 @@ class CRMLead(Document):
 	def create_deal(self, contact, organization, deal=None):
 		new_deal = frappe.new_doc("CRM Deal")
 
-		lead_deal_map = {
-			"lead_owner": "deal_owner",
-		}
-
 		restricted_fieldtypes = [
 			"Tab Break",
 			"Section Break",
@@ -376,11 +374,9 @@ class CRMLead(Document):
 			if field.fieldname in restricted_map_fields:
 				continue
 
-			fieldname = field.fieldname
-			if field.fieldname in lead_deal_map:
-				fieldname = lead_deal_map[field.fieldname]
+			fieldname = get_deal_fieldname(field, new_deal.meta)
 
-			if hasattr(new_deal, fieldname):
+			if fieldname:
 				if fieldname == "organization":
 					new_deal.update({fieldname: organization})
 				else:
@@ -546,3 +542,38 @@ def convert_to_deal(
 	organization = lead.create_organization(existing_organization)
 	_deal = lead.create_deal(contact, organization, deal)
 	return _deal
+
+
+def get_deal_fieldname(field, deal_meta):
+	mapped_fieldname = LEAD_DEAL_FIELD_MAP.get(field.fieldname)
+	if mapped_fieldname:
+		return mapped_fieldname if deal_meta.has_field(mapped_fieldname) else None
+	if deal_meta.has_field(field.fieldname):
+		return field.fieldname
+	if not is_custom_field(field):
+		return None
+	return get_matching_custom_deal_field(field, deal_meta)
+
+
+def get_matching_custom_deal_field(field, deal_meta):
+	matches = [
+		deal_field.fieldname for deal_field in deal_meta.fields if is_matching_custom_field(field, deal_field)
+	]
+	return matches[0] if len(matches) == 1 else None
+
+
+def is_matching_custom_field(lead_field, deal_field):
+	return (
+		is_custom_field(deal_field)
+		and lead_field.label == deal_field.label
+		and lead_field.fieldtype == deal_field.fieldtype
+	)
+
+
+def is_custom_field(field):
+	return bool(
+		field.get("is_custom_field")
+		or field.get("custom")
+		or (field.fieldname or "").startswith("custom_")
+		or field.name == f"{field.parent}-{field.fieldname}"
+	)

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.desk.form.assign_to import add as assign_add
 from frappe.desk.form.assign_to import remove as assign_remove
 from frappe.tests import IntegrationTestCase
@@ -511,6 +512,20 @@ class TestCRMLead(IntegrationTestCase):
 		self.assertEqual(deal.annual_revenue, 750000)
 		self.assertEqual(deal.job_title, "CEO")
 
+	def test_custom_fields_copied_to_deal_by_label(self):
+		"""Custom Lead fields map to matching custom Deal fields."""
+		create_lead_deal_custom_fields()
+		lead = create_lead(
+			first_name="Custom",
+			organization="Custom Field Inc",
+			custom_lead_conversion_region="North",
+		)
+
+		deal_name = lead.convert_to_deal()
+		deal = frappe.get_doc("CRM Deal", deal_name)
+
+		self.assertEqual(deal.custom_deal_conversion_region, "North")
+
 	def test_assignees_transferred_on_conversion(self):
 		"""Test that additional assignees are transferred from lead to deal on conversion"""
 		lead = create_lead(
@@ -553,3 +568,24 @@ def create_lead(**kwargs):
 	data = {"doctype": "CRM Lead"}
 	data.update(kwargs)
 	return frappe.get_doc(data).insert()
+
+
+def create_lead_deal_custom_fields():
+	create_custom_fields(
+		{
+			"CRM Lead": [conversion_region_field("custom_lead_conversion_region")],
+			"CRM Deal": [conversion_region_field("custom_deal_conversion_region")],
+		},
+		ignore_validate=True,
+	)
+	frappe.clear_cache(doctype="CRM Lead")
+	frappe.clear_cache(doctype="CRM Deal")
+
+
+def conversion_region_field(fieldname):
+	return {
+		"fieldname": fieldname,
+		"fieldtype": "Data",
+		"insert_after": "source",
+		"label": "Conversion Region",
+	}

--- a/frontend/src/components/Modals/ConvertToDealModal.vue
+++ b/frontend/src/components/Modals/ConvertToDealModal.vue
@@ -95,6 +95,7 @@ import { useDocument } from '@/data/document'
 import { usersStore } from '@/stores/users'
 import { sessionStore } from '@/stores/session'
 import { statusesStore } from '@/stores/statuses'
+import { getMeta } from '@/stores/meta'
 import { showQuickEntryModal, quickEntryProps } from '@/composables/modals'
 import { isMobileView } from '@/composables/settings'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
@@ -114,6 +115,7 @@ const { statusOptions, getDealStatus } = statusesStore()
 const { isManager } = usersStore()
 const { user } = sessionStore()
 const { updateOnboardingStep } = useOnboarding('frappecrm')
+const { doctypeMeta: leadMeta } = getMeta('CRM Lead')
 
 const existingContactChecked = ref(false)
 const existingOrganizationChecked = ref(false)
@@ -196,7 +198,7 @@ const dealTabs = createResource({
   auto: true,
   transform: (_tabs) => {
     let hasFields = false
-    let parsedTabs = _tabs?.forEach((tab) => {
+    _tabs?.forEach((tab) => {
       tab.sections?.forEach((section) => {
         section.columns?.forEach((column) => {
           column.fields?.forEach((field) => {
@@ -210,42 +212,94 @@ const dealTabs = createResource({
         })
       })
     })
-    return hasFields ? parsedTabs : []
+    return hasFields ? _tabs : []
   },
 })
 
 const leadDealFieldMap = { deal_owner: 'lead_owner' }
 const skipPrefillFields = ['organization', 'status']
+const leadFields = computed(() => leadMeta.value?.fields || [])
 
 watch(
   () => dealTabs.data,
-  (tabs) => {
-    deal.doc = { __newDocument: true, doctype: 'CRM Deal' }
-    tabs?.forEach((tab) =>
-      tab.sections?.forEach((section) =>
-        section.columns?.forEach((column) =>
-          column.fields?.forEach((field) => {
-            if (field.fieldtype === 'Table') {
-              deal.doc[field.fieldname] = []
-            } else {
-              prefillFromLead(field)
-            }
-          }),
-        ),
-      ),
-    )
-  },
+  (tabs) => resetDealDoc(tabs),
   { immediate: true },
 )
 
+watch(leadFields, () => prefillFields(dealTabs.data))
+
+function resetDealDoc(tabs) {
+  deal.doc = { __newDocument: true, doctype: 'CRM Deal' }
+  prefillFields(tabs)
+}
+
+function prefillFields(tabs) {
+  tabs?.forEach((tab) =>
+    tab.sections?.forEach((section) =>
+      section.columns?.forEach((column) =>
+        column.fields?.forEach((field) => prefillField(field)),
+      ),
+    ),
+  )
+}
+
+function prefillField(field) {
+  if (field.fieldtype === 'Table') {
+    deal.doc[field.fieldname] = []
+    return
+  }
+  prefillFromLead(field)
+}
+
 function prefillFromLead(field) {
   if (skipPrefillFields.includes(field.fieldname)) return
+  if (hasValue(deal.doc[field.fieldname])) return
 
-  const leadFieldname = leadDealFieldMap[field.fieldname] || field.fieldname
+  const leadFieldname = getLeadFieldname(field)
+  if (!leadFieldname) return
+
   const value = props.lead[leadFieldname]
   if (value != null && value !== '') {
     deal.doc[field.fieldname] = value
   }
+}
+
+function getLeadFieldname(field) {
+  const mappedFieldname = leadDealFieldMap[field.fieldname]
+  if (mappedFieldname) return mappedFieldname
+  if (Object.hasOwn(props.lead, field.fieldname)) return field.fieldname
+
+  return getMatchingCustomLeadField(field)?.fieldname
+}
+
+function getMatchingCustomLeadField(field) {
+  if (!isCustomField(field)) return
+
+  const matches = leadFields.value.filter((leadField) =>
+    isMatchingCustomField(leadField, field),
+  )
+  return matches.length === 1 ? matches[0] : null
+}
+
+function isMatchingCustomField(leadField, dealField) {
+  return (
+    isCustomField(leadField) &&
+    leadField.label === dealField.label &&
+    leadField.fieldtype === dealField.fieldtype
+  )
+}
+
+function isCustomField(field) {
+  return Boolean(
+    field?.is_custom_field ||
+      field?.custom ||
+      field?.fieldname?.startsWith('custom_') ||
+      field?.name === `${field?.parent}-${field?.fieldname}`,
+  )
+}
+
+function hasValue(value) {
+  return value != null && value !== ''
 }
 
 function openQuickEntryModal() {


### PR DESCRIPTION
previously only default fields were included in the pre-fill fields functionality while converting a lead to deal, now it will also pre-fill custom fields if exists

https://github.com/user-attachments/assets/03e56300-b6d6-4ee8-96c7-13ffa1a0ac52

 