### PR TITLE
fix: guard filters before list params initialize

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -511,6 +511,11 @@ function getParams() {
   }
 }
 
+/** Return cloned active filters even before resource params initialize. */
+function getCurrentFilters() {
+  return { ...(list.value.params?.filters ?? getParams().filters) }
+}
+
 list.value = createResource({
   url: 'crm.api.doc.get_data',
   params: getParams(),
@@ -833,7 +838,7 @@ function setupNewQuickFilters(filters) {
 }
 
 function applyQuickFilter(filter, value) {
-  let filters = { ...list.value.params.filters }
+  let filters = getCurrentFilters()
   let field = filter.fieldname
   if (value) {
     if (
@@ -1283,7 +1288,7 @@ function applyFilter({ event, idx, column, item, firstColumn }) {
   event.stopPropagation()
   event.preventDefault()
 
-  let filters = { ...list.value.params.filters }
+  let filters = getCurrentFilters()
 
   let value = item.name ?? item.label ?? item
 
@@ -1308,7 +1313,7 @@ function applyFilter({ event, idx, column, item, firstColumn }) {
 }
 
 function applyLikeFilter() {
-  let filters = { ...list.value.params.filters }
+  let filters = getCurrentFilters()
   if (!filters._liked_by) {
     filters['_liked_by'] = ['LIKE', '%@me%']
   } else {


### PR DESCRIPTION
## Summary

Prevent quick-filter actions from throwing when the list resource has not
initialized `params` yet.

Fixes #2509.

## Root cause

`ViewControls.vue` directly spread `list.value.params.filters` in three paths:

- Applying a quick filter
- Filtering by a list cell value
- Toggling the "liked by me" filter

The list resource initializes asynchronously. Immediately after opening or
switching a view, `list.value.params` can be null, so those handlers throw:

```text
TypeError: Cannot read properties of null (reading 'filters')
```

Using the main filter dialog first can hide the problem because it initializes
params as a side effect.

## Fix

Add one initialization-boundary helper and use it in all three handlers:

```js
function getCurrentFilters() {
  return { ...(list.value.params?.filters ?? getParams().filters) }
}
```

This is preferable to three independent null guards because it:

- Keeps the resource-initialization rule in one place.
- Clones filters before mutation.
- Preserves filters from the active view when resource params are unavailable.
- Uses a nullish fallback without changing initialized behavior.

## Validation

- `yarn test:run`: 7 test files passed, 129 tests passed.
- `yarn prettier --check src/components/ViewControls.vue`: passed.
- A downstream production build with the same component change passed,
  including PWA generation.

