### PR TITLE
fix(forms): stop logging the author out when previewing a Link-field form

### DIFF
--- a/crm/tests/test_form_api.py
+++ b/crm/tests/test_form_api.py
@@ -232,6 +232,64 @@ class TestFormAPI(IntegrationTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			F.delete_form(other.name)
 
+	# ---- public page: Link options must not corrupt the author's session ----
+
+	def test_link_field_options_preserve_authenticated_session(self):
+		"""Rendering a Link field's guest-scoped options for a logged-in author's
+		preview must leave the author's live session untouched. Regression for the
+		preview-logout bug: frappe.set_user() overwrites session.sid (→ username) and
+		wipes session.data, so the enumerate-as-Guest path must snapshot and restore
+		them — otherwise the corrupted session is persisted under the real sid and the
+		author is demoted to Guest on their next request."""
+		from unittest.mock import patch
+
+		from crm.www import crm_form
+
+		# a realistic logged-in author session
+		frappe.set_user("Administrator")
+		frappe.session.sid = "regression_real_sid"
+		frappe.session.data = frappe._dict(
+			{
+				"user": "Administrator",
+				"sid": "regression_real_sid",
+				"data": frappe._dict({"session_expiry": "06:00:00", "csrf_token": "tok"}),
+			}
+		)
+		before_user, before_sid, before_data = (
+			frappe.session.user,
+			frappe.session.sid,
+			frappe.session.data,
+		)
+
+		# force the guest-enumeration branch (guest_can_select True); the actual
+		# query is irrelevant here — we're asserting the session dance is clean
+		with (
+			patch.object(crm_form, "guest_can_select", return_value=True),
+			patch("frappe.get_list", return_value=[]),
+		):
+			crm_form._link_field_options("CRM Industry")
+
+		self.assertEqual(frappe.session.user, before_user)
+		self.assertEqual(frappe.session.sid, before_sid)  # not mangled to the username
+		self.assertIs(frappe.session.data, before_data)  # nested data object preserved, not wiped
+		self.assertEqual(frappe.session.data.data.get("session_expiry"), "06:00:00")
+
+	def test_link_field_options_skip_switch_for_guest(self):
+		"""An anonymous visitor is already in the Guest context, so no session switch
+		happens — the query runs directly (set_user is never called)."""
+		from unittest.mock import patch
+
+		from crm.www import crm_form
+
+		frappe.set_user("Guest")
+		with (
+			patch.object(crm_form, "guest_can_select", return_value=True),
+			patch("frappe.get_list", return_value=[]),
+			patch("frappe.set_user") as mock_set_user,
+		):
+			crm_form._link_field_options("CRM Industry")
+			mock_set_user.assert_not_called()
+
 	# ---- permissions ----
 
 	def test_non_manager_cannot_manage_forms(self):

--- a/crm/www/crm_form.py
+++ b/crm/www/crm_form.py
@@ -78,12 +78,18 @@ def get_context(context):
 
 
 def _link_field_options(doctype: str) -> list[dict]:
-	"""Existing records of `doctype` as {value, label} dropdown options. Run as the Guest
-	user so the result honours the target's permissions at every level (doctype `select`,
-	row rules, if_owner) and shows exactly what an anonymous visitor may see. We switch the
-	session to Guest rather than `get_list(user="Guest")` because the latter still derives
-	its permission *tier* from the active session, so a manager preview would be checked for
-	Guest `read` and fail on a select-only target."""
+	"""Existing records of `doctype` as {value, label} dropdown options, scoped to what an
+	anonymous visitor may see — honouring the target's permissions at every level (doctype
+	`select`, row rules, if_owner).
+
+	An actual guest is already in that context, so we query directly. Only a logged-in author
+	*previewing* the page needs the session temporarily switched to Guest (rather than
+	`get_list(user="Guest")`, which still derives its permission *tier* from the active
+	session and would check the manager for Guest `read`, failing on a select-only target).
+	That switch is destructive — `frappe.set_user()` overwrites `session.sid` with the
+	username and wipes `session.data` — and restoring only the user leaves a corrupted
+	session that gets persisted under the real sid, logging the author out on their next
+	request. So snapshot and restore sid + data as well."""
 	if not doctype or not frappe.db.exists("DocType", doctype):
 		return []
 	if not guest_can_select(doctype):
@@ -91,17 +97,30 @@ def _link_field_options(doctype: str) -> list[dict]:
 	meta = frappe.get_meta(doctype)
 	title_field = meta.title_field or "name"
 	fields = ["name"] if title_field == "name" else ["name", title_field]
-	current_user = frappe.session.user
-	try:
-		frappe.set_user("Guest")  # nosemgrep — restored in finally; see docstring
-		rows = frappe.get_list(
+
+	def _query():
+		return frappe.get_list(
 			doctype,
 			fields=fields,
 			order_by=f"{title_field} asc",
 			limit=MAX_LINK_OPTIONS,
 		)
-	finally:
-		frappe.set_user(current_user)  # nosemgrep
+
+	current_user = frappe.session.user
+	if current_user == "Guest":
+		rows = _query()
+	else:
+		saved_sid = frappe.session.sid
+		saved_data = frappe.session.data
+		try:
+			frappe.set_user("Guest")  # nosemgrep — session fully restored in finally
+			rows = _query()
+		finally:
+			frappe.set_user(current_user)
+			# set_user() clobbers sid (→ username) and wipes data; put the real ones
+			# back so the request doesn't persist a corrupted session (see #logout).
+			frappe.session.sid = saved_sid
+			frappe.session.data = saved_data
 	return [{"value": r["name"], "label": r.get(title_field) or r["name"]} for r in rows]
 
 


### PR DESCRIPTION
When a Web Form maps a **Link** field whose target has Guest `select` granted, opening the public page `/crm-form/<route>` while **logged in** (an author previewing after publish) logs the author out. Every subsequent request then fails as Guest — the SPA bounces to login repeatedly and desk/API calls raise `PermissionError: … is not whitelisted`.

### Cause

`crm/www/crm_form.py::_link_field_options()` enumerates a Link field's options in a Guest context so a logged-in preview shows exactly what an anonymous visitor would see. It did this with:

```python
current_user = frappe.session.user
try:
    frappe.set_user("Guest")
    rows = frappe.get_list(...)
finally:
    frappe.set_user(current_user)
```

`frappe.set_user()` is destructive beyond swapping the user — it overwrites `session.sid` with the username and replaces `session.data` with an empty dict. Restoring only the *user* leaves `session.sid` = the user-id string and `session.data` empty. At end of request `Session.update()` persists that corrupted session into the cache under the **real** sid, so the author's next request reads an expired session → demoted to Guest → repeated logouts.

Verified at the session layer:

| | user | sid | `session.data.data` |
|---|---|---|---|
| before | Administrator | `REALSID_abc123` | intact |
| after (old) | Administrator | `Administrator` | `{}` (wiped) |
| after (this PR) | Administrator | `REALSID_abc123` | intact |

### Fix

- Skip the Guest switch entirely when the visitor is **already Guest** (the normal public case) — it was redundant there and only ran the destructive path for no reason.
- On the author-preview path, snapshot and restore `sid` and `data` alongside the user, so the live session is left untouched.

No API or template changes; the rendered options are unchanged.

### Tests

Adds two regression tests in `crm/tests/test_form_api.py`:

- `test_link_field_options_preserve_authenticated_session` — asserts `session.user`, `sid`, and `data` are all unchanged after the authenticated preview path. Fails against the pre-fix code (which mangled `sid` to the username and wiped `data`).
- `test_link_field_options_skip_switch_for_guest` — asserts an already-Guest visitor never triggers `set_user` at all.