### PR TITLE
fix(views): require a name to create/save a view

### DIFF
--- a/frontend/src/components/Modals/ViewModal.vue
+++ b/frontend/src/components/Modals/ViewModal.vue
@@ -54,6 +54,7 @@
       <div class="flex justify-end">
         <Button
           variant="solid"
+          :disabled="!view.label?.trim()"
           :label="
             editMode
               ? __('Save Changes')


### PR DESCRIPTION
The view modal let you submit with an empty name. Disable the Create/Save button until the view label is non-empty (trimmed).