### PR TITLE
fix: link notification emails to CRM UI instead of Desk

### DIFF
--- a/crm/extends/notification_log.py
+++ b/crm/extends/notification_log.py
@@ -1,0 +1,49 @@
+import frappe
+
+# CRM doctype -> frontend list route. Records live at /crm/<route>/<name>.
+CRM_ROUTES = {
+	"CRM Lead": "leads",
+	"CRM Deal": "deals",
+}
+
+
+def before_insert(doc, method=None):
+	"""Point CRM notification emails at the CRM UI instead of the Desk form.
+
+	Notification Log's email builder uses `doc.link` when set, otherwise it
+	falls back to a Desk (`/app/...`) form URL. CRM users often have Desk
+	access restricted, so build a CRM frontend link for CRM documents.
+	See https://github.com/frappe/crm/issues/705.
+	"""
+	if doc.link:
+		return
+
+	route = get_crm_route(doc.document_type, doc.document_name)
+	if route:
+		doc.link = frappe.utils.get_url(route)
+
+
+def get_crm_route(doctype, name):
+	"""Frontend path for a CRM record, or None for non-CRM documents.
+
+	Tasks have no standalone page in the CRM UI, so link to their parent
+	Lead/Deal's Tasks tab, mirroring the in-app notification behaviour.
+	"""
+	if not name:
+		return None
+
+	suffix = ""
+	if doctype == "CRM Task":
+		parent = frappe.db.get_value(
+			"CRM Task", name, ["reference_doctype", "reference_docname"], as_dict=True
+		)
+		if not parent or not parent.reference_docname:
+			return None
+		doctype, name = parent.reference_doctype, parent.reference_docname
+		suffix = "#tasks"
+
+	list_route = CRM_ROUTES.get(doctype)
+	if not list_route:
+		return None
+
+	return f"/crm/{list_route}/{name}{suffix}"

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -164,6 +164,9 @@ doc_events = {
 	"Contact": {
 		"validate": ["crm.api.contact.validate"],
 	},
+	"Notification Log": {
+		"before_insert": ["crm.extends.notification_log.before_insert"],
+	},
 	"ToDo": {
 		"after_insert": ["crm.api.todo.after_insert"],
 		"on_update": ["crm.api.todo.on_update"],

--- a/crm/tests/test_notification_log.py
+++ b/crm/tests/test_notification_log.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from crm.extends.notification_log import before_insert, get_crm_route
+
+
+class TestNotificationLogLink(IntegrationTestCase):
+	def test_get_crm_route_lead(self):
+		self.assertEqual(get_crm_route("CRM Lead", "CRM-LEAD-0001"), "/crm/leads/CRM-LEAD-0001")
+
+	def test_get_crm_route_deal(self):
+		self.assertEqual(get_crm_route("CRM Deal", "CRM-DEAL-0001"), "/crm/deals/CRM-DEAL-0001")
+
+	def test_get_crm_route_non_crm_doctype(self):
+		"""Non-CRM documents get no CRM route (email keeps the Desk fallback)."""
+		self.assertIsNone(get_crm_route("ToDo", "abc123"))
+
+	def test_get_crm_route_missing_name(self):
+		self.assertIsNone(get_crm_route("CRM Lead", None))
+
+	def test_get_crm_route_task_links_to_parent(self):
+		"""Tasks have no standalone page; link to the parent Lead/Deal Tasks tab."""
+		parent = frappe._dict(reference_doctype="CRM Deal", reference_docname="CRM-DEAL-0009")
+		with patch("frappe.db.get_value", return_value=parent):
+			self.assertEqual(get_crm_route("CRM Task", "task-1"), "/crm/deals/CRM-DEAL-0009#tasks")
+
+	def test_get_crm_route_task_without_parent(self):
+		with patch("frappe.db.get_value", return_value=None):
+			self.assertIsNone(get_crm_route("CRM Task", "task-orphan"))
+
+	def test_before_insert_sets_crm_link(self):
+		doc = frappe._dict(link=None, document_type="CRM Lead", document_name="CRM-LEAD-0002")
+		before_insert(doc)
+		self.assertEqual(doc.link, frappe.utils.get_url("/crm/leads/CRM-LEAD-0002"))
+
+	def test_before_insert_preserves_existing_link(self):
+		doc = frappe._dict(link="/custom/link", document_type="CRM Lead", document_name="CRM-LEAD-0003")
+		before_insert(doc)
+		self.assertEqual(doc.link, "/custom/link")
+
+	def test_before_insert_ignores_non_crm_doc(self):
+		doc = frappe._dict(link=None, document_type="ToDo", document_name="abc")
+		before_insert(doc)
+		self.assertIsNone(doc.link)
+
+	def test_before_insert_is_type_agnostic(self):
+		"""Covers assign AND unassign: both emit type='Assignment' logs, but the link is
+		set purely from the CRM document_type, so any notification type is handled."""
+		for notification_type in ("Assignment", "Share", "Default", None):
+			doc = frappe._dict(
+				link=None,
+				type=notification_type,
+				document_type="CRM Deal",
+				document_name="CRM-DEAL-0004",
+			)
+			before_insert(doc)
+			self.assertEqual(doc.link, frappe.utils.get_url("/crm/deals/CRM-DEAL-0004"))


### PR DESCRIPTION
## Problem

Assignment and unassignment **email notifications** link to the Desk UI (`/app/crm-deal/...`) instead of the Frappe CRM interface. This breaks for organizations that restrict Desk access for certain roles (e.g. sales executives), as reported in #705.

## Root cause

CRM assignments go through the framework's `assign_to` → `notify_assignment`, which creates a **Notification Log**. Its email builder uses `doc.link` when set, otherwise it falls back to `get_url_to_form()` → a `/app/...` Desk URL. CRM never set `link`.

## Fix

Add a `Notification Log` `before_insert` hook that sets `doc.link` to the CRM frontend URL for CRM documents (same approach Frappe Helpdesk uses for HD Tickets):

- `CRM Lead` → `/crm/leads/<name>`
- `CRM Deal` → `/crm/deals/<name>`
- `CRM Task` → parent Lead/Deal's Tasks tab (`/crm/deals/<name>#tasks`), since tasks have no standalone page

The hook keys off the **document type** rather than the notification type, so both **assign** and **unassign** emails are covered (and any future type such as Share). Pre-set links and non-CRM documents are left untouched.

## Testing

- Added `crm/tests/test_notification_log.py` (10 tests), including an explicit test that the behaviour is type-agnostic so assign/unassign coverage can't silently regress.
- Verified end-to-end by capturing the rendered email: the `Open Document` link now points to `/crm/deals/<name>` instead of `/app/...`.

Fixes #705