### PR TITLE
fix(forms): keep the Unpublished badge visible on row hover

### DIFF
--- a/frontend/src/components/Settings/Forms/FormsList.vue
+++ b/frontend/src/components/Settings/Forms/FormsList.vue
@@ -69,7 +69,7 @@
             <div class="flex w-3/12 items-center justify-between">
               <Badge
                 :theme="form.published ? 'green' : 'gray'"
-                variant="subtle"
+                :variant="form.published ? 'subtle' : 'outline'"
                 size="md"
                 :label="form.published ? __('Published') : __('Unpublished')"
               />


### PR DESCRIPTION
The Forms list's gray **Unpublished** badge used `variant=subtle`, whose light-gray fill blended into the row's `hover:bg-surface-gray-2` — so it looked borderless on hover. Switched it to `variant=outline` so it keeps a visible border on any background. The green **Published** badge stays `subtle`.