### PR TITLE
fix: preserve sender identity on received email replies

### DIFF
--- a/crm/api/activities.py
+++ b/crm/api/activities.py
@@ -1,12 +1,11 @@
 import json
 
 import frappe
-from bs4 import BeautifulSoup
 from frappe import _
 from frappe.desk.form.load import get_docinfo
 from frappe.query_builder import JoinType
-from frappe.translate import get_translated_doctypes
 
+from crm.api.activity_helpers import get_communication_directions, is_translatable, parse_attachment_log
 from crm.fcrm.doctype.crm_call_log.crm_call_log import parse_call_log
 
 
@@ -26,6 +25,7 @@ def get_deal_activities(name: str):
 
 	get_docinfo("", "CRM Deal", name)
 	docinfo = frappe.response["docinfo"]
+	communication_directions = get_communication_directions(docinfo.communications)
 	deal_meta = frappe.get_meta("CRM Deal")
 	deal_fields = {
 		field.fieldname: {"label": field.label, "options": field.options} for field in deal_meta.fields
@@ -147,6 +147,7 @@ def get_deal_activities(name: str):
 				"attachments": get_attachments("Communication", communication.name),
 				"read_by_recipient": communication.read_by_recipient,
 				"delivery_status": communication.delivery_status,
+				"sent_or_received": communication_directions.get(communication.name),
 			},
 			"is_lead": False,
 		}
@@ -180,6 +181,7 @@ def get_lead_activities(name: str):
 
 	get_docinfo("", "CRM Lead", name)
 	docinfo = frappe.response["docinfo"]
+	communication_directions = get_communication_directions(docinfo.communications)
 	lead_meta = frappe.get_meta("CRM Lead")
 	lead_fields = {
 		field.fieldname: {"label": field.label, "options": field.options} for field in lead_meta.fields
@@ -288,6 +290,7 @@ def get_lead_activities(name: str):
 				"attachments": get_attachments("Communication", communication.name),
 				"read_by_recipient": communication.read_by_recipient,
 				"delivery_status": communication.delivery_status,
+				"sent_or_received": communication_directions.get(communication.name),
 			},
 			"is_lead": True,
 		}
@@ -493,31 +496,3 @@ def get_linked_tasks(name: str):
 		],
 	)
 	return tasks or []
-
-
-def parse_attachment_log(html: str, type: str):
-	soup = BeautifulSoup(html, "html.parser")
-	a_tag = soup.find("a")
-	type = "added" if type == "Attachment" else "removed"
-	if not a_tag:
-		return {
-			"type": type,
-			"file_name": html.replace("Removed ", ""),
-			"file_url": "",
-			"is_private": False,
-		}
-
-	is_private = False
-	if "private/files" in a_tag["href"]:
-		is_private = True
-
-	return {
-		"type": type,
-		"file_name": a_tag.text,
-		"file_url": a_tag["href"],
-		"is_private": is_private,
-	}
-
-
-def is_translatable(doctype: str) -> bool:
-	return doctype in get_translated_doctypes()

--- a/crm/api/activity_helpers.py
+++ b/crm/api/activity_helpers.py
@@ -1,0 +1,46 @@
+import frappe
+from bs4 import BeautifulSoup
+from frappe.translate import get_translated_doctypes
+
+
+def get_communication_directions(communications: list) -> dict:
+	names = [communication.name for communication in communications]
+	if not names:
+		return {}
+
+	return {
+		communication.name: communication.sent_or_received
+		for communication in frappe.get_all(
+			"Communication",
+			filters={"name": ("in", names)},
+			fields=["name", "sent_or_received"],
+		)
+	}
+
+
+def parse_attachment_log(html: str, type: str):
+	soup = BeautifulSoup(html, "html.parser")
+	a_tag = soup.find("a")
+	type = "added" if type == "Attachment" else "removed"
+	if not a_tag:
+		return {
+			"type": type,
+			"file_name": html.replace("Removed ", ""),
+			"file_url": "",
+			"is_private": False,
+		}
+
+	is_private = False
+	if "private/files" in a_tag["href"]:
+		is_private = True
+
+	return {
+		"type": type,
+		"file_name": a_tag.text,
+		"file_url": a_tag["href"],
+		"is_private": is_private,
+	}
+
+
+def is_translatable(doctype: str) -> bool:
+	return doctype in get_translated_doctypes()

--- a/frontend/src/components/Activities/EmailArea.vue
+++ b/frontend/src/components/Activities/EmailArea.vue
@@ -93,7 +93,9 @@ function reply(email, reply_all = false) {
   let editor = emailBox.editor
   let message = email.content
   let recipients = email.recipients.split(',').map((r) => r.trim())
-  editor.fromEmail = email.sender
+  if (email.sent_or_received === 'Sent') {
+    editor.fromEmail = email.sender
+  }
   editor.toEmails = [email.sender]
   editor.cc = editor.bcc = false
   editor.ccEmails = []


### PR DESCRIPTION
## Summary

- expose the canonical `Communication.sent_or_received` value in Lead and Deal activity payloads using one batched lookup
- restore a communication's historical sender only for explicitly `Sent` messages
- preserve the editor's authorized/default sender for `Received`, missing, or unknown direction values

Closes #2480.

## Context

#1859 added the authorized From selector and also made replies unconditionally assign `email.sender` to the editor's From value. That is useful for a `Sent` communication, where `sender` is the user's historical sending identity, but unsafe for a `Received` communication, where `sender` is the external correspondent.

This change keeps the intended behavior for sent messages while making received and legacy/missing-direction messages fail safe. Recipient, Reply All CC handling, subject, quoted content, attachments, drafts, and New Email behavior are unchanged.

`activities.py` was already near the repository's 500-line module limit, so its existing attachment/translation helpers were moved unchanged into `activity_helpers.py` alongside the batched direction lookup.

## Validation

Compared on the untouched `upstream/develop` base and the patched tree:

- full pre-commit suite (`pre-commit run --all-files`)
- frontend ESLint and Oxlint
- frontend Vitest coverage: 129/129 tests passed
- frontend production build
- full CRM server suite with coverage on a fresh local site
- existing Playwright email test: 2/2 setup/email tests passed
- isolated browser matrix covering New Email; Reply and Reply All for Received and Sent communications; multiple and single authorized identities; and a missing direction value

The browser matrix used only local `example.com` fixtures and did not click Send. The existing Playwright test created a local Communication using the repository's dummy localhost account; no real SMTP integration or external delivery was exercised.

## Backport

The regression is also present on the stable branch. Please consider this for the normal `main-hotfix` backport flow after merge.
