### PR TITLE
feat(views): lucide icon picker for views

### DIFF
--- a/frontend/src/components/Icon.vue
+++ b/frontend/src/components/Icon.vue
@@ -2,11 +2,22 @@
   <div v-if="isEmoji(icon)" v-bind="$attrs">
     {{ icon }}
   </div>
-  <FeatherIcon
+  <!-- lucide icon from the sprite the IconPicker reads (lucide is a superset of
+       feather, so legacy names still resolve). No width/height attrs so size
+       classes like `h-4` control it, matching the old FeatherIcon behaviour. -->
+  <svg
     v-else-if="typeof icon == 'string'"
-    :name="icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="shrink-0"
     v-bind="$attrs"
-  />
+  >
+    <use :href="`#${icon.replace(/^lucide-/, '')}`" />
+  </svg>
   <component :is="icon" v-else v-bind="$attrs" />
 </template>
 <script setup>

--- a/frontend/src/components/Modals/ViewModal.vue
+++ b/frontend/src/components/Modals/ViewModal.vue
@@ -10,25 +10,44 @@
     "
   >
     <template #default>
-      <div class="mb-1.5 block text-base text-ink-gray-5">
-        {{ __('View Name') }}
-      </div>
-      <div class="flex gap-2">
-        <IconPicker v-slot="{ togglePopover }" v-model="view.icon">
-          <Button
+      <div class="flex flex-col gap-4">
+        <div>
+          <div class="mb-1.5 block text-base text-ink-gray-5">
+            {{ __('View Name') }}
+          </div>
+          <FormControl
+            v-model="view.label"
             size="md"
-            class="flex size-8 text-3xl leading-none"
-            :label="view.icon"
-            @click="togglePopover"
+            type="text"
+            :placeholder="__('My Open Deals')"
           />
-        </IconPicker>
-        <FormControl
-          v-model="view.label"
-          class="flex-1"
-          size="md"
-          type="text"
-          :placeholder="__('My Open Deals')"
-        />
+        </div>
+        <div>
+          <div class="mb-1.5 block text-base text-ink-gray-5">
+            {{ __('Icon') }}
+          </div>
+          <div class="flex items-center gap-2">
+            <!-- legacy views may store an emoji; the lucide picker can't render
+                 it, so show it alongside until a lucide icon is picked -->
+            <div
+              v-if="currentIsEmoji"
+              class="grid size-8 shrink-0 place-items-center rounded bg-surface-gray-3 text-lg leading-none"
+              :title="__('Current icon')"
+            >
+              {{ view.icon }}
+            </div>
+            <IconPicker
+              v-model="pickerIcon"
+              class="flex-1"
+              :max-icons="1000"
+              :placeholder="
+                currentIsEmoji
+                  ? __('Replace with an icon...')
+                  : __('Select an icon...')
+              "
+            />
+          </div>
+        </div>
       </div>
     </template>
     <template #actions>
@@ -50,9 +69,10 @@
 </template>
 
 <script setup>
-import IconPicker from '@/components/IconPicker.vue'
+import { IconPicker } from 'frappe-ui/icons'
+import { isEmoji } from '@/utils'
 import { call } from 'frappe-ui'
-import { ref, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 
 const props = defineProps({
   doctype: { type: String, required: true },
@@ -64,6 +84,21 @@ const props = defineProps({
 
 const show = defineModel({ type: Boolean })
 const view = defineModel('view', { type: Object, default: () => ({}) })
+
+// frappe-ui's IconPicker is lucide-only. Legacy views may store an emoji, which
+// the picker can't render — hide non-lucide values from it (showing the
+// placeholder) while keeping the stored icon, so a no-op edit preserves the
+// emoji and picking a lucide icon migrates it.
+const currentIsEmoji = computed(() => isEmoji(view.value?.icon || ''))
+const pickerIcon = computed({
+  get: () => {
+    const icon = view.value?.icon
+    return !icon || isEmoji(icon) ? '' : icon
+  },
+  set: (value) => {
+    view.value.icon = value || ''
+  },
+})
 
 const editMode = ref(false)
 const duplicateMode = ref(false)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -24,6 +24,9 @@ import {
 } from 'frappe-ui'
 
 import { telemetryPlugin } from 'frappe-ui/frappe'
+// injects the lucide SVG sprite into the DOM so the IconPicker and lucide Icons
+// (used for view icons) can render from it
+import { spritePlugin } from 'frappe-ui/icons'
 
 let globalComponents = {
   Button,
@@ -44,6 +47,7 @@ let app = createApp(App)
 
 setConfig('resourceFetcher', frappeRequest)
 app.use(FrappeUI)
+app.use(spritePlugin)
 app.use(pinia)
 app.use(router)
 app.use(translationPlugin)


### PR DESCRIPTION
Replaces the emoji-only icon picker in the view modal with frappe-ui's **lucide `IconPicker`** (searchable, ~1000 icons) — the same approach the latest Helpdesk uses.

### Changes
- **`main.js`** — register frappe-ui's `spritePlugin` so the lucide SVG sprite is injected into the DOM. The `IconPicker` and lucide `Icon`s read icon names from it (without this the picker shows *"No icons available"*).
- **`Modals/ViewModal.vue`** — use `IconPicker` from `frappe-ui/icons`. Keeps a **legacy-emoji fallback**: a view that stored an emoji shows the emoji beside the picker and preserves it until a lucide icon is picked.
- **`Icon.vue`** — render string icon names from the lucide sprite (no fixed width/height, so size classes still control sizing, matching the old FeatherIcon). Emoji and component branches are unchanged, so existing emoji icons keep rendering.

### Migration
Backward-compatible, **per-view opt-in** — no data patch. Existing emoji icons keep rendering and migrate individually only when a view is edited and a lucide icon chosen. Standard views (List/Kanban/Group By) use component icons and are unaffected.

### Screenshots

<img width="1470" height="761" alt="image" src="https://github.com/user-attachments/assets/235876ee-990b-4436-8194-d85d0cca4a3d" />

