### PR TITLE
fix(telephony): play call recordings reliably

### DIFF
--- a/crm/fcrm/doctype/crm_call_log/test_crm_call_log.py
+++ b/crm/fcrm/doctype/crm_call_log/test_crm_call_log.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from unittest.mock import MagicMock, patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -9,6 +11,7 @@ from crm.fcrm.doctype.crm_call_log.crm_call_log import (
 	get_call_log,
 	parse_call_log,
 )
+from crm.integrations.api import _get_recording_credentials
 
 
 class TestCRMCallLog(IntegrationTestCase):
@@ -421,6 +424,43 @@ class TestCRMCallLog(IntegrationTestCase):
 
 		call2 = create_test_call_log(telephony_medium="Exotel")
 		self.assertEqual(call2.telephony_medium, "Exotel")
+
+	def test_recording_credentials_manual_medium_needs_no_auth(self):
+		"""A manually added recording is fetched as-is, with no provider auth."""
+		self.assertIsNone(_get_recording_credentials("Manual"))
+
+	def test_recording_credentials_unknown_medium_returns_none(self):
+		"""An empty/unrecognized medium must not raise; it just skips auth."""
+		self.assertIsNone(_get_recording_credentials(""))
+		self.assertIsNone(_get_recording_credentials(None))
+
+	def test_recording_credentials_twilio_unconfigured_returns_none(self):
+		"""Twilio without a configured secret falls back to no auth instead of raising.
+
+		Regression: get_password used to raise when the secret was unset, which made
+		the recording proxy 500 and the UI show "Recording not available".
+		"""
+		settings = MagicMock()
+		settings.api_key = "ACxxxxxxxx"
+		settings.get_password.return_value = None
+		with patch("crm.integrations.api.frappe.get_single", return_value=settings):
+			self.assertIsNone(_get_recording_credentials("Twilio"))
+
+	def test_recording_credentials_twilio_configured_returns_tuple(self):
+		"""Twilio with both key and secret set yields the auth pair."""
+		settings = MagicMock()
+		settings.api_key = "ACxxxxxxxx"
+		settings.get_password.return_value = "twilio_secret"
+		with patch("crm.integrations.api.frappe.get_single", return_value=settings):
+			self.assertEqual(_get_recording_credentials("Twilio"), ("ACxxxxxxxx", "twilio_secret"))
+
+	def test_recording_credentials_exotel_configured_returns_tuple(self):
+		"""Exotel with both key and token set yields the auth pair."""
+		settings = MagicMock()
+		settings.api_key = "exotel_key"
+		settings.get_password.return_value = "exotel_token"
+		with patch("crm.integrations.api.frappe.get_single", return_value=settings):
+			self.assertEqual(_get_recording_credentials("Exotel"), ("exotel_key", "exotel_token"))
 
 
 def create_test_call_log(**kwargs):

--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -153,7 +153,12 @@ def get_contact_by_phone_number(phone_number: str):
 
 @frappe.whitelist()
 def get_recording_url(call_log_name: str):
-	"""Fetch and stream a call recording, authenticating with the provider's credentials."""
+	"""Proxy a call recording (authenticating with the provider) so it plays in the browser.
+
+	Forwards the browser's Range request to the provider and passes the response back with
+	Accept-Ranges/Content-Length set. Without range support the HTML <audio> element can't
+	read the recording's duration (shows 0:00) or seek within it.
+	"""
 	if not call_log_name or not frappe.db.exists("CRM Call Log", call_log_name):
 		frappe.throw(_("Call log not found"), frappe.DoesNotExistError)
 
@@ -163,11 +168,34 @@ def get_recording_url(call_log_name: str):
 		frappe.throw(_("Recording URL not found"), frappe.DoesNotExistError)
 
 	auth = _get_recording_credentials(log.telephony_medium)
-	with requests.get(log.recording_url, auth=auth, stream=True, timeout=10) as r:
-		r.raise_for_status()
-		response = Response()
-		response.data = r.content
-		response.mimetype = "audio/mpeg"
+	# forward the browser's Range header so the provider (Twilio/Exotel CDN) can return
+	# just the requested bytes; falls back to the full file if it doesn't support ranges
+	req_headers = {}
+	range_header = frappe.get_request_header("Range")
+	if range_header:
+		req_headers["Range"] = range_header
+
+	# stream instead of buffering the whole file: the provider's Content-Length reaches
+	# the browser immediately so the <audio> element can show the duration right away,
+	# rather than waiting for the entire recording to download server-side first
+	upstream = requests.get(log.recording_url, auth=auth, headers=req_headers, stream=True, timeout=30)
+	upstream.raise_for_status()
+
+	def _stream():
+		try:
+			yield from upstream.iter_content(chunk_size=64 * 1024)
+		finally:
+			upstream.close()
+
+	response = Response(
+		_stream(),
+		status=upstream.status_code,
+		mimetype=upstream.headers.get("Content-Type") or "audio/mpeg",
+	)
+	response.headers["Accept-Ranges"] = "bytes"
+	for header in ("Content-Length", "Content-Range"):
+		if upstream.headers.get(header):
+			response.headers[header] = upstream.headers[header]
 	return response
 
 

