### PR TITLE
fix: validate contact email/mobile and rework the primary dropdown

### DIFF
--- a/e2e/pages/lead.page.ts
+++ b/e2e/pages/lead.page.ts
@@ -47,7 +47,9 @@ export class LeadPage {
 		const editor = this.page.locator('[contenteditable="true"]').last()
 		await editor.click()
 		await editor.fill(body)
-		await this.page.getByRole('button', { name: 'Send', exact: true }).click()
+		// The label carries a platform-dependent shortcut hint, e.g. "Send (⌘⏎)".
+		// Anchored both ends so it can't match "Send an Email" / "Send Template".
+		await this.page.getByRole('button', { name: /^Send(\s*\(.*\))?$/ }).click()
 	}
 
 	/** Switch to a named tab in the activity area (Activity, Emails, ...). */

--- a/frontend/src/components/PrimaryDropdown.vue
+++ b/frontend/src/components/PrimaryDropdown.vue
@@ -20,7 +20,7 @@
     </template>
     <template #body>
       <div
-        class="my-2 p-1.5 min-w-72 space-y-1.5 divide-y divide-outline-gray-1 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
+        class="my-2 p-1.5 w-72 space-y-1.5 divide-y divide-outline-gray-1 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
       >
         <div>
           <PrimaryDropdownItem

--- a/frontend/src/components/PrimaryDropdown.vue
+++ b/frontend/src/components/PrimaryDropdown.vue
@@ -81,8 +81,11 @@ function addDraft() {
     value: '',
     selected: false,
     onSave: async (option) => {
-      await props.onCreate?.(option.value)
-      draft.value = null
+      // Clear the draft only once the create succeeds; on failure it stays
+      // so the value remains editable. Returns success to the item.
+      const created = await props.onCreate?.(option.value)
+      if (created) draft.value = null
+      return created
     },
     onDelete: () => (draft.value = null),
   }

--- a/frontend/src/components/PrimaryDropdown.vue
+++ b/frontend/src/components/PrimaryDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <Popover class="w-full">
+  <Popover class="w-full min-w-0">
     <template #target="{ isOpen, togglePopover }">
       <Button
         :label="value"
@@ -20,27 +20,35 @@
     </template>
     <template #body>
       <div
-        class="my-2 p-1.5 min-w-40 space-y-1.5 divide-y divide-outline-gray-1 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
+        class="my-2 p-1.5 min-w-72 space-y-1.5 divide-y divide-outline-gray-1 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
       >
         <div>
           <PrimaryDropdownItem
             v-for="option in options"
             :key="option.name || option.value"
             :option="option"
+            :placeholder="itemPlaceholder"
+            :validate="validate"
           />
-          <div v-if="!options?.length">
+          <PrimaryDropdownItem
+            v-if="draft"
+            :option="draft"
+            :placeholder="itemPlaceholder"
+            :validate="validate"
+          />
+          <div v-if="!options.length && !draft">
             <div class="p-1.5 pl-3 pr-4 text-base text-ink-gray-4">
               {{ __('No {0} available', [label]) }}
             </div>
           </div>
         </div>
-        <div class="pt-1.5">
+        <div v-if="!draft" class="pt-1.5">
           <Button
             variant="ghost"
             class="w-full !justify-start"
             :label="__('Create New')"
             iconLeft="plus"
-            @click="create && create()"
+            @click="addDraft"
           />
         </div>
       </div>
@@ -51,19 +59,49 @@
 <script setup>
 import PrimaryDropdownItem from '@/components/PrimaryDropdownItem.vue'
 import { Popover } from 'frappe-ui'
+import { ref } from 'vue'
 
