### PR TITLE
build: add production docker compose stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ e2e/.auth
 test-results
 playwright-report
 package-lock.json
+.env
 
 .vscode
 .github/instructions

--- a/docker/production/.env.example
+++ b/docker/production/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env next to docker-compose.yml and fill in real values.
+# Do not commit the filled-in .env.
+
+# Published HTTP port. Must match whatever port the deploy platform health
+# checks. nginx listens on 8080 inside the container regardless of this value.
+CRM_HTTP_PORT=8052
+
+# Site name. Also sent as FRAPPE_SITE_NAME_HEADER so that requests resolve to
+# this site no matter what Host header arrives. For a real domain, use it here
+# (e.g. crm.example.com) so generated links and emails are correct.
+SITE_NAME=crm.localhost
+
+# Image tag from ghcr.io/frappe/crm. "stable" tracks the latest release; pin an
+# explicit tag (e.g. v1.79.1) for reproducible deploys.
+CRM_VERSION=stable
+
+# MariaDB root password. Used to create the site's database on first boot.
+DB_ROOT_PASSWORD=change-me
+
+# Password for the Administrator user. Change it after first login.
+ADMIN_PASSWORD=change-me

--- a/docker/production/README.md
+++ b/docker/production/README.md
@@ -1,0 +1,76 @@
+# Production Docker stack
+
+This directory holds a deployable stack for Frappe CRM. It is **not** the same
+thing as `../docker-compose.yml`, which is a development bench.
+
+| | `../docker-compose.yml` | this stack |
+| --- | --- | --- |
+| Image | `frappe/bench:latest` | `ghcr.io/frappe/crm` (prebuilt) |
+| Startup | Runs `bench init`, downloads and builds Frappe | Starts the built app |
+| Time to first response | ~10-30 minutes | seconds (plus one-time site creation) |
+| Web server | `bench start` (dev server) | gunicorn behind nginx |
+| Needs a host bind mount | Yes (`.:/workspace`) | No |
+| Deploys your local code | No, pulls `crm` from GitHub `main` | No, runs the released image |
+
+The dev stack cannot pass a platform health check, for the reasons in the first
+two rows: its entrypoint script lives on the host and is bind-mounted in, and
+even when that works it does not listen on a port until the build finishes.
+
+## Deploying
+
+```bash
+cp .env.example .env
+$EDITOR .env          # set DB_ROOT_PASSWORD, ADMIN_PASSWORD, SITE_NAME, CRM_HTTP_PORT
+docker compose up -d
+```
+
+Point the platform at `docker/production/docker-compose.yml`, and mark
+**`frontend`** as the primary service — it is the only one publishing a port.
+
+## Health checks
+
+`frontend` has a Compose-level health check against `/api/method/ping` with a
+300s `start_period`. On the very first deploy the `create-site` job has to build
+the database and install the app before that endpoint answers, which takes a few
+minutes.
+
+**Set the platform's health check grace period to at least 5 minutes.** A probe
+that starts failing the container after 30-60s will kill the stack mid-site
+creation, and because the half-created site persists in the `sites` volume, the
+retry can come up in a broken state. If that happens, clear the volumes and
+redeploy:
+
+```bash
+docker compose down -v && docker compose up -d
+```
+
+Subsequent deploys are fast — `create-site` sees the existing site and exits.
+
+## Port
+
+The platform health check in the failing deploy targeted **8052**, which is the
+default for `CRM_HTTP_PORT`. Inside the container nginx always listens on 8080;
+only the published port is configurable. If the platform assigns a port
+dynamically, set `CRM_HTTP_PORT` from its injected variable rather than
+hardcoding it.
+
+## Host header
+
+`FRAPPE_SITE_NAME_HEADER` is pinned to `SITE_NAME`. Frappe is multi-tenant and
+normally picks the site from the Host header, so a probe hitting a bare IP or an
+internal hostname would get "Site does not exist" and fail the check even though
+the app is healthy. Pinning it forces every request to resolve to the one site.
+
+## TLS
+
+This stack serves plain HTTP on `CRM_HTTP_PORT`. Terminate TLS at the platform's
+load balancer. If it forwards `X-Forwarded-For`, set `UPSTREAM_REAL_IP_ADDRESS`
+in the compose file to the balancer's address so client IPs are logged correctly.
+
+## Persistence
+
+Four named volumes: `db-data`, `sites`, `logs`, `redis-queue-data`. `db-data`
+and `sites` hold all durable state — the database and the site's files,
+including uploads and `site_config.json`. Back both up together; they must be
+restored as a matched pair. If the platform does not persist named volumes
+across deploys, this stack will recreate the site from scratch every time.

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,0 +1,216 @@
+# Production stack for Frappe CRM.
+#
+# Unlike ../docker-compose.yml (which is a development bench that builds itself
+# at startup), this stack runs the prebuilt ghcr.io/frappe/crm image, so the web
+# service binds its port within seconds of boot instead of after a ~20 minute
+# `bench init`. That is what makes it survivable under a platform health check.
+#
+# Copy .env.example to .env and edit it before deploying.
+
+x-crm-image: &crm_image
+  image: ghcr.io/frappe/crm:${CRM_VERSION:-stable}
+
+x-backend-env: &backend_env
+  DB_HOST: db
+  DB_PORT: "3306"
+  MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?set DB_ROOT_PASSWORD in .env}
+  MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?set DB_ROOT_PASSWORD in .env}
+
+x-bench-volumes: &bench_volumes
+  - sites:/home/frappe/frappe-bench/sites
+  - logs:/home/frappe/frappe-bench/logs
+
+services:
+  # The primary service. This is the one to point the platform health check at.
+  frontend:
+    <<: *crm_image
+    command: ["nginx-entrypoint.sh"]
+    environment:
+      BACKEND: backend:8000
+      SOCKETIO: websocket:9000
+      # Pinning this to the site name makes Frappe resolve every request to that
+      # site regardless of the Host header. Without it, a health probe hitting a
+      # raw IP or an internal hostname gets "Site does not exist" and fails.
+      FRAPPE_SITE_NAME_HEADER: ${SITE_NAME:-crm.localhost}
+      UPSTREAM_REAL_IP_ADDRESS: 127.0.0.1
+      UPSTREAM_REAL_IP_HEADER: X-Forwarded-For
+      UPSTREAM_REAL_IP_RECURSIVE: "off"
+      PROXY_READ_TIMEOUT: 120
+      CLIENT_MAX_BODY_SIZE: 50m
+    volumes: *bench_volumes
+    ports:
+      # nginx always listens on 8080 inside the container; only the published
+      # port changes. Set CRM_HTTP_PORT to whatever the platform probes.
+      - "${CRM_HTTP_PORT:-8052}:8080"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/method/ping')"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      # First boot has to wait for create-site to finish. Give it room, and set
+      # the platform's own grace period to at least this much.
+      start_period: 300s
+    depends_on:
+      - backend
+      - websocket
+    restart: unless-stopped
+
+  backend:
+    <<: *crm_image
+    environment: *backend_env
+    volumes: *bench_volumes
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  websocket:
+    <<: *crm_image
+    command: ["node", "/home/frappe/frappe-bench/apps/frappe/socketio.js"]
+    environment:
+      FRAPPE_REDIS_CACHE: redis://redis-cache:6379
+      FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
+    volumes: *bench_volumes
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  queue-short:
+    <<: *crm_image
+    command: ["bench", "worker", "--queue", "short,default"]
+    environment:
+      FRAPPE_REDIS_CACHE: redis://redis-cache:6379
+      FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
+    volumes: *bench_volumes
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  queue-long:
+    <<: *crm_image
+    command: ["bench", "worker", "--queue", "long,default,short"]
+    environment:
+      FRAPPE_REDIS_CACHE: redis://redis-cache:6379
+      FRAPPE_REDIS_QUEUE: redis://redis-queue:6379
+    volumes: *bench_volumes
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  scheduler:
+    <<: *crm_image
+    command: ["bench", "schedule"]
+    volumes: *bench_volumes
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  # One-shot: writes common_site_config.json into the sites volume.
+  configurator:
+    <<: *crm_image
+    entrypoint: ["bash", "-c"]
+    command:
+      - >
+        ls -1 apps > sites/apps.txt;
+        bench set-config -g db_host $$DB_HOST;
+        bench set-config -gp db_port $$DB_PORT;
+        bench set-config -g redis_cache "redis://$$REDIS_CACHE";
+        bench set-config -g redis_queue "redis://$$REDIS_QUEUE";
+        bench set-config -g redis_socketio "redis://$$REDIS_QUEUE";
+        bench set-config -gp socketio_port $$SOCKETIO_PORT;
+    environment:
+      DB_HOST: db
+      DB_PORT: "3306"
+      REDIS_CACHE: redis-cache:6379
+      REDIS_QUEUE: redis-queue:6379
+      SOCKETIO_PORT: "9000"
+    volumes: *bench_volumes
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
+
+  # One-shot: creates the site on first deploy, no-ops on every deploy after.
+  create-site:
+    <<: *crm_image
+    entrypoint: ["bash", "-c"]
+    command:
+      - >
+        wait-for-it -t 120 db:3306;
+        wait-for-it -t 120 redis-cache:6379;
+        wait-for-it -t 120 redis-queue:6379;
+        export start=`date +%s`;
+        until [[ -n `grep -hs ^ sites/common_site_config.json | jq -r ".db_host // empty"` ]] && \
+          [[ -n `grep -hs ^ sites/common_site_config.json | jq -r ".redis_cache // empty"` ]] && \
+          [[ -n `grep -hs ^ sites/common_site_config.json | jq -r ".redis_queue // empty"` ]];
+        do
+          echo "Waiting for sites/common_site_config.json to be created";
+          sleep 5;
+          if (( `date +%s`-start > 120 )); then
+            echo "could not find sites/common_site_config.json with required keys";
+            exit 1
+          fi
+        done;
+        echo "sites/common_site_config.json found";
+        if [ -d "sites/$$SITE_NAME" ]; then
+          echo "Site $$SITE_NAME already exists, skipping creation";
+        else
+          bench new-site \
+            --mariadb-user-host-login-scope='%' \
+            --db-root-username=root \
+            --db-root-password=$$MARIADB_ROOT_PASSWORD \
+            --admin-password=$$ADMIN_PASSWORD \
+            --install-app crm \
+            --set-default $$SITE_NAME;
+        fi;
+    environment:
+      <<: *backend_env
+      SITE_NAME: ${SITE_NAME:-crm.localhost}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:?set ADMIN_PASSWORD in .env}
+    volumes: *bench_volumes
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+    restart: "no"
+
+  db:
+    image: mariadb:10.6
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?set DB_ROOT_PASSWORD in .env}
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?set DB_ROOT_PASSWORD in .env}
+    volumes:
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 15s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis-cache:
+    image: redis:6.2-alpine
+    restart: unless-stopped
+
+  redis-queue:
+    image: redis:6.2-alpine
+    volumes:
+      - redis-queue-data:/data
+    restart: unless-stopped
+
+volumes:
+  db-data:
+  redis-queue-data:
+  sites:
+  logs:


### PR DESCRIPTION
The existing docker/docker-compose.yml is a development bench: it bind-mounts init.sh from the host and runs `bench init` at container start, so it cannot survive a deploy platform's startup health check. It has no host mount to read its entrypoint from, and binds no port until a 10-30 minute build completes.

Add docker/production/ as a deployable alternative, adapted from upstream frappe_docker's pwd.yml:

- Runs the prebuilt ghcr.io/frappe/crm image instead of building at startup.
- Publishes a configurable CRM_HTTP_PORT (default 8052) onto nginx's 8080.
- Pins FRAPPE_SITE_NAME_HEADER to the site name so health probes hitting a bare IP resolve to the site instead of erroring with "Site does not exist".
- Uses `restart:` rather than `deploy.restart_policy`, which plain Compose ignores outside Swarm.
- Adds a frontend healthcheck against /api/method/ping with a start_period wide enough to cover first-boot site creation.

Also gitignore .env so filled-in deployment secrets are not committed.