### PR TITLE
fix(assign_to): use public add() API instead of removed private _add()

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.desk.form.assign_to import _add as assign
+from frappe.desk.form.assign_to import add as assign
 from frappe.model.document import Document
 
 from crm.api.exchange_rate import get_exchange_rate
@@ -172,7 +172,7 @@ class CRMDeal(Document):
 					# the agent is already set as an assignee
 					return
 
-		assign({"assign_to": [agent], "doctype": "CRM Deal", "name": self.name}, ignore_permissions=True)
+		assign({"assign_to": [agent], "doctype": "CRM Deal", "name": self.name})
 
 	def share_with_agent(self, agent):
 		if not agent:

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -5,7 +5,7 @@ import json
 
 import frappe
 from frappe import _
-from frappe.desk.form.assign_to import _add as assign
+from frappe.desk.form.assign_to import add as assign
 from frappe.model.document import Document
 from frappe.utils import validate_email_address
 
@@ -177,7 +177,7 @@ class CRMLead(Document):
 					# the agent is already set as an assignee
 					return
 
-		assign({"assign_to": [agent], "doctype": "CRM Lead", "name": self.name}, ignore_permissions=True)
+		assign({"assign_to": [agent], "doctype": "CRM Lead", "name": self.name})
 
 	def share_with_agent(self, agent):
 		if not agent:


### PR DESCRIPTION
**Note: This PR is AI-assisted**

## Summary

`CRM Lead` and `CRM Deal` import the **private** `_add()` from `frappe.desk.form.assign_to`. That symbol was removed in some Frappe 16.x patch releases (it is present on `version-16` HEAD, but absent in others — e.g. **16.5.0**, shipped inside `frappe/erpnext:v16.4.1`). On those Frappe versions, `bench install-app crm` / `bench migrate` abort while syncing the doctypes:

```
ImportError: cannot import name '_add' from 'frappe.desk.form.assign_to'
```

This switches Lead/Deal to Frappe's **public, stable** `add()` — the same API `CRM Task` already uses (`crm/fcrm/doctype/crm_task/crm_task.py`).

> Retargeted to `develop` from #2580 per review.

## Why this is correct

- `add(args)` is the `@frappe.whitelist()`-decorated public entry point; `_add()` is the internal worker whose existence varies across Frappe versions.
- `add()` does not accept `ignore_permissions=`, so the kwarg is dropped from the two call sites. This is safe: `assign_agent()` is invoked by a user who already holds permission on the Lead/Deal (they are editing/creating it), so the permission check inside `add()` passes — exactly the path `CRM Task.assign_to()` already relies on.
- Behaviour is unchanged for the common case; the only difference is that an explicit permission check now runs (consistent with `CRM Task`).

## Prior art

#2413 reported this and #2380 was merged as the fix, but **the offending `import _add` was not actually removed** — it is still present on both `main` and `develop`:

- `crm/fcrm/doctype/crm_lead/crm_lead.py:8`
- `crm/fcrm/doctype/crm_deal/crm_deal.py:6`

This PR removes it.

## Test

Validated against `frappe/erpnext:v16.4.1` (which bundles **Frappe Framework 16.5.0**, where `_add` is absent). On a throwaway site, without the fix `bench --site <site> install-app crm` fails with the `ImportError` above; **with this fix it completes cleanly**:

```
Installing crm...
Updating DocTypes for crm: 100%
* Installing Custom Fields in Email Template / Email Account / Web Form / Assignment Rule
Creating Workspace Sidebars
Creating Sidebar Items for Frappe CRM
Updating Dashboard for crm      # exit 0
```

Result: 39 FCRM doctypes created, `crm` registered in `Installed Application`. No `ImportError`.

Fixes #2413.
