### PR TITLE
feat: capture new feature adoption daily

### DIFF
--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -224,6 +224,7 @@ scheduler_events = {
 	"daily": [
 		"crm.api.event.trigger_daily_event_notifications",
 		"crm.fcrm.doctype.crm_view_settings.crm_view_settings.clear_old_versions",
+		"crm.telemetry.capture_feature_state",
 	],
 	"weekly": ["crm.api.event.trigger_weekly_event_notifications"],
 	"daily_long": ["crm.lead_syncing.background_sync.sync_leads_from_sources_daily"],

--- a/crm/lead_syncing/doctype/lead_sync_source/facebook.py
+++ b/crm/lead_syncing/doctype/lead_sync_source/facebook.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe.exceptions import ValidationError
 from frappe.integrations.utils import make_get_request
-from frappe.utils.telemetry import capture
 
 FB_GRAPH_API_BASE = "https://graph.facebook.com"
 FB_GRAPH_API_VERSION = "v23.0"
@@ -35,16 +34,9 @@ class FacebookSyncSource:
 
 	def sync(self):
 		leads = self.fetch_leads()
-		created = 0
 		for lead in leads:
-			if self.sync_single_lead(lead):
-				created += 1
+			self.sync_single_lead(lead)
 		self.update_last_synced_at()
-		capture(
-			"lead_sync_completed",
-			"crm",
-			properties={"source_type": "Facebook", "count": created},
-		)
 
 	def sync_single_lead(self, lead, raise_exception=False):
 		question_to_field_map = self.get_form_questions_mapping()

--- a/crm/telemetry.py
+++ b/crm/telemetry.py
@@ -46,12 +46,20 @@ def count_synced_leads(days: int | None = None) -> int:
 def product_sync_state() -> dict:
 	settings = frappe.get_cached_doc("ERPNext CRM Settings")
 
-	return {
+	state = {
 		"erpnext_sync_enabled": bool(settings.enabled),
 		"products_sync_enabled": bool(settings.sync_products),
-		"products_synced_total": frappe.db.count("CRM Product"),
+		"products_total": frappe.db.count("CRM Product"),
 		"product_sync_issues_open": frappe.db.count("CRM Product Sync Issue", {"dismissed": 0}),
 	}
+
+	# erpnext_item_code is a custom field, added only once the integration is enabled
+	if frappe.db.has_column("CRM Product", "erpnext_item_code"):
+		state["products_synced_total"] = frappe.db.count(
+			"CRM Product", {"erpnext_item_code": ["is", "set"]}
+		)
+
+	return state
 
 
 def sales_hierarchy_state() -> dict:

--- a/crm/telemetry.py
+++ b/crm/telemetry.py
@@ -55,9 +55,7 @@ def product_sync_state() -> dict:
 
 	# erpnext_item_code is a custom field, added only once the integration is enabled
 	if frappe.db.has_column("CRM Product", "erpnext_item_code"):
-		state["products_synced_total"] = frappe.db.count(
-			"CRM Product", {"erpnext_item_code": ["is", "set"]}
-		)
+		state["products_synced_total"] = frappe.db.count("CRM Product", {"erpnext_item_code": ["is", "set"]})
 
 	return state
 

--- a/crm/telemetry.py
+++ b/crm/telemetry.py
@@ -2,11 +2,14 @@
 
 import frappe
 from frappe.utils import add_days, nowdate
-from frappe.utils.telemetry import capture
+from frappe.utils.telemetry import capture, is_pulse_enabled
 
 
 def capture_feature_state():
 	"""Emit one `crm_feature_state` event per site per day."""
+	if not is_pulse_enabled():
+		return
+
 	properties = {}
 
 	for collect in (lead_sync_state, product_sync_state, sales_hierarchy_state):

--- a/crm/telemetry.py
+++ b/crm/telemetry.py
@@ -1,0 +1,60 @@
+"""Daily snapshot of which features a site has configured and how much it uses them."""
+
+import frappe
+from frappe.utils import add_days, nowdate
+from frappe.utils.telemetry import capture
+
+
+def capture_feature_state():
+	"""Emit one `crm_feature_state` event per site per day."""
+	properties = {}
+
+	for collect in (lead_sync_state, product_sync_state, sales_hierarchy_state):
+		try:
+			properties.update(collect())
+		except Exception:
+			frappe.log_error(f"Feature state telemetry failed: {collect.__name__}")
+
+	if properties:
+		capture("crm_feature_state", "crm", properties=properties, interval="1d")
+
+
+def lead_sync_state() -> dict:
+	sources = frappe.get_all("Lead Sync Source", fields=["type", "enabled"])
+	enabled_types = {s.type for s in sources if s.enabled}
+
+	return {
+		"lead_sync_enabled": bool(enabled_types),
+		"lead_sync_sources": len(sources),
+		"lead_sync_source_types": sorted(enabled_types),
+		"leads_synced_total": count_synced_leads(),
+		"leads_synced_30d": count_synced_leads(days=30),
+	}
+
+
+def count_synced_leads(days: int | None = None) -> int:
+	filters = {"facebook_lead_id": ["is", "set"]}
+	if days:
+		filters["creation"] = [">", add_days(nowdate(), -days)]
+
+	return frappe.db.count("CRM Lead", filters)
+
+
+def product_sync_state() -> dict:
+	settings = frappe.get_cached_doc("ERPNext CRM Settings")
+
+	return {
+		"erpnext_sync_enabled": bool(settings.enabled),
+		"products_sync_enabled": bool(settings.sync_products),
+		"products_synced_total": frappe.db.count("CRM Product"),
+		"product_sync_issues_open": frappe.db.count("CRM Product Sync Issue", {"dismissed": 0}),
+	}
+
+
+def sales_hierarchy_state() -> dict:
+	return {
+		"sales_hierarchy_enabled": bool(
+			frappe.db.get_single_value("FCRM Settings", "enable_sales_hierarchy")
+		),
+		"sales_hierarchy_nodes": frappe.db.count("CRM Sales Hierarchy"),
+	}

--- a/frontend/src/components/Settings/ERPNextSettings.vue
+++ b/frontend/src/components/Settings/ERPNextSettings.vue
@@ -227,10 +227,6 @@
                   <Switch
                     v-model="erpnextCRMSettingsResource.doc.sync_products"
                     size="sm"
-                    @update:modelValue="
-                      (v) =>
-                        capture('erpnext_product_sync_toggled', { enabled: v })
-                    "
                   />
                 </div>
               </div>
@@ -633,8 +629,6 @@ const isDirty = computed(() => {
 const saveSettings = async () => {
   if (!validateData() || !validateSiteConnection()) return
 
-  const wasEnabled = !!erpnextCRMSettingsResource.originalDoc?.enabled
-
   updateFields(
     {
       enabled: erpnextCRMSettingsResource.doc.enabled,
@@ -651,9 +645,6 @@ const saveSettings = async () => {
     },
     {
       onSuccess: async () => {
-        if (erpnextCRMSettingsResource.doc.enabled && !wasEnabled) {
-          capture('erpnext_integration_enabled')
-        }
         if (!erpnextCRMSettingsResource.isERPNextInstalled.data) {
           await erpnextCRMSettingsResource.getExternalCompanies.submit()
         }

--- a/frontend/src/components/Settings/Hierarchy/Hierarchy.vue
+++ b/frontend/src/components/Settings/Hierarchy/Hierarchy.vue
@@ -251,7 +251,6 @@ import { useRemoveNode } from './useRemoveNode'
 import { useDragDrop } from './useDragDrop'
 import { globalStore } from '@/stores/global'
 import { usersStore } from '@/stores/users'
-import { useTelemetry } from 'frappe-ui/frappe'
 import LucideNetwork from '~icons/lucide/network'
 import LucideCircleQuestionMark from '~icons/lucide/circle-question-mark'
 import {
@@ -281,7 +280,6 @@ const ROLE_LABEL = {
 const { users: usersResource, getUserRole, isAdmin } = usersStore()
 const canEdit = computed(() => isAdmin())
 const { $dialog } = globalStore()
-const { capture } = useTelemetry()
 
 const fcrmSettings = createDocumentResource({
   doctype: 'FCRM Settings',
@@ -335,7 +333,6 @@ function toggleEnable(currentlyEnabled) {
       { enable_sales_hierarchy: 1 },
       {
         onSuccess: () => {
-          capture('sales_hierarchy_enabled')
           toast.success(__('Sales Hierarchy enabled'))
         },
       },
@@ -504,7 +501,6 @@ async function bulkAdd(parent, userIds) {
       }
     }
     if (added) {
-      capture('sales_hierarchy_user_added', { count: added })
       toast.success(
         added === 1
           ? __('User added to hierarchy')

--- a/frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue
+++ b/frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue
@@ -176,7 +176,6 @@ import {
   Tabs,
 } from 'frappe-ui'
 
-import { useTelemetry } from 'frappe-ui/frappe'
 import { getMeta } from '@/stores/meta'
 import Link from '@/components/Controls/Link.vue'
 import Grid from '@/components/Controls/Grid.vue'
@@ -241,7 +240,6 @@ const fieldsMap = computed(() => {
 })
 
 const sources = inject('sources')
-const { capture } = useTelemetry()
 const syncSource = ref({
   name: '',
   type: '',
@@ -288,9 +286,6 @@ function createSource() {
     },
     {
       onSuccess: (newDoc) => {
-        capture('lead_sync_source_created', {
-          source_type: syncSource.value.type,
-        })
         toast.success(__('Lead Sync Source created successfully'))
         isLocal.value = false
         docResource.value = getSourceDocResource(newDoc.name)

--- a/frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue
+++ b/frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue
@@ -122,7 +122,6 @@
 </template>
 <script setup>
 import { Switch, Dropdown, toast, Badge } from 'frappe-ui'
-import { useTelemetry } from 'frappe-ui/frappe'
 import { ref, computed, inject } from 'vue'
 import EmptyState from '../../ListViews/EmptyState.vue'
 import { ConfirmDelete } from '../../../utils'
@@ -130,7 +129,6 @@ import { ConfirmDelete } from '../../../utils'
 const emit = defineEmits(['updateStep'])
 
 const sources = inject('sources')
-const { capture } = useTelemetry()
 
 const search = ref('')
 const confirmDelete = ref(false)
@@ -155,10 +153,6 @@ function toggleLeadSyncSourceEnabled(source) {
     },
     {
       onSuccess: () => {
-        capture('lead_sync_source_toggled', {
-          enabled: Boolean(source.enabled),
-          source_type: source.type,
-        })
         toast.success(
           source.enabled
             ? __('Source enabled successfully')


### PR DESCRIPTION
Captures new features daily to track adoption.
This is gated behind a check which only collects these if telemetry is enabled

Removed | File | Replaced by
-- | -- | --
erpnext_product_sync_toggled | ERPNextSettings.vue | products_sync_enabled
erpnext_integration_enabled | ERPNextSettings.vue | erpnext_sync_enabled
sales_hierarchy_enabled | Hierarchy.vue | sales_hierarchy_enabled
sales_hierarchy_user_added | Hierarchy.vue | sales_hierarchy_nodes
lead_sync_source_created | LeadSyncSourceForm.vue | lead_sync_sources
lead_sync_source_toggled | LeadSyncSources.vue | lead_sync_enabled


the event payload will look like: 
 ```
{
  "event_name": "crm_feature_state",
  "site": "crm.localhost",
  "properties": {
    "lead_sync_enabled": false,     "lead_sync_sources": 0,
    "leads_synced_total": 0,        "leads_synced_30d": 0,
    "erpnext_sync_enabled": true,   "products_sync_enabled": false,
    "products_synced_total": 54,    "product_sync_issues_open": 1,
    "sales_hierarchy_enabled": true, "sales_hierarchy_nodes": 7,
   "product_total": 100,
  }
```