### PR TITLE
fix: guard filters before list params initialize

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -520,6 +520,11 @@ function getParams() {
   }
 }
 
+/** Return cloned active filters even before resource params initialize. */
+function getCurrentFilters() {
+  return { ...(list.value.params?.filters ?? getParams().filters) }
+}
+
 list.value = createResource({
   url: 'crm.api.doc.get_data',
   params: getParams(),
@@ -864,7 +869,7 @@ function setupNewQuickFilters(filters) {
 }
 
 function applyQuickFilter(filter, value) {
-  let filters = { ...list.value.params.filters }
+  let filters = getCurrentFilters()
   let field = filter.fieldname
   if (value) {
     if (
@@ -1314,7 +1319,7 @@ function applyFilter({ event, idx, column, item, firstColumn }) {
   event.stopPropagation()
   event.preventDefault()
 
-  let filters = { ...list.value.params.filters }
+  let filters = getCurrentFilters()
 
   let value = item.name ?? item.label ?? item
 
@@ -1339,7 +1344,7 @@ function applyFilter({ event, idx, column, item, firstColumn }) {
 }
 
 function applyLikeFilter() {
-  let filters = { ...list.value.params.filters }
+  let filters = getCurrentFilters()
   if (!filters._liked_by) {
     filters['_liked_by'] = ['LIKE', '%@me%']
   } else {


### PR DESCRIPTION
## Summary

Prevent quick-filter actions from throwing when the list resource has not
initialized `params` yet.

Fixes #2509.

This replaces #2531, which Mergify closed because it targeted the stable
`main` branch. This branch is based on `develop`.

## Root cause

`ViewControls.vue` directly spread `list.value.params.filters` in three paths:

- Applying a quick filter
- Filtering by a list cell value
- Toggling the "liked by me" filter

The Vue component can render and accept input while the Frappe UI list resource
is still initializing. During that window, the reactive resource exists but
`list.value.params` can be null. JavaScript therefore throws while evaluating
`params.filters`, before the handler reaches `updateFilter()`.

Using the main filter dialog first can hide the problem because that path
initializes params as a side effect.

## Fix

Add one initialization-boundary helper and use it in all three handlers:

```js
function getCurrentFilters() {
  return { ...(list.value.params?.filters ?? getParams().filters) }
}
```

This approach:

- Keeps the asynchronous initialization rule in one place.
- Clones filters before a handler modifies them.
- Uses initialized resource filters when available.
- Reconstructs filters from the active view while resource params are absent,
  preserving existing view state rather than falling back to an empty object.
- Leaves the existing `updateFilter()` and resource reload workflow unchanged.

## Validation

- `yarn test:run`: 7 test files passed, 129 tests passed.
- `yarn prettier --check src/components/ViewControls.vue`: passed.
- A downstream production build with the same component change passed,
  including PWA generation.