-defineProps({
+const props = defineProps({
   value: { type: [String, Number], default: '' },
   placeholder: { type: String, default: '' },
+  itemPlaceholder: { type: String, default: '' },
   options: { type: Array, default: () => [] },
-  create: { type: Function, default: null },
+  validate: { type: Function, default: null },
+  onCreate: { type: Function, default: null },
   label: { type: String, default: '' },
 })
+
+// A new entry is drafted here, never in the parent's doc, so an incomplete
+// value can never leak into an auto-save. The draft is saved by handing its
+// value to onCreate, and cleared once saved or dismissed.
+const draft = ref(null)
+
+function addDraft() {
+  draft.value = {
+    value: '',
+    selected: false,
+    onSave: async (option) => {
+      await props.onCreate?.(option.value)
+      draft.value = null
+    },
+    onDelete: () => (draft.value = null),
+  }
+}
 </script>
 
 <style scoped>
 .dropdown-button {
   border-color: transparent;
   background: transparent;
+  /* The button is a shrink-0 flex child with min-width:auto, so it overflows
+     its container on long values. Allow it to shrink so the value can truncate. */
+  min-width: 0;
+}
+
+/* Button wraps the value in a `truncate` span; it also needs min-width:0 to
+   shrink in the button's flex row so the long value ellipsizes. */
+:deep(.dropdown-button > span) {
+  min-width: 0;
+  flex: 1;
 }
 </style>

--- a/frontend/src/components/PrimaryDropdownItem.vue
+++ b/frontend/src/components/PrimaryDropdownItem.vue
@@ -5,16 +5,19 @@
     <div class="flex flex-1 items-center justify-between gap-7">
       <!-- v-if, not v-show: TextInput has a fragment root when it has no
            label/description/error, and Vue drops directives on such roots -->
-      <div v-if="!editMode">{{ option.value }}</div>
-      <TextInput
-        v-else
-        ref="inputRef"
-        v-model="localOption.value"
-        class="w-full"
-        :placeholder="option.placeholder"
-        @blur.stop="saveOption"
-        @keydown.enter.stop="(e) => e.target.blur()"
-      />
+      <div v-if="!editMode">{{ localOption.value }}</div>
+      <div v-else class="flex w-full flex-col gap-1">
+        <TextInput
+          ref="inputRef"
+          v-model="localOption.value"
+          :placeholder="option.placeholder"
+          @blur.stop="saveOption"
+          @keydown.enter.stop="(e) => e.target.blur()"
+        />
+        <div v-if="errorMessage" class="text-xs font-medium text-ink-red-6">
+          {{ errorMessage }}
+        </div>
+      </div>
 
       <div class="actions flex items-center justify-center">
         <Button
@@ -75,6 +78,12 @@ watch(
 const editMode = ref(false)
 const isNew = ref(false)
 const inputRef = ref(null)
+const errorMessage = ref('')
+
+watch(
+  () => localOption.value,
+  () => (errorMessage.value = ''),
+)
 
 onMounted(() => {
   if (!props.option?.value) {
@@ -91,13 +100,19 @@ const toggleEditMode = () => {
   }
 }
 
-const saveOption = (e) => {
-  if (!e.target.value) return
+const saveOption = () => {
+  const value = localOption.value?.trim()
+  if (!value) return
+
+  const error = props.option.validate?.(value)
+  if (error) {
+    errorMessage.value = error
+    nextTick(() => inputRef.value?.el?.focus())
+    return
+  }
+
+  props.option.onSave({ ...props.option, value }, isNew.value)
   toggleEditMode()
-  props.option.onSave(
-    { ...props.option, value: localOption.value },
-    isNew.value,
-  )
   isNew.value = false
 }
 </script>

--- a/frontend/src/components/PrimaryDropdownItem.vue
+++ b/frontend/src/components/PrimaryDropdownItem.vue
@@ -87,6 +87,7 @@ const editMode = ref(false)
 const isNew = ref(false)
 const inputRef = ref(null)
 const errorMessage = ref('')
+const saving = ref(false)
 
 watch(
   () => localOption.value,
@@ -136,7 +137,11 @@ const cancelEdit = () => {
   editMode.value = false
 }
 
-const saveOption = () => {
+const saveOption = async () => {
+  // Blur and the Save click both fire this; guard so a create/update is
+  // issued once, never duplicated.
+  if (saving.value) return
+
   const value = localOption.value?.trim()
   if (!value) return
 
@@ -147,8 +152,26 @@ const saveOption = () => {
     return
   }
 
-  props.option.onSave({ ...props.option, value }, isNew.value)
-  toggleEditMode()
-  isNew.value = false
+  saving.value = true
+  try {
+    const saved = await props.option.onSave(
+      { ...props.option, value },
+      isNew.value,
+    )
+    // Only leave edit mode once the value is actually persisted; a failed
+    // save stays editable instead of showing an unsaved value as saved.
+    if (!saved) {
+      errorMessage.value = __('Could not save, please try again')
+      nextTick(() => inputRef.value?.el?.focus())
+      return
+    }
+    editMode.value = false
+    isNew.value = false
+  } catch {
+    errorMessage.value = __('Could not save, please try again')
+    nextTick(() => inputRef.value?.el?.focus())
+  } finally {
+    saving.value = false
+  }
 }
 </script>

--- a/frontend/src/components/PrimaryDropdownItem.vue
+++ b/frontend/src/components/PrimaryDropdownItem.vue
@@ -10,7 +10,7 @@
   >
     <!-- Prefix reserved on every row so text stays aligned; the primary row
          shows the indicator. Clicking a row makes it primary. -->
-    <div class="flex w-4 shrink-0 items-center justify-center">
+    <div class="flex h-7 w-4 shrink-0 items-center justify-center">
       <Tooltip v-if="option.selected" :text="__('Primary')">
         <span class="lucide-check size-4 text-ink-gray-8" aria-hidden="true" />
       </Tooltip>

--- a/frontend/src/components/PrimaryDropdownItem.vue
+++ b/frontend/src/components/PrimaryDropdownItem.vue
@@ -1,16 +1,31 @@
 <template>
   <div
-    class="group flex w-full items-center justify-between rounded bg-transparent p-1 pl-2 text-base text-ink-gray-8 transition-colors hover:bg-surface-gray-3 active:bg-surface-gray-4"
+    class="group flex w-full gap-2 rounded p-1 pl-2 text-base text-ink-gray-8 transition-colors"
+    :class="
+      editMode
+        ? 'items-start'
+        : 'items-center cursor-pointer hover:bg-surface-gray-3 active:bg-surface-gray-4'
+    "
+    @click="selectRow"
   >
-    <div class="flex flex-1 items-center justify-between gap-7">
+    <!-- Prefix reserved on every row so text stays aligned; the primary row
+         shows the indicator. Clicking a row makes it primary. -->
+    <div class="flex w-4 shrink-0 items-center justify-center">
+      <Tooltip v-if="option.selected" :text="__('Primary')">
+        <span class="lucide-check size-4 text-ink-gray-8" aria-hidden="true" />
+      </Tooltip>
+    </div>
+
+    <div class="min-w-0 flex-1">
       <!-- v-if, not v-show: TextInput has a fragment root when it has no
            label/description/error, and Vue drops directives on such roots -->
-      <div v-if="!editMode">{{ localOption.value }}</div>
-      <div v-else class="flex w-full flex-col gap-1">
+      <div v-if="!editMode" class="truncate">{{ localOption.value }}</div>
+      <div v-else class="flex max-w-40 flex-col gap-1">
         <TextInput
           ref="inputRef"
           v-model="localOption.value"
-          :placeholder="option.placeholder"
+          class="w-full"
+          :placeholder="placeholder"
           @blur.stop="saveOption"
           @keydown.enter.stop="(e) => e.target.blur()"
         />
@@ -18,54 +33,47 @@
           {{ errorMessage }}
         </div>
       </div>
-
-      <div class="actions flex items-center justify-center">
-        <Button
-          v-if="editMode"
-          variant="ghost"
-          :label="__('Save')"
-          class="opacity-0 hover:bg-surface-gray-4 group-hover:opacity-100"
-          @click="saveOption"
-        />
-        <Button
-          v-if="!isNew && !option.selected"
-          :tooltip="__('Set As Primary')"
-          variant="ghost"
-          :icon="SuccessIcon"
-          class="opacity-0 hover:bg-surface-gray-4 group-hover:opacity-100"
-          @click="option.onClick"
-        />
-        <Button
-          v-if="!editMode"
-          :tooltip="__('Edit')"
-          variant="ghost"
-          :icon="EditIcon"
-          class="opacity-0 hover:bg-surface-gray-4 group-hover:opacity-100"
-          @click="toggleEditMode"
-        />
-        <Button
-          :tooltip="__('Delete')"
-          variant="ghost"
-          icon="lucide-x"
-          class="opacity-0 hover:bg-surface-gray-4 group-hover:opacity-100"
-          @click="() => option.onDelete(option, isNew)"
-        />
-      </div>
     </div>
-    <div v-if="option.selected">
-      <span class="lucide-check text-ink-gray-5 h-4 w-6" aria-hidden="true" />
+
+    <div v-if="!editMode" class="shrink-0">
+      <Dropdown
+        :options="menuOptions"
+        :side="isMobileView ? 'bottom' : 'right'"
+        :align="isMobileView ? 'end' : 'start'"
+        offset="2"
+      >
+        <template #default="{ open }">
+          <button
+            class="flex cursor-pointer rounded p-1 text-ink-gray-6 transition-colors hover:bg-surface-gray-4"
+            :class="open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+            @click.stop
+          >
+            <FeatherIcon name="more-vertical" class="size-4" />
+          </button>
+        </template>
+      </Dropdown>
+    </div>
+    <div v-else class="flex shrink-0 items-center">
+      <Button variant="ghost" :label="__('Save')" @click="saveOption" />
+      <Button
+        variant="ghost"
+        icon="lucide-x"
+        :tooltip="__('Cancel')"
+        @click="cancelEdit"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
-import SuccessIcon from '@/components/Icons/SuccessIcon.vue'
-import EditIcon from '@/components/Icons/EditIcon.vue'
-import { TextInput } from 'frappe-ui'
+import { Dropdown, TextInput, Tooltip } from 'frappe-ui'
+import { isMobileView } from '@/composables/settings'
 import { nextTick, ref, onMounted, reactive, watch } from 'vue'
 
 const props = defineProps({
-  option: { type: Object, default: () => {} },
+  option: { type: Object, default: () => ({}) },
+  placeholder: { type: String, default: '' },
+  validate: { type: Function, default: null },
 })
 
 const localOption = reactive({ ...props.option })
@@ -93,6 +101,25 @@ onMounted(() => {
   }
 })
 
+const menuOptions = [
+  {
+    label: __('Edit'),
+    icon: 'lucide-square-pen',
+    onClick: () => toggleEditMode(),
+  },
+  {
+    label: __('Delete'),
+    icon: 'lucide-trash-2',
+    theme: 'red',
+    onClick: () => props.option.onDelete(props.option, isNew.value),
+  },
+]
+
+const selectRow = () => {
+  if (editMode.value || isNew.value) return
+  if (!props.option.selected) props.option.onClick?.()
+}
+
 const toggleEditMode = () => {
   editMode.value = !editMode.value
   if (editMode.value) {
@@ -100,11 +127,20 @@ const toggleEditMode = () => {
   }
 }
 
+const cancelEdit = () => {
+  if (isNew.value) {
+    props.option.onDelete(props.option, true)
+    return
+  }
+  localOption.value = props.option.value
+  editMode.value = false
+}
+
 const saveOption = () => {
   const value = localOption.value?.trim()
   if (!value) return
 
-  const error = props.option.validate?.(value)
+  const error = props.validate?.(value)
   if (error) {
     errorMessage.value = error
     nextTick(() => inputRef.value?.el?.focus())

--- a/frontend/src/components/PrimaryDropdownItem.vue
+++ b/frontend/src/components/PrimaryDropdownItem.vue
@@ -54,11 +54,19 @@
       </Dropdown>
     </div>
     <div v-else class="flex shrink-0 items-center">
-      <Button variant="ghost" :label="__('Save')" @click="saveOption" />
+      <!-- mousedown.prevent keeps the input from blurring when a button is
+           clicked, so Cancel discards instead of the blur-save persisting it -->
+      <Button
+        variant="ghost"
+        :label="__('Save')"
+        @mousedown.prevent
+        @click="saveOption"
+      />
       <Button
         variant="ghost"
         icon="lucide-x"
         :tooltip="__('Cancel')"
+        @mousedown.prevent
         @click="cancelEdit"
       />
     </div>
@@ -129,18 +137,20 @@ const toggleEditMode = () => {
 }
 
 const cancelEdit = () => {
+  // Exit edit mode first so a blur fired while the input unmounts is a no-op.
+  editMode.value = false
   if (isNew.value) {
     props.option.onDelete(props.option, true)
     return
   }
   localOption.value = props.option.value
-  editMode.value = false
 }
 
 const saveOption = async () => {
   // Blur and the Save click both fire this; guard so a create/update is
-  // issued once, never duplicated.
-  if (saving.value) return
+  // issued once, never duplicated. Also bail once edit mode has exited (e.g.
+  // Cancel), so an unmount blur can't persist a discarded value.
+  if (saving.value || !editMode.value) return
 
   const value = localOption.value?.trim()
   if (!value) return

--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -106,8 +106,10 @@
                           v-else-if="field.fieldtype === 'Dropdown'"
                           :value="doc[field.fieldname]"
                           :placeholder="field.placeholder"
+                          :itemPlaceholder="field.itemPlaceholder"
                           :options="field.options"
-                          :create="field.create"
+                          :validate="field.validate"
+                          :onCreate="field.onCreate"
                           :label="field.label"
                         />
                         <FormControl

--- a/frontend/src/composables/useContactFields.ts
+++ b/frontend/src/composables/useContactFields.ts
@@ -30,10 +30,14 @@ interface DropdownOption {
 
 type SidePanelField = Record<string, unknown> & { fieldname?: string }
 
-export function contactFieldTransform(contact: ContactDocument) {
-  async function reloadWithToast() {
+export function useContactFields(contact: ContactDocument) {
+  // 'email' | 'mobile_no' (setAsPrimary) and 'email' | 'phone' (createNew)
+  const isEmailField = (field: string) => field === 'email'
+  const isEmailDoctype = (doctype: string) => doctype === 'Contact Email'
+
+  async function reloadWithToast(message: string) {
     await contact.reload()
-    toast.success(__('Contact Updated'))
+    toast.success(message)
   }
 
   async function setAsPrimary(field: string, value: string) {
@@ -42,7 +46,12 @@ export function contactFieldTransform(contact: ContactDocument) {
       field,
       value,
     })
-    if (updated) reloadWithToast()
+    if (updated)
+      reloadWithToast(
+        isEmailField(field)
+          ? __('Primary email address updated')
+          : __('Primary mobile number updated'),
+      )
   }
 
   async function createNew(field: string, value: string) {
@@ -52,7 +61,12 @@ export function contactFieldTransform(contact: ContactDocument) {
       field,
       value,
     })
-    if (created) reloadWithToast()
+    if (created)
+      reloadWithToast(
+        isEmailField(field)
+          ? __('Email address added')
+          : __('Mobile number added'),
+      )
     return Boolean(created)
   }
 
@@ -68,13 +82,22 @@ export function contactFieldTransform(contact: ContactDocument) {
       fieldname,
       value,
     })
-    if (updated) reloadWithToast()
+    if (updated)
+      reloadWithToast(
+        isEmailDoctype(doctype)
+          ? __('Email address updated')
+          : __('Mobile number updated'),
+      )
     return Boolean(updated)
   }
 
   async function deleteOption(doctype: string, name: string) {
     await call('frappe.client.delete', { doctype, name })
-    reloadWithToast()
+    reloadWithToast(
+      isEmailDoctype(doctype)
+        ? __('Email address removed')
+        : __('Mobile number removed'),
+    )
   }
 
   const validateEmailOption = (value: string) =>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,3 +22,10 @@
 			prose-th:relative;
   }
 }
+
+/* Reka menu content (e.g. the kebab menu inside PrimaryDropdown) portals to
+   <body> without a z-index, so it falls behind frappe-ui Popover content
+   (z-[100]). Lift menus above popovers so nested menus stay visible. */
+.menu-content {
+  z-index: 101;
+}

--- a/frontend/src/pages/Contact.vue
+++ b/frontend/src/pages/Contact.vue
@@ -180,7 +180,12 @@ import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
 import CustomActions from '@/components/CustomActions.vue'
-import { validateIsImageFile, setupCustomizations } from '@/utils'
+import {
+  validateIsImageFile,
+  setupCustomizations,
+  validateEmail,
+  validatePhone,
+} from '@/utils'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
@@ -235,6 +240,27 @@ const {
 } = useDocument('Contact', props.contactId)
 
 const canDelete = computed(() => permissions.data?.permissions?.delete || false)
+
+// UI-only draft rows for new emails/phones. Kept out of contact.doc so an
+// incomplete entry never leaks into an auto-save (Contact.validate would crash
+// on a child row whose email_id/phone is empty).
+const emailDrafts = ref([])
+const phoneDrafts = ref([])
+let draftCounter = 0
+
+function addDraft(drafts) {
+  drafts.value.push({ name: `new-${++draftCounter}`, value: '' })
+}
+
+function removeDraft(drafts, name) {
+  drafts.value = drafts.value.filter((d) => d.name !== name)
+}
+
+const validateEmailOption = (value) =>
+  validateEmail(value) ? '' : __('Please enter a valid email address')
+
+const validatePhoneOption = (value) =>
+  validatePhone(value) ? '' : __('Please enter a valid phone number')
 
 onMounted(async () => {
   if (contact.doc) await triggerOnRender()
@@ -340,40 +366,39 @@ const parsedSections = computed(() => {
             ...field,
             read_only: false,
             fieldtype: 'Dropdown',
-            options: (contact.doc?.email_ids || []).map((email) => ({
-              name: email.name,
-              value: email.email_id,
-              selected: email.email_id === contact.doc.email_id,
-              placeholder: 'john@doe.com',
-              onClick: () => setAsPrimary('email', email.email_id),
-              onSave: (option, isNew) =>
-                isNew
-                  ? createNew('email', option.value)
-                  : editOption(
-                      'Contact Email',
-                      option.name,
-                      'email_id',
-                      option.value,
-                    ),
-              onDelete: async (option, isNew) => {
-                contact.doc.email_ids = contact.doc.email_ids.filter(
-                  (e) => e.name !== option.name,
-                )
-                if (!isNew) await deleteOption('Contact Email', option.name)
-              },
-            })),
-            create: () => {
-              // Add a temporary new option locally (mirrors original behavior)
-              contact.doc.email_ids = [
-                ...(contact.doc.email_ids || []),
-                {
-                  name: 'new-1',
-                  value: '',
-                  selected: false,
-                  isNew: true,
+            options: [
+              ...(contact.doc?.email_ids || []).map((email) => ({
+                name: email.name,
+                value: email.email_id,
+                selected: email.email_id === contact.doc.email_id,
+                placeholder: 'john@doe.com',
+                validate: validateEmailOption,
+                onClick: () => setAsPrimary('email', email.email_id),
+                onSave: (option) =>
+                  editOption(
+                    'Contact Email',
+                    option.name,
+                    'email_id',
+                    option.value,
+                  ),
+                onDelete: async (option) => {
+                  contact.doc.email_ids = contact.doc.email_ids.filter(
+                    (e) => e.name !== option.name,
+                  )
+                  await deleteOption('Contact Email', option.name)
                 },
-              ]
-            },
+              })),
+              ...emailDrafts.value.map((draft) => ({
+                name: draft.name,
+                value: draft.value,
+                selected: false,
+                placeholder: 'john@doe.com',
+                validate: validateEmailOption,
+                onSave: (option) => createNew('email', option.value),
+                onDelete: () => removeDraft(emailDrafts, draft.name),
+              })),
+            ],
+            create: () => addDraft(emailDrafts),
           }
         }
         if (field.fieldname === 'mobile_no') {
@@ -381,38 +406,37 @@ const parsedSections = computed(() => {
             ...field,
             read_only: false,
             fieldtype: 'Dropdown',
-            options: (contact.doc?.phone_nos || []).map((phone) => ({
-              name: phone.name,
-              value: phone.phone,
-              selected: phone.phone === contact.doc.mobile_no,
-              onClick: () => setAsPrimary('mobile_no', phone.phone),
-              onSave: (option, isNew) =>
-                isNew
-                  ? createNew('phone', option.value)
-                  : editOption(
-                      'Contact Phone',
-                      option.name,
-                      'phone',
-                      option.value,
-                    ),
-              onDelete: async (option, isNew) => {
-                contact.doc.phone_nos = contact.doc.phone_nos.filter(
-                  (p) => p.name !== option.name,
-                )
-                if (!isNew) await deleteOption('Contact Phone', option.name)
-              },
-            })),
-            create: () => {
-              contact.doc.phone_nos = [
-                ...(contact.doc.phone_nos || []),
-                {
-                  name: 'new-1',
-                  value: '',
-                  selected: false,
-                  isNew: true,
+            options: [
+              ...(contact.doc?.phone_nos || []).map((phone) => ({
+                name: phone.name,
+                value: phone.phone,
+                selected: phone.phone === contact.doc.mobile_no,
+                validate: validatePhoneOption,
+                onClick: () => setAsPrimary('mobile_no', phone.phone),
+                onSave: (option) =>
+                  editOption(
+                    'Contact Phone',
+                    option.name,
+                    'phone',
+                    option.value,
+                  ),
+                onDelete: async (option) => {
+                  contact.doc.phone_nos = contact.doc.phone_nos.filter(
+                    (p) => p.name !== option.name,
+                  )
+                  await deleteOption('Contact Phone', option.name)
                 },
-              ]
-            },
+              })),
+              ...phoneDrafts.value.map((draft) => ({
+                name: draft.name,
+                value: draft.value,
+                selected: false,
+                validate: validatePhoneOption,
+                onSave: (option) => createNew('phone', option.value),
+                onDelete: () => removeDraft(phoneDrafts, draft.name),
+              })),
+            ],
+            create: () => addDraft(phoneDrafts),
           }
         }
         if (field.fieldname === 'address') {
@@ -461,6 +485,8 @@ async function createNew(field, value) {
     value,
   })
   if (d) {
+    if (field === 'email') emailDrafts.value = []
+    else phoneDrafts.value = []
     contact.reload()
     toast.success(__('Contact Updated'))
   }

--- a/frontend/src/pages/Contact.vue
+++ b/frontend/src/pages/Contact.vue
@@ -180,12 +180,8 @@ import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
 import CustomActions from '@/components/CustomActions.vue'
-import {
-  validateIsImageFile,
-  setupCustomizations,
-  validateEmail,
-  validatePhone,
-} from '@/utils'
+import { validateIsImageFile, setupCustomizations } from '@/utils'
+import { contactFieldTransform } from '@/utils/contactFields'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
@@ -241,26 +237,7 @@ const {
 
 const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
-// UI-only draft rows for new emails/phones. Kept out of contact.doc so an
-// incomplete entry never leaks into an auto-save (Contact.validate would crash
-// on a child row whose email_id/phone is empty).
-const emailDrafts = ref([])
-const phoneDrafts = ref([])
-let draftCounter = 0
-
-function addDraft(drafts) {
-  drafts.value.push({ name: `new-${++draftCounter}`, value: '' })
-}
-
-function removeDraft(drafts, name) {
-  drafts.value = drafts.value.filter((d) => d.name !== name)
-}
-
-const validateEmailOption = (value) =>
-  validateEmail(value) ? '' : __('Please enter a valid email address')
-
-const validatePhoneOption = (value) =>
-  validatePhone(value) ? '' : __('Please enter a valid phone number')
+const transformField = contactFieldTransform(contact)
 
 onMounted(async () => {
   if (contact.doc) await triggerOnRender()
@@ -360,96 +337,7 @@ const parsedSections = computed(() => {
         field.label = fieldLabelMap[field.fieldname] || field.label
         field.placeholder =
           fieldPlaceholderMap[field.fieldname] || field.placeholder
-
-        if (field.fieldname === 'email_id') {
-          return {
-            ...field,
-            read_only: false,
-            fieldtype: 'Dropdown',
-            options: [
-              ...(contact.doc?.email_ids || []).map((email) => ({
-                name: email.name,
-                value: email.email_id,
-                selected: email.email_id === contact.doc.email_id,
-                placeholder: 'john@doe.com',
-                validate: validateEmailOption,
-                onClick: () => setAsPrimary('email', email.email_id),
-                onSave: (option) =>
-                  editOption(
-                    'Contact Email',
-                    option.name,
-                    'email_id',
-                    option.value,
-                  ),
-                onDelete: async (option) => {
-                  contact.doc.email_ids = contact.doc.email_ids.filter(
-                    (e) => e.name !== option.name,
-                  )
-                  await deleteOption('Contact Email', option.name)
-                },
-              })),
-              ...emailDrafts.value.map((draft) => ({
-                name: draft.name,
-                value: draft.value,
-                selected: false,
-                placeholder: 'john@doe.com',
-                validate: validateEmailOption,
-                onSave: (option) => createNew('email', option.value),
-                onDelete: () => removeDraft(emailDrafts, draft.name),
-              })),
-            ],
-            create: () => addDraft(emailDrafts),
-          }
-        }
-        if (field.fieldname === 'mobile_no') {
-          return {
-            ...field,
-            read_only: false,
-            fieldtype: 'Dropdown',
-            options: [
-              ...(contact.doc?.phone_nos || []).map((phone) => ({
-                name: phone.name,
-                value: phone.phone,
-                selected: phone.phone === contact.doc.mobile_no,
-                validate: validatePhoneOption,
-                onClick: () => setAsPrimary('mobile_no', phone.phone),
-                onSave: (option) =>
-                  editOption(
-                    'Contact Phone',
-                    option.name,
-                    'phone',
-                    option.value,
-                  ),
-                onDelete: async (option) => {
-                  contact.doc.phone_nos = contact.doc.phone_nos.filter(
-                    (p) => p.name !== option.name,
-                  )
-                  await deleteOption('Contact Phone', option.name)
-                },
-              })),
-              ...phoneDrafts.value.map((draft) => ({
-                name: draft.name,
-                value: draft.value,
-                selected: false,
-                validate: validatePhoneOption,
-                onSave: (option) => createNew('phone', option.value),
-                onDelete: () => removeDraft(phoneDrafts, draft.name),
-              })),
-            ],
-            create: () => addDraft(phoneDrafts),
-          }
-        }
-        if (field.fieldname === 'address') {
-          return {
-            ...field,
-            create: (_value, close) => {
-              showAddressModal()
-              close?.()
-            },
-            edit: (address) => showAddressModal(address),
-          }
-        }
-        return field
+        return transformField(field, { showAddressModal })
       }),
     })),
   }))
@@ -463,55 +351,6 @@ const fieldLabelMap = {
 const fieldPlaceholderMap = {
   mobile_no: __('Add Mobile Number...'),
   company_name: __('Add Organization...'),
-}
-
-async function setAsPrimary(field, value) {
-  let d = await call('crm.api.contact.set_as_primary', {
-    contact: contact.doc.name,
-    field,
-    value,
-  })
-  if (d) {
-    contact.reload()
-    toast.success(__('Contact Updated'))
-  }
-}
-
-async function createNew(field, value) {
-  if (!value) return
-  let d = await call('crm.api.contact.create_new', {
-    contact: contact.doc.name,
-    field,
-    value,
-  })
-  if (d) {
-    if (field === 'email') emailDrafts.value = []
-    else phoneDrafts.value = []
-    contact.reload()
-    toast.success(__('Contact Updated'))
-  }
-}
-
-async function editOption(doctype, name, fieldname, value) {
-  let d = await call('frappe.client.set_value', {
-    doctype,
-    name,
-    fieldname,
-    value,
-  })
-  if (d) {
-    contact.reload()
-    toast.success(__('Contact Updated'))
-  }
-}
-
-async function deleteOption(doctype, name) {
-  await call('frappe.client.delete', {
-    doctype,
-    name,
-  })
-  await contact.reload()
-  toast.success(__('Contact Updated'))
 }
 
 const { getFormattedCurrency } = getMeta('CRM Deal')

--- a/frontend/src/pages/Contact.vue
+++ b/frontend/src/pages/Contact.vue
@@ -181,7 +181,7 @@ import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
 import CustomActions from '@/components/CustomActions.vue'
 import { validateIsImageFile, setupCustomizations } from '@/utils'
-import { contactFieldTransform } from '@/utils/contactFields'
+import { useContactFields } from '@/composables/useContactFields'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
@@ -237,7 +237,7 @@ const {
 
 const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
-const transformField = contactFieldTransform(contact)
+const transformField = useContactFields(contact)
 
 onMounted(async () => {
   if (contact.doc) await triggerOnRender()

--- a/frontend/src/pages/MobileContact.vue
+++ b/frontend/src/pages/MobileContact.vue
@@ -167,7 +167,7 @@ import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
 import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
-import { validateIsImageFile } from '@/utils'
+import { validateIsImageFile, validateEmail, validatePhone } from '@/utils'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
@@ -217,6 +217,27 @@ const {
 } = useDocument('Contact', props.contactId)
 
 const canDelete = computed(() => permissions.data?.permissions?.delete || false)
+
+// UI-only draft rows for new emails/phones. Kept out of contact.doc so an
+// incomplete entry never leaks into an auto-save (Contact.validate would crash
+// on a child row whose email_id/phone is empty).
+const emailDrafts = ref([])
+const phoneDrafts = ref([])
+let draftCounter = 0
+
+function addDraft(drafts) {
+  drafts.value.push({ name: `new-${++draftCounter}`, value: '' })
+}
+
+function removeDraft(drafts, name) {
+  drafts.value = drafts.value.filter((d) => d.name !== name)
+}
+
+const validateEmailOption = (value) =>
+  validateEmail(value) ? '' : __('Please enter a valid email address')
+
+const validatePhoneOption = (value) =>
+  validatePhone(value) ? '' : __('Please enter a valid phone number')
 
 onMounted(async () => {
   if (contact.doc) await triggerOnRender()
@@ -338,87 +359,84 @@ function getParsedSections(_sections) {
           return {
             ...field,
             type: 'dropdown',
-            options:
-              contact.doc?.email_ids?.map((email) => {
+            options: [
+              ...(contact.doc?.email_ids?.map((email) => {
                 return {
                   name: email.name,
                   value: email.email_id,
                   selected: email.email_id === contact.doc.email_id,
                   placeholder: 'john@doe.com',
+                  validate: validateEmailOption,
                   onClick: () => {
                     setAsPrimary('email', email.email_id)
                   },
-                  onSave: (option, isNew) => {
-                    if (isNew) {
-                      createNew('email', option.value)
-                    } else {
-                      editOption(
-                        'Contact Email',
-                        option.name,
-                        'email_id',
-                        option.value,
-                      )
-                    }
-                  },
-                  onDelete: async (option, isNew) => {
+                  onSave: (option) =>
+                    editOption(
+                      'Contact Email',
+                      option.name,
+                      'email_id',
+                      option.value,
+                    ),
+                  onDelete: async (option) => {
                     contact.doc.email_ids = contact.doc.email_ids.filter(
                       (email) => email.name !== option.name,
                     )
-                    if (!isNew) await deleteOption('Contact Email', option.name)
+                    await deleteOption('Contact Email', option.name)
                   },
                 }
-              }) || [],
-            create: () => {
-              contact.doc?.email_ids?.push({
-                name: 'new-1',
-                value: '',
+              }) || []),
+              ...emailDrafts.value.map((draft) => ({
+                name: draft.name,
+                value: draft.value,
                 selected: false,
-                isNew: true,
-              })
-            },
+                placeholder: 'john@doe.com',
+                validate: validateEmailOption,
+                onSave: (option) => createNew('email', option.value),
+                onDelete: () => removeDraft(emailDrafts, draft.name),
+              })),
+            ],
+            create: () => addDraft(emailDrafts),
           }
         } else if (field.name === 'mobile_no') {
           return {
             ...field,
             read_only: false,
             fieldtype: 'dropdown',
-            options:
-              contact.doc?.phone_nos?.map((phone) => {
+            options: [
+              ...(contact.doc?.phone_nos?.map((phone) => {
                 return {
                   name: phone.name,
                   value: phone.phone,
                   selected: phone.phone === contact.doc.mobile_no,
+                  validate: validatePhoneOption,
                   onClick: () => {
                     setAsPrimary('mobile_no', phone.phone)
                   },
-                  onSave: (option, isNew) => {
-                    if (isNew) {
-                      createNew('phone', option.value)
-                    } else {
-                      editOption(
-                        'Contact Phone',
-                        option.name,
-                        'phone',
-                        option.value,
-                      )
-                    }
-                  },
-                  onDelete: async (option, isNew) => {
+                  onSave: (option) =>
+                    editOption(
+                      'Contact Phone',
+                      option.name,
+                      'phone',
+                      option.value,
+                    ),
+                  onDelete: async (option) => {
                     contact.doc.phone_nos = contact.doc.phone_nos.filter(
                       (phone) => phone.name !== option.name,
                     )
-                    if (!isNew) await deleteOption('Contact Phone', option.name)
+                    await deleteOption('Contact Phone', option.name)
                   },
                 }
-              }) || [],
-            create: () => {
-              contact.doc?.phone_nos?.push({
-                name: 'new-1',
-                value: '',
+              }) || []),
+              ...phoneDrafts.value.map((draft) => ({
+                name: draft.name,
+                value: draft.value,
                 selected: false,
-                isNew: true,
-              })
-            },
+                validate: validatePhoneOption,
+                onSave: (option) => createNew('phone', option.value),
+                onDelete: () => removeDraft(phoneDrafts, draft.name),
+              })),
+            ],
+            create: () => addDraft(phoneDrafts),
           }
         } else if (field.name === 'address') {
           return {
@@ -459,6 +477,8 @@ async function createNew(field, value) {
     value,
   })
   if (d) {
+    if (field === 'email') emailDrafts.value = []
+    else phoneDrafts.value = []
     contact.reload()
     toast.success(__('Contact Updated'))
   }

--- a/frontend/src/pages/MobileContact.vue
+++ b/frontend/src/pages/MobileContact.vue
@@ -167,7 +167,8 @@ import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
 import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
-import { validateIsImageFile, validateEmail, validatePhone } from '@/utils'
+import { validateIsImageFile } from '@/utils'
+import { contactFieldTransform } from '@/utils/contactFields'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
@@ -218,26 +219,7 @@ const {
 
 const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
-// UI-only draft rows for new emails/phones. Kept out of contact.doc so an
-// incomplete entry never leaks into an auto-save (Contact.validate would crash
-// on a child row whose email_id/phone is empty).
-const emailDrafts = ref([])
-const phoneDrafts = ref([])
-let draftCounter = 0
-
-function addDraft(drafts) {
-  drafts.value.push({ name: `new-${++draftCounter}`, value: '' })
-}
-
-function removeDraft(drafts, name) {
-  drafts.value = drafts.value.filter((d) => d.name !== name)
-}
-
-const validateEmailOption = (value) =>
-  validateEmail(value) ? '' : __('Please enter a valid email address')
-
-const validatePhoneOption = (value) =>
-  validatePhone(value) ? '' : __('Please enter a valid phone number')
+const transformField = contactFieldTransform(contact)
 
 onMounted(async () => {
   if (contact.doc) await triggerOnRender()
@@ -354,156 +336,13 @@ const sections = createResource({
 function getParsedSections(_sections) {
   return _sections.map((section) => {
     section.columns = section.columns.map((column) => {
-      column.fields = column.fields.map((field) => {
-        if (field.fieldname === 'email_id') {
-          return {
-            ...field,
-            type: 'dropdown',
-            options: [
-              ...(contact.doc?.email_ids?.map((email) => {
-                return {
-                  name: email.name,
-                  value: email.email_id,
-                  selected: email.email_id === contact.doc.email_id,
-                  placeholder: 'john@doe.com',
-                  validate: validateEmailOption,
-                  onClick: () => {
-                    setAsPrimary('email', email.email_id)
-                  },
-                  onSave: (option) =>
-                    editOption(
-                      'Contact Email',
-                      option.name,
-                      'email_id',
-                      option.value,
-                    ),
-                  onDelete: async (option) => {
-                    contact.doc.email_ids = contact.doc.email_ids.filter(
-                      (email) => email.name !== option.name,
-                    )
-                    await deleteOption('Contact Email', option.name)
-                  },
-                }
-              }) || []),
-              ...emailDrafts.value.map((draft) => ({
-                name: draft.name,
-                value: draft.value,
-                selected: false,
-                placeholder: 'john@doe.com',
-                validate: validateEmailOption,
-                onSave: (option) => createNew('email', option.value),
-                onDelete: () => removeDraft(emailDrafts, draft.name),
-              })),
-            ],
-            create: () => addDraft(emailDrafts),
-          }
-        } else if (field.name === 'mobile_no') {
-          return {
-            ...field,
-            read_only: false,
-            fieldtype: 'dropdown',
-            options: [
-              ...(contact.doc?.phone_nos?.map((phone) => {
-                return {
-                  name: phone.name,
-                  value: phone.phone,
-                  selected: phone.phone === contact.doc.mobile_no,
-                  validate: validatePhoneOption,
-                  onClick: () => {
-                    setAsPrimary('mobile_no', phone.phone)
-                  },
-                  onSave: (option) =>
-                    editOption(
-                      'Contact Phone',
-                      option.name,
-                      'phone',
-                      option.value,
-                    ),
-                  onDelete: async (option) => {
-                    contact.doc.phone_nos = contact.doc.phone_nos.filter(
-                      (phone) => phone.name !== option.name,
-                    )
-                    await deleteOption('Contact Phone', option.name)
-                  },
-                }
-              }) || []),
-              ...phoneDrafts.value.map((draft) => ({
-                name: draft.name,
-                value: draft.value,
-                selected: false,
-                validate: validatePhoneOption,
-                onSave: (option) => createNew('phone', option.value),
-                onDelete: () => removeDraft(phoneDrafts, draft.name),
-              })),
-            ],
-            create: () => addDraft(phoneDrafts),
-          }
-        } else if (field.name === 'address') {
-          return {
-            ...field,
-            create: (value, close) => {
-              showAddressModal()
-              close()
-            },
-            edit: (address) => showAddressModal(address),
-          }
-        } else {
-          return field
-        }
-      })
+      column.fields = column.fields.map((field) =>
+        transformField(field, { showAddressModal }),
+      )
       return column
     })
     return section
   })
-}
-
-async function setAsPrimary(field, value) {
-  let d = await call('crm.api.contact.set_as_primary', {
-    contact: contact.doc.name,
-    field,
-    value,
-  })
-  if (d) {
-    contact.reload()
-    toast.success(__('Contact Updated'))
-  }
-}
-
-async function createNew(field, value) {
-  if (!value) return
-  let d = await call('crm.api.contact.create_new', {
-    contact: contact.doc.name,
-    field,
-    value,
-  })
-  if (d) {
-    if (field === 'email') emailDrafts.value = []
-    else phoneDrafts.value = []
-    contact.reload()
-    toast.success(__('Contact Updated'))
-  }
-}
-
-async function editOption(doctype, name, fieldname, value) {
-  let d = await call('frappe.client.set_value', {
-    doctype,
-    name,
-    fieldname,
-    value,
-  })
-  if (d) {
-    contact.reload()
-    toast.success(__('Contact Updated'))
-  }
-}
-
-async function deleteOption(doctype, name) {
-  await call('frappe.client.delete', {
-    doctype,
-    name,
-  })
-  await contact.reload()
-  toast.success(__('Contact Updated'))
 }
 
 const { getFormattedCurrency } = getMeta('CRM Deal')

--- a/frontend/src/pages/MobileContact.vue
+++ b/frontend/src/pages/MobileContact.vue
@@ -168,7 +168,7 @@ import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
 import { validateIsImageFile } from '@/utils'
-import { contactFieldTransform } from '@/utils/contactFields'
+import { useContactFields } from '@/composables/useContactFields'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { getView } from '@/utils/view'
 import { useDocument } from '@/data/document'
@@ -219,7 +219,7 @@ const {
 
 const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
-const transformField = contactFieldTransform(contact)
+const transformField = useContactFields(contact)
 
 onMounted(async () => {
   if (contact.doc) await triggerOnRender()

--- a/frontend/src/utils/contactFields.ts
+++ b/frontend/src/utils/contactFields.ts
@@ -46,13 +46,14 @@ export function contactFieldTransform(contact: ContactDocument) {
   }
 
   async function createNew(field: string, value: string) {
-    if (!value) return
+    if (!value) return false
     const created = await call('crm.api.contact.create_new', {
       contact: contact.doc.name,
       field,
       value,
     })
     if (created) reloadWithToast()
+    return Boolean(created)
   }
 
   async function editOption(
@@ -68,6 +69,7 @@ export function contactFieldTransform(contact: ContactDocument) {
       value,
     })
     if (updated) reloadWithToast()
+    return Boolean(updated)
   }
 
   async function deleteOption(doctype: string, name: string) {

--- a/frontend/src/utils/contactFields.ts
+++ b/frontend/src/utils/contactFields.ts
@@ -1,0 +1,157 @@
+import { call, toast } from 'frappe-ui'
+import { validateEmail, validatePhone } from '@/utils'
+
+// Shared email/mobile/address side-panel field logic for Contact.vue (desktop)
+// and MobileContact.vue. Emails and phones render as `Dropdown` fields; new
+// entries are created through PrimaryDropdown's own draft rows, so an incomplete
+// value never reaches contact.doc (and never leaks into an auto-save).
+
+interface ContactDoc {
+  name: string
+  email_id?: string
+  mobile_no?: string
+  email_ids?: { name: string; email_id: string }[]
+  phone_nos?: { name: string; phone: string }[]
+}
+
+interface ContactDocument {
+  doc: ContactDoc
+  reload: () => Promise<unknown>
+}
+
+interface DropdownOption {
+  name: string
+  value: string
+  selected: boolean
+  onClick?: () => void
+  onSave: (option: DropdownOption) => void
+  onDelete: (option: DropdownOption) => void
+}
+
+type SidePanelField = Record<string, unknown> & { fieldname?: string }
+
+export function contactFieldTransform(contact: ContactDocument) {
+  async function reloadWithToast() {
+    await contact.reload()
+    toast.success(__('Contact Updated'))
+  }
+
+  async function setAsPrimary(field: string, value: string) {
+    const updated = await call('crm.api.contact.set_as_primary', {
+      contact: contact.doc.name,
+      field,
+      value,
+    })
+    if (updated) reloadWithToast()
+  }
+
+  async function createNew(field: string, value: string) {
+    if (!value) return
+    const created = await call('crm.api.contact.create_new', {
+      contact: contact.doc.name,
+      field,
+      value,
+    })
+    if (created) reloadWithToast()
+  }
+
+  async function editOption(
+    doctype: string,
+    name: string,
+    fieldname: string,
+    value: string,
+  ) {
+    const updated = await call('frappe.client.set_value', {
+      doctype,
+      name,
+      fieldname,
+      value,
+    })
+    if (updated) reloadWithToast()
+  }
+
+  async function deleteOption(doctype: string, name: string) {
+    await call('frappe.client.delete', { doctype, name })
+    reloadWithToast()
+  }
+
+  const validateEmailOption = (value: string) =>
+    validateEmail(value) ? '' : __('Please enter a valid email address')
+
+  const validatePhoneOption = (value: string) =>
+    validatePhone(value) ? '' : __('Please enter a valid phone number')
+
+  function emailOptions(): DropdownOption[] {
+    return (contact.doc?.email_ids || []).map((email) => ({
+      name: email.name,
+      value: email.email_id,
+      selected: email.email_id === contact.doc.email_id,
+      onClick: () => setAsPrimary('email', email.email_id),
+      onSave: (option) =>
+        editOption('Contact Email', option.name, 'email_id', option.value),
+      onDelete: async (option) => {
+        contact.doc.email_ids = contact.doc.email_ids?.filter(
+          (e) => e.name !== option.name,
+        )
+        await deleteOption('Contact Email', option.name)
+      },
+    }))
+  }
+
+  function phoneOptions(): DropdownOption[] {
+    return (contact.doc?.phone_nos || []).map((phone) => ({
+      name: phone.name,
+      value: phone.phone,
+      selected: phone.phone === contact.doc.mobile_no,
+      onClick: () => setAsPrimary('mobile_no', phone.phone),
+      onSave: (option) =>
+        editOption('Contact Phone', option.name, 'phone', option.value),
+      onDelete: async (option) => {
+        contact.doc.phone_nos = contact.doc.phone_nos?.filter(
+          (p) => p.name !== option.name,
+        )
+        await deleteOption('Contact Phone', option.name)
+      },
+    }))
+  }
+
+  return function transformField(
+    field: SidePanelField,
+    {
+      showAddressModal,
+    }: { showAddressModal?: (address?: string) => void } = {},
+  ): SidePanelField {
+    if (field.fieldname === 'email_id') {
+      return {
+        ...field,
+        read_only: false,
+        fieldtype: 'Dropdown',
+        itemPlaceholder: 'john@doe.com',
+        validate: validateEmailOption,
+        options: emailOptions(),
+        onCreate: (value: string) => createNew('email', value),
+      }
+    }
+    if (field.fieldname === 'mobile_no') {
+      return {
+        ...field,
+        read_only: false,
+        fieldtype: 'Dropdown',
+        validate: validatePhoneOption,
+        options: phoneOptions(),
+        onCreate: (value: string) => createNew('phone', value),
+      }
+    }
+    if (field.fieldname === 'address') {
+      return {
+        ...field,
+        create: (_value: unknown, close?: () => void) => {
+          showAddressModal?.()
+          close?.()
+        },
+        edit: (address: string) => showAddressModal?.(address),
+      }
+    }
+    return field
+  }
+}

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -337,6 +337,11 @@ export function validateEmail(email) {
   return regExp.test(email)
 }
 
+export function validatePhone(phone) {
+  let value = String(phone).trim()
+  return /^\+?[\d\s()-]+$/.test(value) && /\d/.test(value)
+}
+
 export const isMac =
   typeof navigator !== 'undefined' &&
   /Mac|iPod|iPhone|iPad/i.test(


### PR DESCRIPTION
Draft states cause failure in auto save in PrimaryDropdown

Also consolidates the duplicated contact email/mobile/address side panel logic from Contact.vue and MobileContact.vue into a shared util, and reworks the primary dropdown item so the row itself sets primary with edit/delete moved into a kebab menu

https://github.com/user-attachments/assets/ab06ec8d-19dc-4268-b9b7-a5cdc70e6294