### PR TITLE
fix: lead/deal report 500s when a child-table column is selected

### DIFF
--- a/crm/permissions/org_hierarchy.py
+++ b/crm/permissions/org_hierarchy.py
@@ -62,12 +62,12 @@ def _permission_query_conditions(user: str | None, doctype: str):
 
 def get_lead_permission_query_conditions(user=None):
 	cond = _permission_query_conditions(user, "CRM Lead")
-	return cond.get_sql(quote_char="`", secondary_quote_char="'") if cond else ""
+	return cond.get_sql(with_namespace=True, quote_char="`", secondary_quote_char="'") if cond else ""
 
 
 def get_deal_permission_query_conditions(user=None):
 	cond = _permission_query_conditions(user, "CRM Deal")
-	return cond.get_sql(quote_char="`", secondary_quote_char="'") if cond else ""
+	return cond.get_sql(with_namespace=True, quote_char="`", secondary_quote_char="'") if cond else ""
 
 
 def _has_permission(doc, ptype, user, doctype: str) -> bool | None:

--- a/crm/permissions/test_org_hierarchy.py
+++ b/crm/permissions/test_org_hierarchy.py
@@ -131,6 +131,19 @@ class TestOrgHierarchy(IntegrationTestCase):
 	def test_query_conditions_non_empty_for_regular_user(self):
 		self.assertTrue(get_lead_permission_query_conditions("rep1@hier.test"))
 
+	def test_report_with_child_table_field_does_not_raise(self):
+		make_lead("rep1@hier.test")
+		self.assertTrue(get_lead_permission_query_conditions("rep1@hier.test"))
+		frappe.set_user("rep1@hier.test")
+		try:
+			frappe.get_list(
+				"CRM Lead",
+				fields=["name", "`tabCRM Products`.`amount`"],
+				limit_page_length=5,
+			)
+		finally:
+			frappe.set_user("Administrator")
+
 	# ------------------------------------------------------------------
 	# Hierarchy disabled
 	# ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Restricted, in-hierarchy users opening the CRM Lead report and selecting a field from **CRM Products** hit:

```text
OperationalError (1052, "Column 'name' in IN/ALL/ANY is ambiguous")
```

This happened because the permission condition was rendered as `name IN (...)` instead of qualifying the column.
The query worked until a child-table field introduced a `LEFT JOIN`, making `name` ambiguous.

## Fix

Render the permission condition with `with_namespace=True` so it qualifies its own columns. 
The same fix is applied to both Lead and Deal.

---

Ref: https://support.frappe.io/helpdesk/tickets/74023?view=VIEW-HD+Ticket-1252