### PR TITLE
refactor :replace read-only texteditor with sanitizeHTML  

### DIFF
--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -25,13 +25,13 @@
         />
       </Dropdown>
     </div>
-    <TextEditor
+    <!-- eslint-disable vue/no-v-html -->
+    <div
       v-if="note.content"
-      :content="note.content"
-      :editable="false"
-      editor-class="prose-sm text-p-sm max-w-none text-ink-gray-5 focus:outline-none"
-      class="flex-1 overflow-hidden"
+      class="prose-f prose-sm text-p-sm max-w-none text-ink-gray-5 flex-1 overflow-hidden"
+      v-html="sanitizeHTML(note.content)"
     />
+    <!-- eslint-enable vue/no-v-html -->
     <div class="mt-1 flex items-center justify-between gap-2">
       <div class="flex items-center gap-2 truncate">
         <UserAvatar :user="note.owner" size="xs" />
@@ -52,8 +52,9 @@
 <script setup>
 import UserAvatar from '@/components/UserAvatar.vue'
 import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
-import { Dropdown, TextEditor, call, toast } from 'frappe-ui'
+import { Dropdown, call, toast } from 'frappe-ui'
 import { usersStore } from '@/stores/users'
+import { sanitizeHTML } from '@/utils'
 
 defineProps({
   note: { type: Object, default: () => ({}) },

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -25,6 +25,7 @@
         />
       </Dropdown>
     </div>
+    <!-- content is passed through sanitizeHTML() (DOMPurify) before rendering, so v-html is safe here -->
     <!-- eslint-disable vue/no-v-html -->
     <div
       v-if="note.content"

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -25,12 +25,10 @@
         />
       </Dropdown>
     </div>
-    <TextEditor
+    <div
       v-if="note.content"
-      :content="note.content"
-      :editable="false"
-      editor-class="prose-sm text-p-sm max-w-none text-ink-gray-5 focus:outline-none"
-      class="flex-1 overflow-hidden"
+      class="prose-f prose-sm text-p-sm max-w-none text-ink-gray-5 flex-1 overflow-hidden"
+      v-html="sanitizeHTML(note.content)"
     />
     <div class="mt-1 flex items-center justify-between gap-2">
       <div class="flex items-center gap-2 truncate">
@@ -52,8 +50,9 @@
 <script setup>
 import UserAvatar from '@/components/UserAvatar.vue'
 import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
-import { Dropdown, TextEditor, call, toast } from 'frappe-ui'
+import { Dropdown, call, toast } from 'frappe-ui'
 import { usersStore } from '@/stores/users'
+import { sanitizeHTML } from '@/utils'
 
 defineProps({
   note: { type: Object, default: () => ({}) },

--- a/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
@@ -34,19 +34,15 @@
           <div v-if="template.subject" class="text-sm text-ink-gray-5">
             {{ __('Subject: {0}', [template.subject]) }}
           </div>
-          <TextEditor
+          <div
             v-if="template.use_html && template.response_html"
-            :content="template.response_html"
-            :editable="false"
-            editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f !prose-sm max-w-none !text-sm text-ink-gray-5 flex-1 overflow-hidden"
+            v-html="sanitizeHTML(template.response_html)"
           />
-          <TextEditor
+          <div
             v-else-if="template.response"
-            :content="template.response"
-            :editable="false"
-            editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f !prose-sm max-w-none !text-sm text-ink-gray-5 flex-1 overflow-hidden"
+            v-html="sanitizeHTML(template.response)"
           />
         </div>
       </div>
@@ -65,7 +61,8 @@
 <script setup>
 import { showSettings, activeSettingsPage } from '@/composables/settings'
 import { useBroadcast } from '@/composables/useBroadcast'
-import { TextEditor, createListResource } from 'frappe-ui'
+import { sanitizeHTML } from '@/utils'
+import { createListResource } from 'frappe-ui'
 import { ref, computed, nextTick, watch, onMounted } from 'vue'
 
 const props = defineProps({

--- a/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
@@ -34,20 +34,18 @@
           <div v-if="template.subject" class="text-sm text-ink-gray-5">
             {{ __('Subject: {0}', [template.subject]) }}
           </div>
-          <TextEditor
+          <!-- eslint-disable vue/no-v-html -->
+          <div
             v-if="template.use_html && template.response_html"
-            :content="template.response_html"
-            :editable="false"
-            editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f prose-sm max-w-none !text-sm text-ink-gray-5 flex-1 overflow-hidden"
+            v-html="sanitizeHTML(template.response_html)"
           />
-          <TextEditor
+          <div
             v-else-if="template.response"
-            :content="template.response"
-            :editable="false"
-            editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f prose-sm max-w-none !text-sm text-ink-gray-5 flex-1 overflow-hidden"
+            v-html="sanitizeHTML(template.response)"
           />
+          <!-- eslint-enable vue/no-v-html -->
         </div>
       </div>
       <div v-else class="mt-2">
@@ -65,7 +63,8 @@
 <script setup>
 import { showSettings, activeSettingsPage } from '@/composables/settings'
 import { useBroadcast } from '@/composables/useBroadcast'
-import { TextEditor, createListResource } from 'frappe-ui'
+import { createListResource } from 'frappe-ui'
+import { sanitizeHTML } from '@/utils'
 import { ref, computed, nextTick, watch, onMounted } from 'vue'
 
 const props = defineProps({

--- a/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/EmailTemplateSelectorModal.vue
@@ -34,6 +34,7 @@
           <div v-if="template.subject" class="text-sm text-ink-gray-5">
             {{ __('Subject: {0}', [template.subject]) }}
           </div>
+          <!-- content is passed through sanitizeHTML() (DOMPurify) before rendering, so v-html is safe here -->
           <!-- eslint-disable vue/no-v-html -->
           <div
             v-if="template.use_html && template.response_html"

--- a/frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue
@@ -42,6 +42,7 @@
           >
             {{ template.name }}
           </div>
+          <!-- content is passed through sanitizeHTML() (DOMPurify) before rendering, so v-html is safe here -->
           <!-- eslint-disable vue/no-v-html -->
           <div
             v-if="template.template"

--- a/frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue
@@ -42,13 +42,13 @@
           >
             {{ template.name }}
           </div>
-          <TextEditor
+          <!-- eslint-disable vue/no-v-html -->
+          <div
             v-if="template.template"
-            :content="template.template"
-            :editable="false"
-            editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f prose-sm max-w-none !text-sm text-ink-gray-5 flex-1 overflow-hidden"
+            v-html="sanitizeHTML(template.template)"
           />
+          <!-- eslint-enable vue/no-v-html -->
         </div>
       </div>
       <div v-else class="mt-2">
@@ -68,8 +68,9 @@
 </template>
 
 <script setup>
-import { TextEditor, createListResource } from 'frappe-ui'
+import { createListResource } from 'frappe-ui'
 import { ref, computed, nextTick, watch, onMounted } from 'vue'
+import { sanitizeHTML } from '@/utils'
 
 const props = defineProps({
   doctype: { type: String, default: '' },

--- a/frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue
+++ b/frontend/src/components/Modals/WhatsappTemplateSelectorModal.vue
@@ -42,12 +42,10 @@
           >
             {{ template.name }}
           </div>
-          <TextEditor
+          <div
             v-if="template.template"
-            :content="template.template"
-            :editable="false"
-            editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f !prose-sm max-w-none !text-sm text-ink-gray-5 flex-1 overflow-hidden"
+            v-html="sanitizeHTML(template.template)"
           />
         </div>
       </div>
@@ -68,8 +66,9 @@
 </template>
 
 <script setup>
-import { TextEditor, createListResource } from 'frappe-ui'
+import { createListResource } from 'frappe-ui'
 import { ref, computed, nextTick, watch, onMounted } from 'vue'
+import { sanitizeHTML } from '@/utils'
 
 const props = defineProps({
   doctype: { type: String, default: '' },

--- a/frontend/src/pages/Notes.vue
+++ b/frontend/src/pages/Notes.vue
@@ -55,6 +55,7 @@
             />
           </Dropdown>
         </div>
+        <!-- content is passed through sanitizeHTML() (DOMPurify) before rendering, so v-html is safe here -->
         <!-- eslint-disable vue/no-v-html -->
         <div
           v-if="note.content"

--- a/frontend/src/pages/Notes.vue
+++ b/frontend/src/pages/Notes.vue
@@ -55,13 +55,13 @@
             />
           </Dropdown>
         </div>
-        <TextEditor
+        <!-- eslint-disable vue/no-v-html -->
+        <div
           v-if="note.content"
-          :content="note.content"
-          :editable="false"
-          editor-class="prose-sm text-p-sm max-w-none text-ink-gray-5 focus:outline-none"
-          class="flex-1 overflow-hidden"
+          class="prose-f prose-sm text-p-sm max-w-none text-ink-gray-5 flex-1 overflow-hidden"
+          v-html="sanitizeHTML(note.content)"
         />
+        <!-- eslint-enable vue/no-v-html -->
         <div class="mt-2 flex items-center justify-between gap-2">
           <div class="flex items-center gap-2">
             <UserAvatar :user="note.owner" size="xs" />
@@ -100,9 +100,9 @@ import ViewControls from '@/components/ViewControls.vue'
 import { useDoctypeModal } from '@/composables/doctypeModal'
 import EmptyState from '@/components/ListViews/EmptyState.vue'
 import { usersStore } from '@/stores/users'
-import { timeAgo, formatDate } from '@/utils'
+import { timeAgo, formatDate, sanitizeHTML } from '@/utils'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import { TextEditor, call, Dropdown, Tooltip, ListFooter } from 'frappe-ui'
+import { call, Dropdown, Tooltip, ListFooter } from 'frappe-ui'
 import { ref, watch } from 'vue'
 
 const { getUser } = usersStore()

--- a/frontend/src/pages/Notes.vue
+++ b/frontend/src/pages/Notes.vue
@@ -55,12 +55,10 @@
             />
           </Dropdown>
         </div>
-        <TextEditor
+        <div
           v-if="note.content"
-          :content="note.content"
-          :editable="false"
-          editor-class="prose-sm text-p-sm max-w-none text-ink-gray-5 focus:outline-none"
-          class="flex-1 overflow-hidden"
+          class="prose-f prose-sm text-p-sm max-w-none text-ink-gray-5 flex-1 overflow-hidden"
+          v-html="sanitizeHTML(note.content)"
         />
         <div class="mt-2 flex items-center justify-between gap-2">
           <div class="flex items-center gap-2">
@@ -100,9 +98,9 @@ import ViewControls from '@/components/ViewControls.vue'
 import { useDoctypeModal } from '@/composables/doctypeModal'
 import EmptyState from '@/components/ListViews/EmptyState.vue'
 import { usersStore } from '@/stores/users'
-import { timeAgo, formatDate } from '@/utils'
+import { timeAgo, formatDate, sanitizeHTML } from '@/utils'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import { TextEditor, call, Dropdown, Tooltip, ListFooter } from 'frappe-ui'
+import { call, Dropdown, Tooltip, ListFooter } from 'frappe-ui'
 import { ref, watch } from 'vue'
 
 const { getUser } = usersStore()

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -106,6 +106,7 @@
           v-else-if="fieldName == 'description'"
           class="truncate text-base max-h-44"
         >
+          <!-- content is passed through sanitizeHTML() (DOMPurify) before rendering, so v-html is safe here -->
           <!-- eslint-disable vue/no-v-html -->
           <div
             v-if="getRow(itemName, fieldName).label"

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -106,12 +106,10 @@
           v-else-if="fieldName == 'description'"
           class="truncate text-base max-h-44"
         >
-          <TextEditor
+          <div
             v-if="getRow(itemName, fieldName).label"
-            :content="getRow(itemName, fieldName).label"
-            :editable="false"
-            editor-class="!prose-sm max-w-none focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f !prose-sm max-w-none flex-1 overflow-hidden"
+            v-html="sanitizeHTML(getRow(itemName, fieldName).label)"
           />
         </div>
         <div v-else class="truncate text-base">
@@ -198,10 +196,10 @@ import KanbanView from '@/components/Kanban/KanbanView.vue'
 import { useDoctypeModal } from '@/composables/doctypeModal'
 import { getMeta } from '@/stores/meta'
 import { usersStore } from '@/stores/users'
-import { formatDate } from '@/utils'
+import { formatDate, sanitizeHTML } from '@/utils'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import { Tooltip, Avatar, TextEditor, Dropdown, call } from 'frappe-ui'
+import { Tooltip, Avatar, Dropdown, call } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -106,13 +106,13 @@
           v-else-if="fieldName == 'description'"
           class="truncate text-base max-h-44"
         >
-          <TextEditor
+          <!-- eslint-disable vue/no-v-html -->
+          <div
             v-if="getRow(itemName, fieldName).label"
-            :content="getRow(itemName, fieldName).label"
-            :editable="false"
-            editor-class="!prose-sm max-w-none focus:outline-none"
-            class="flex-1 overflow-hidden"
+            class="prose-f prose-sm max-w-none flex-1 overflow-hidden"
+            v-html="sanitizeHTML(getRow(itemName, fieldName).label)"
           />
+          <!-- eslint-enable vue/no-v-html -->
         </div>
         <div v-else class="truncate text-base">
           {{ getRow(itemName, fieldName).label }}
@@ -198,10 +198,10 @@ import KanbanView from '@/components/Kanban/KanbanView.vue'
 import { useDoctypeModal } from '@/composables/doctypeModal'
 import { getMeta } from '@/stores/meta'
 import { usersStore } from '@/stores/users'
-import { formatDate } from '@/utils'
+import { formatDate, sanitizeHTML } from '@/utils'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import { Tooltip, Avatar, TextEditor, Dropdown, call } from 'frappe-ui'
+import { Tooltip, Avatar, Dropdown, call } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 


### PR DESCRIPTION
Replaces the read-only  TextEditor  instances with sanitizeHTML() + v-html in NoteArea.vue, Notes.vue, Tasks.vue, EmailTemplateSelectorModal.vue, and WhatsappTemplateSelectorModal.vue


the issue :  #2613 