### PR TITLE
fix: filter call logs by receiver/caller email instead of full name

### DIFF
--- a/frontend/src/utils/callLog.js
+++ b/frontend/src/utils/callLog.js
@@ -15,11 +15,13 @@ export function getCallLogDetail(row, log, columns = []) {
     }
   } else if (row === 'caller') {
     return {
+      name: log.caller,
       label: log._caller?.label,
       image: log._caller?.image,
     }
   } else if (row === 'receiver') {
     return {
+      name: log.receiver,
       label: log._receiver?.label,
       image: log._receiver?.image,
     }


### PR DESCRIPTION
## Summary

Filtering Call Logs by clicking a "Caller" or "Receiver" cell was silently returning no results.

`caller` and `receiver` are `Link` fields to `User`, whose primar  key (`name`) is the user's email — but their stored/filterable value must be the email, not the full name. The row item objects built for these two columns in `getCallLogDetail()` (frontend/src/utils/callLog.js) only included `label` (full name) and `image`, with no `name`. The generic click-to-filter handler in `ViewControls.applyFilter()` resolves the filter value as `item.name ?? item.label ?? item`, so in the absence of `item.name` it fell back to the full name and sent that as the filter value — which never matches the stored email.

Other Link-to-User columns (`deal_owner`, `lead_owner`, `_assign`) already attach the email as `name` alongside `label`, so `applyFilter` picks the right value for them. This PR applies the same pattern to `caller`/`receiver`:

Fixes #2145 