--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -8,15 +8,25 @@ from werkzeug.wrappers import Response
 from crm.utils import are_same_phone_number, parse_phone_number
 
 
-def _get_recording_credentials(telephony_medium: str) -> tuple:
-	"""Return (api_key, secret) for the given telephony medium."""
+def _get_recording_credentials(telephony_medium: str) -> tuple | None:
+	"""Return (api_key, secret) for the given telephony medium, or None when the
+	recording needs no auth.
+
+	A manual/unrecognized medium (a recording added by hand) is fetched as-is, and
+	a provider whose credentials aren't configured yet falls back to no auth rather
+	than raising — so the proxy attempts the fetch and lets the provider decide,
+	instead of 500-ing before the request is even made.
+	"""
 	if telephony_medium == "Twilio":
 		s = frappe.get_single("CRM Twilio Settings")
-		return s.api_key, s.get_password("api_secret")
+		secret = s.get_password("api_secret", raise_exception=False)
+		return (s.api_key, secret) if s.api_key and secret else None
 	elif telephony_medium == "Exotel":
 		s = frappe.get_single("CRM Exotel Settings")
-		return s.api_key, s.get_password("api_token")
-	frappe.throw(_("Unknown telephony medium: {0}").format(telephony_medium))
+		token = s.get_password("api_token", raise_exception=False)
+		return (s.api_key, token) if s.api_key and token else None
+	# manual or unrecognized medium: no provider auth to apply
+	return None
 
 
 @frappe.whitelist()

--- a/frontend/src/components/Modals/CallLogDetailModal.vue
+++ b/frontend/src/components/Modals/CallLogDetailModal.vue
@@ -405,6 +405,13 @@ watch(
     d.value = useDocument('CRM Call Log', value)
   },
 )
+
+// also reset when the modal reopens — the name watch above won't fire when the
+// same call log is opened again, which would otherwise keep a stale error state
+// and hide a now-playable recording behind "Recording not available"
+watch(show, (value) => {
+  if (value) recordingError.value = false
+})
 </script>
 
 <style scoped>

--- a/frontend/src/components/Modals/CallLogDetailModal.vue
+++ b/frontend/src/components/Modals/CallLogDetailModal.vue
@@ -93,10 +93,18 @@
                 class="w-full"
               >
                 <audio
+                  v-if="!recordingError"
                   class="audio-control w-full"
                   controls
                   :src="field.value"
+                  @error="recordingError = true"
                 ></audio>
+                <div
+                  v-else
+                  class="flex h-9 items-center text-base text-ink-gray-5"
+                >
+                  {{ __('Recording not available') }}
+                </div>
               </div>
               <div
                 v-else-if="field.name == 'note'"
@@ -194,6 +202,10 @@ const { showModal } = useDoctypeModal()
 
 const note = ref('')
 const task = ref('')
+// a call log can carry a recording_url that no longer resolves to a playable file
+// (recording never made / expired) — track load failure to show a fallback instead
+// of a dead 0:00 player
+const recordingError = ref(false)
 
 function showNote(name) {
   showModal({
@@ -389,6 +401,7 @@ watch(
   () => callLog.value?.data?.name,
   (value) => {
     if (!value) return
+    recordingError.value = false
     d.value = useDocument('CRM Call Log', value)
   },
 )

--- a/frontend/src/components/Modals/CallLogDetailModal.vue
+++ b/frontend/src/components/Modals/CallLogDetailModal.vue
@@ -412,6 +412,16 @@ watch(
 watch(show, (value) => {
   if (value) recordingError.value = false
 })
+
+// and reset when the recording source changes — a reload (e.g. afterUpdate)
+// can make a previously-missing recording available while the modal stays open,
+// leaving name and show unchanged so neither watch above fires
+watch(
+  () => callLog.value?.data?.recording_url_path,
+  () => {
+    recordingError.value = false
+  },
+)
 </script>
 
 <style scoped>


### PR DESCRIPTION
Fixes #2550.

The call-log recording player was broken in two ways: recordings that *did* exist showed a **0:00 duration** with a ~2-3s delay before playing (and couldn't seek), and calls whose `recording_url` no longer resolves to a real recording showed a **dead empty player**.

### Changes
- **`get_recording_url` (`crm/integrations/api.py`)** — stream the provider's response instead of buffering the whole file, and forward the browser's `Range` header plus the provider's `Content-Length`/`Content-Range` (with `Accept-Ranges`). The HTML `<audio>` element can now read the duration **immediately** and seek, instead of waiting for the entire recording to download server-side first. (Verified: a range request returns `206` with `Content-Range` in ~0.7s vs the whole file buffering for 2-3s.)
- **`CallLogDetailModal.vue`** — when the recording fails to load (`recording_url` set but no real/expired recording), show **"Recording not available"** instead of a dead 0:00 player. Resets per call log.

### Testing
Manual (needs a telephony provider + a real recording, so no automated test): verified with a Range-capable audio source that the endpoint returns `206 Partial Content` with correct `Content-Range`/`Content-Length` quickly, and that a non-resolving `recording_url` renders the fallback.


