### PR TITLE
fix(list): align deals like button with its column header

### DIFF
--- a/frontend/src/components/ListViews/DealsListView.vue
+++ b/frontend/src/components/ListViews/DealsListView.vue
@@ -89,19 +89,6 @@
           <div v-else-if="column.key === 'mobile_no' && item">
             <PhoneIcon class="h-4 w-4" />
           </div>
-          <div v-else-if="column.key === '_liked_by'">
-            <Button
-              variant="ghost"
-              @click.stop.prevent="
-                () => emit('likeDoc', { name: row.name, liked: isLiked(item) })
-              "
-            >
-              <HeartIcon
-                class="h-4 w-4"
-                :class="isLiked(item) ? 'fill-red-500 text-red-500' : ''"
-              />
-            </Button>
-          </div>
         </template>
         <template #default="{ label }">
           <div
@@ -159,6 +146,19 @@
               :disabled="true"
               class="text-ink-gray-9"
             />
+          </div>
+          <div v-else-if="column.key === '_liked_by'">
+            <Button
+              variant="ghost"
+              @click.stop.prevent="
+                () => emit('likeDoc', { name: row.name, liked: isLiked(item) })
+              "
+            >
+              <HeartIcon
+                class="h-4 w-4"
+                :class="isLiked(item) ? 'fill-red-500 text-red-500' : ''"
+              />
+            </Button>
           </div>
           <RatingInput
             v-else-if="column.type === 'Rating'"


### PR DESCRIPTION
The like (heart) column in the **Deals** list was misaligned — the row hearts sat ~8px left of the column-header heart. Every other list view (Leads, Contacts, Call Logs, Tasks, Organizations) was already correct.

## Cause
`DealsListView` rendered the `_liked_by` heart in the `ListRowItem` **`#prefix`** slot. That left an empty label as a second flex item in `#default`; with the column right-aligned (`justify-end` + `gap-2`), the empty label pinned to the cell's right edge and the gap pushed the heart ~8px left. The other views render the heart in `#default`, so it's the only item in the cell and stays flush-right.

## Fix
Move the heart from `#prefix` to `#default` in `DealsListView`, matching the other list views.

## Testing
Measured the header vs. row heart centers in the rendered deals list:
- Before: 8px offset (header heart flush right at the cell edge, row heart 8px inside).
- After: **0** — both flush at the right edge, centers aligned.

## Before

<img width="118" height="730" alt="image" src="https://github.com/user-attachments/assets/45e8ba4f-d0fb-4809-a843-161d2abd626b" />


## After

<img width="106" height="779" alt="image" src="https://github.com/user-attachments/assets/2ee78c06-7efd-457c-80d1-faf2e5ecb488" />
