### PR TITLE
fix(whatsapp): skip notification when no user is assigned

### DIFF
--- a/crm/fcrm/doctype/crm_notification/crm_notification.py
+++ b/crm/fcrm/doctype/crm_notification/crm_notification.py
@@ -60,7 +60,7 @@ def notify_user(notification):
 	Notify the assigned user
 	"""
 	notification = frappe._dict(notification)
-	if notification.owner == notification.assigned_to:
+	if not notification.assigned_to or notification.owner == notification.assigned_to:
 		return
 
 	values = frappe._dict(


### PR DESCRIPTION
notify_user() required to_user, so CRM Notification.insert() raised a MandatoryError whenever a WhatsApp message arrived on a lead/deal with no assigned agent (assigned_to is None). Return early in that case instead of attempting the insert.

Fixes #1715