### PR TITLE
fix(views): render saved-view lucide icons in the view dropdown

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -300,6 +300,7 @@
   </Dialog>
 </template>
 <script setup>
+import Icon from '@/components/Icon.vue'
 import ListIcon from '@/components/Icons/ListIcon.vue'
 import KanbanIcon from '@/components/Icons/KanbanIcon.vue'
 import GroupByIcon from '@/components/Icons/GroupByIcon.vue'
@@ -664,6 +665,11 @@ function getIcon(icon, type) {
     return markRaw(GroupByIcon)
   } else if (!icon && type === 'kanban') {
     return markRaw(KanbanIcon)
+  } else if (typeof icon === 'string') {
+    // a lucide icon name (from the IconPicker) — render it through Icon so it
+    // resolves from the injected lucide sprite. The Dropdown renders a bare
+    // string via FeatherIcon, which lacks the newer lucide names and shows blank.
+    return () => h(Icon, { icon, class: 'h-4 w-4' })
   }
   return icon || markRaw(ListIcon)
 }

--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -665,7 +665,7 @@ function getIcon(icon, type) {
     return markRaw(GroupByIcon)
   } else if (!icon && type === 'kanban') {
     return markRaw(KanbanIcon)
-  } else if (typeof icon === 'string') {
+  } else if (icon && typeof icon === 'string') {
     // a lucide icon name (from the IconPicker) — render it through Icon so it
     // resolves from the injected lucide sprite. The Dropdown renders a bare
     // string via FeatherIcon, which lacks the newer lucide names and shows blank.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -160,8 +160,9 @@ function getAliases(config) {
     ),
     'frappe-ui/frappe': path.resolve(__dirname, '../frappe-ui/frappe/index.js'),
     // subpath entries must precede the bare `frappe-ui` key: a plain string alias
-    // matches by prefix, so without these `frappe-ui/editor` would rewrite to
-    // `.../src/index.ts/editor`. `internals` is pulled in by @framework/ui.
+    // matches by prefix, so without these subpaths would rewrite under
+    // `.../src/index.ts`. `internals` is pulled in by @framework/ui.
+    'frappe-ui/icons': path.resolve(__dirname, '../frappe-ui/icons/index.ts'),
     'frappe-ui/editor': path.resolve(
       __dirname,
       '../frappe-ui/src/molecules/editor/index.ts',


### PR DESCRIPTION
### Problem

Saved views in the view-type dropdown (List / Kanban / Group By ▾) render a blank glyph instead of their chosen icon.

Saved views store their icon as a bare lucide name (e.g. `a-arrow-up`, `align-center-horizontal`). `getIcon()` returned that string as-is, and the frappe-ui `Dropdown` renders a string icon through `FeatherIcon`. Feather doesn't have the newer lucide names, so nothing draws — you get an empty circle. Standard views (List/Kanban/Group By) were unaffected because they pass actual icon components.

### Fix

In `getIcon`, wrap a string icon in the project's `Icon` component so it resolves from the injected lucide sprite (`spritePlugin` from `frappe-ui/icons`) — the same way the breadcrumb prefix and the IconPicker already render view icons.

### Testing

- Verified locally: saved views with lucide icons now render their icon in the dropdown instead of a blank circle.
- Emoji icons, standard views, and empty-icon fallbacks are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)