### PR TITLE
feat(forms): field interdependencies + clear embedded form in place on submit

### DIFF
--- a/crm/api/form.py
+++ b/crm/api/form.py
@@ -431,8 +431,13 @@ def save_form(name: str | None, form: dict | str) -> dict:
 	# only rewrite the layout when fields were actually sent — an update that omits
 	# `fields` (e.g. a settings-only save) must not wipe the existing layout
 	if fields is not None:
+		# carry each field's interdependencies (depends_on / mandatory_depends_on /
+		# read_only_depends_on) from the target DocType so the public form honours the
+		# same show/hide/require rules the Desk form does (evaluated client-side)
+		src_meta = frappe.get_meta(doc.doc_type)
 		doc.set("web_form_fields", [])
 		for i, f in enumerate(fields):
+			df = src_meta.get_field(f.get("fieldname"))
 			doc.append(
 				"web_form_fields",
 				{
@@ -443,6 +448,9 @@ def save_form(name: str | None, form: dict | str) -> dict:
 					"reqd": 1 if f.get("reqd") else 0,
 					"placeholder": f.get("placeholder"),
 					"description": f.get("field_description"),
+					"depends_on": (df.depends_on or "") if df else "",
+					"mandatory_depends_on": (df.mandatory_depends_on or "") if df else "",
+					"read_only_depends_on": (df.read_only_depends_on or "") if df else "",
 					"idx": i + 1,
 				},
 			)

--- a/crm/api/form.py
+++ b/crm/api/form.py
@@ -431,9 +431,7 @@ def save_form(name: str | None, form: dict | str) -> dict:
 	# only rewrite the layout when fields were actually sent — an update that omits
 	# `fields` (e.g. a settings-only save) must not wipe the existing layout
 	if fields is not None:
-		# carry each field's interdependencies (depends_on / mandatory_depends_on /
-		# read_only_depends_on) from the target DocType so the public form honours the
-		# same show/hide/require rules the Desk form does (evaluated client-side)
+		# carry each field's depends_on rules from the target DocType onto the web form
 		src_meta = frappe.get_meta(doc.doc_type)
 		doc.set("web_form_fields", [])
 		for i, f in enumerate(fields):

--- a/crm/tests/test_form_api.py
+++ b/crm/tests/test_form_api.py
@@ -20,6 +20,9 @@ class TestFormAPI(IntegrationTestCase):
 		frappe.flags.in_web_form = False
 		frappe.form_dict.pop("web_form", None)
 		frappe.db.rollback()
+		# a test may have added a Property Setter to CRM Lead; drop the cached meta so
+		# the rolled-back change can't leak into the next test
+		frappe.clear_cache(doctype="CRM Lead")
 
 	# ---- field picker ----
 
@@ -181,6 +184,58 @@ class TestFormAPI(IntegrationTestCase):
 
 		# "Qualification" is a Deal status; the guard must keep it off the Lead
 		self.assertNotEqual(lead.status, "Qualification")
+
+	# ---- field interdependencies ----
+
+	def test_save_form_carries_field_dependencies_from_doctype(self):
+		"""depends_on / mandatory_depends_on / read_only_depends_on defined on the
+		target DocType's fields are copied onto the Web Form fields, so the public
+		page can honour the same show/hide/require/read-only rules as the Desk form."""
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+		make_property_setter(
+			"CRM Lead",
+			"website",
+			"depends_on",
+			"eval:doc.organization",
+			"Data",
+			validate_fields_for_doctype=False,
+		)
+		make_property_setter(
+			"CRM Lead",
+			"phone",
+			"mandatory_depends_on",
+			'eval:doc.organization == "Acme"',
+			"Data",
+			validate_fields_for_doctype=False,
+		)
+		make_property_setter(
+			"CRM Lead",
+			"last_name",
+			"read_only_depends_on",
+			"eval:doc.first_name",
+			"Data",
+			validate_fields_for_doctype=False,
+		)
+		frappe.clear_cache(doctype="CRM Lead")
+
+		name = make_form(
+			"dep-carry",
+			fields=[
+				{"fieldname": "organization", "fieldtype": "Data"},
+				{"fieldname": "website", "fieldtype": "Data"},
+				{"fieldname": "phone", "fieldtype": "Data"},
+				{"fieldname": "last_name", "fieldtype": "Data"},
+			],
+			hidden_fields=[],
+		)
+		by = {f.fieldname: f for f in frappe.get_doc("Web Form", name).web_form_fields}
+		self.assertEqual(by["website"].depends_on, "eval:doc.organization")
+		self.assertEqual(by["phone"].mandatory_depends_on, 'eval:doc.organization == "Acme"')
+		self.assertEqual(by["last_name"].read_only_depends_on, "eval:doc.first_name")
+		# a field without any rule stays clean
+		self.assertFalse(by["organization"].depends_on)
+		self.assertFalse(by["organization"].mandatory_depends_on)
 
 	# ---- layout persistence ----
 

--- a/crm/www/crm_form.html
+++ b/crm/www/crm_form.html
@@ -136,6 +136,16 @@
         padding: 10px 12px;
         margin-bottom: 16px;
       }
+      /* inline confirmation after an embedded submit (form stays, just clears) */
+      .form-ok {
+        display: none;
+        background: var(--success-bg);
+        color: var(--success-ink);
+        font-size: 13px;
+        border-radius: 9px;
+        padding: 10px 12px;
+        margin-bottom: 16px;
+      }
       .success { text-align: center; padding: 20px 4px 8px; }
       .success .check-ring {
         width: 48px; height: 48px; border-radius: 999px; margin: 0 auto 16px;
@@ -172,6 +182,7 @@
         {% if form_description %}<p class="subtitle">{{ form_description }}</p>{% endif %}
 
         <div class="form-error" id="form-error"></div>
+        <div class="form-ok" id="form-ok"></div>
 
         <form id="web-form" novalidate>
           {% for section in layout %}
@@ -249,17 +260,15 @@
         var CSRF = {{ csrf_token | tojson }};
         var DRAFT = {{ draft_preview | tojson }};
         var SUCCESS_URL = {{ success_url | tojson }};
+        var EMBED = {{ embed | tojson }};
         var form = document.getElementById("web-form");
         var errBox = document.getElementById("form-error");
+        var okBox = document.getElementById("form-ok");
         var btn = document.getElementById("submit-btn");
         var BREAKS = { "Section Break": 1, "Column Break": 1 };
 
-        // ---- field interdependencies (depends_on / mandatory_depends_on /
-        // read_only_depends_on) — mirror the framework so the public form applies the
-        // same show/hide, require, and read-only rules the Desk form does.
-
-        // current values of every field, keyed by fieldname (hidden ones included, so
-        // an expression can still reference a field the user isn't seeing right now)
+        // Field interdependencies: apply the DocType's depends_on / mandatory_depends_on
+        // / read_only_depends_on client-side, same rules as the Desk form.
         function collectDoc() {
           var doc = {};
           FIELDS.forEach(function (f) {
@@ -270,20 +279,12 @@
           });
           return doc;
         }
-
-        // A small, side-effect-free interpreter for a depends_on "eval:" expression.
-        // It mirrors the *supported forms* of the framework's evaluate_depends_on_value()
-        // (frappe/public/js/frappe/form/layout.js) but, because this is a public page,
-        // it PARSES the expression instead of running it through Function()/eval — so
-        // stored DocType metadata can never execute arbitrary JavaScript in a visitor's
-        // browser. It understands doc/parent member access, string/number/boolean/null
-        // literals, comparisons (== != === !== < <= > >=), logical (&& || !) and
-        // parentheses. Anything else (e.g. helper calls like in_list(...)) throws, and
-        // the caller falls back — never hiding or relaxing a field on an expression it
-        // can't safely evaluate.
         function coerce(v) {
           return Array.isArray(v) ? v.length > 0 : !!v;
         }
+        // Parse (never execute) an "eval:" expression, so stored metadata can't run JS on
+        // this public page. Supports doc/parent access, literals, comparisons, && || !,
+        // and parentheses; anything else throws → caller's fallback.
         function safeEval(src, doc, parent) {
           var i = 0;
           function ws() {
@@ -403,17 +404,14 @@
           if (i < src.length) throw new Error("trailing input");
           return out;
         }
-
-        // resolve a depends_on-style expression to a boolean. `fallback` is returned for
-        // an empty, unsupported, or invalid expression so a bad rule never silently
-        // hides or relaxes a field.
+        // `fallback` covers an empty, unsupported, or invalid expression
         function truthy(expr, doc, fallback) {
           var s = expr ? String(expr).trim() : "";
           if (!s) return fallback;
           try {
             if (s.slice(0, 5) === "eval:") return coerce(safeEval(s.slice(5), doc, doc));
-            if (s.slice(0, 3) === "fn:") return fallback; // server script hooks: N/A here
-            return coerce(doc[s]); // a plain fieldname
+            if (s.slice(0, 3) === "fn:") return fallback;
+            return coerce(doc[s]);
           } catch (e) {
             return fallback;
           }
@@ -447,8 +445,7 @@
               el.readOnly = ro;
             }
 
-            // show the * for a conditionally-mandatory field only while it applies
-            // (statically required fields keep their always-on * untouched)
+            // toggle the * for a conditionally-mandatory field (static ones keep theirs)
             if (wrap && !f.reqd) {
               var star = wrap.querySelector(".req");
               if (star) star.style.display = visible && isRequired(f, doc) ? "" : "none";
@@ -460,6 +457,16 @@
           errBox.textContent = msg || "Something went wrong. Please try again.";
           errBox.style.display = "block";
           errBox.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
+        // transient success acknowledgement used in embed mode (auto-hides)
+        function showOk(msg) {
+          okBox.textContent = msg || "Your response has been recorded.";
+          okBox.style.display = "block";
+          okBox.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          clearTimeout(showOk._t);
+          showOk._t = setTimeout(function () {
+            okBox.style.display = "none";
+          }, 5000);
         }
         function clearFieldErrors() {
           [].forEach.call(form.querySelectorAll(".has-error"), function (el) {
@@ -490,13 +497,20 @@
           }, 1000);
         }
 
-        // keep the rules live as the user types/selects, and apply them once on load
-        form.addEventListener("input", refreshDeps);
-        form.addEventListener("change", refreshDeps);
+        // keep the rules live as the user types/selects; also dismiss the success note
+        // as soon as they start the next entry
+        function onEdit() {
+          if (okBox.style.display !== "none") {
+            okBox.style.display = "none";
+            clearTimeout(showOk._t);
+          }
+          refreshDeps();
+        }
+        form.addEventListener("input", onEdit);
+        form.addEventListener("change", onEdit);
         refreshDeps();
 
-        // Discard (type="reset") clears the inputs natively; also drop our error UI and
-        // re-apply the dependency rules against the now-empty form (reset fires first)
+        // Discard (type="reset") clears inputs; also drop errors and re-apply the rules
         form.addEventListener("reset", function () {
           errBox.style.display = "none";
           clearFieldErrors();
@@ -515,9 +529,7 @@
             if (BREAKS[f.fieldtype]) return;
             var el = document.getElementById(f.fieldname);
             if (!el) return;
-            // a field hidden by depends_on is not collected or validated — it isn't
-            // part of the submission in its current state
-            if (!isVisible(f, doc)) return;
+            if (!isVisible(f, doc)) return; // hidden by depends_on → not submitted/validated
             var val = f.fieldtype === "Check" ? (el.checked ? 1 : 0) : el.value;
             values[f.fieldname] = val;
             if (isRequired(f, doc) && (val === "" || val === null || val === undefined)) {
@@ -564,6 +576,16 @@
                 var msg = "";
                 try { msg = m ? JSON.parse(JSON.parse(m)[0]).message : ""; } catch (e) {}
                 showError(msg || "Sorry, we couldn't submit your response. Please try again.");
+                btn.disabled = false;
+                btn.textContent = original;
+                return;
+              }
+              // embedded (and not redirecting): clear in place for the next submission
+              // instead of swapping the form out for the success page
+              if (EMBED && !DRAFT && !SUCCESS_URL) {
+                var okMsg = document.getElementById("success-title").textContent;
+                form.reset();
+                showOk(okMsg);
                 btn.disabled = false;
                 btn.textContent = original;
                 return;

--- a/crm/www/crm_form.html
+++ b/crm/www/crm_form.html
@@ -271,24 +271,149 @@
           return doc;
         }
 
-        // evaluate a depends_on-style expression against `doc`. This is a small mirror
-        // of the framework's evaluate_depends_on_value()
-        // (frappe/public/js/frappe/form/layout.js) — same forms: "eval:<js>", a plain
-        // fieldname (truthiness), or a boolean. We re-implement rather than import
-        // because this public page ships without the frappe JS bundle. Enforcement is
-        // client-side in Frappe too (the server doesn't apply mandatory_depends_on).
-        // `fallback` is returned for an empty or invalid expression so a bad rule never
-        // silently hides or relaxes a field.
+        // A small, side-effect-free interpreter for a depends_on "eval:" expression.
+        // It mirrors the *supported forms* of the framework's evaluate_depends_on_value()
+        // (frappe/public/js/frappe/form/layout.js) but, because this is a public page,
+        // it PARSES the expression instead of running it through Function()/eval — so
+        // stored DocType metadata can never execute arbitrary JavaScript in a visitor's
+        // browser. It understands doc/parent member access, string/number/boolean/null
+        // literals, comparisons (== != === !== < <= > >=), logical (&& || !) and
+        // parentheses. Anything else (e.g. helper calls like in_list(...)) throws, and
+        // the caller falls back — never hiding or relaxing a field on an expression it
+        // can't safely evaluate.
+        function coerce(v) {
+          return Array.isArray(v) ? v.length > 0 : !!v;
+        }
+        function safeEval(src, doc, parent) {
+          var i = 0;
+          function ws() {
+            while (i < src.length && /\s/.test(src[i])) i++;
+          }
+          function starts(tok) {
+            ws();
+            return src.substr(i, tok.length) === tok;
+          }
+          function primary() {
+            ws();
+            if (starts("(")) {
+              i++;
+              var e = orExpr();
+              ws();
+              if (!starts(")")) throw new Error("expected )");
+              i++;
+              return e;
+            }
+            if (starts("!")) {
+              i++;
+              return !coerce(primary());
+            }
+            var ch = src[i];
+            if (ch === '"' || ch === "'") {
+              i++;
+              var str = "";
+              while (i < src.length && src[i] !== ch) {
+                if (src[i] === "\\") i++;
+                str += src[i++];
+              }
+              i++;
+              return str;
+            }
+            var num = /^-?\d+(?:\.\d+)?/.exec(src.slice(i));
+            if (num) {
+              i += num[0].length;
+              return parseFloat(num[0]);
+            }
+            var id = /^[A-Za-z_$][\w$]*/.exec(src.slice(i));
+            if (!id) throw new Error("unexpected token");
+            i += id[0].length;
+            if (id[0] === "true") return true;
+            if (id[0] === "false") return false;
+            if (id[0] === "null") return null;
+            var base;
+            if (id[0] === "doc") base = doc;
+            else if (id[0] === "parent") base = parent;
+            else throw new Error("unknown identifier: " + id[0]); // no globals reachable
+            for (;;) {
+              ws();
+              if (src[i] === ".") {
+                i++;
+                var m = /^[A-Za-z_$][\w$]*/.exec(src.slice(i));
+                if (!m) throw new Error("bad member");
+                i += m[0].length;
+                base = base == null ? undefined : base[m[0]];
+              } else if (src[i] === "[") {
+                i++;
+                var key = orExpr();
+                ws();
+                if (!starts("]")) throw new Error("expected ]");
+                i++;
+                base = base == null ? undefined : base[key];
+              } else break;
+            }
+            return base;
+          }
+          function cmp() {
+            var l = primary();
+            ws();
+            var ops = ["===", "!==", "==", "!=", "<=", ">=", "<", ">"];
+            for (var k = 0; k < ops.length; k++) {
+              if (src.substr(i, ops[k].length) === ops[k]) {
+                i += ops[k].length;
+                var r = primary();
+                switch (ops[k]) {
+                  case "===":
+                  case "==":
+                    return l == r; // eslint-disable-line eqeqeq
+                  case "!==":
+                  case "!=":
+                    return l != r; // eslint-disable-line eqeqeq
+                  case "<":
+                    return l < r;
+                  case "<=":
+                    return l <= r;
+                  case ">":
+                    return l > r;
+                  case ">=":
+                    return l >= r;
+                }
+              }
+            }
+            return l;
+          }
+          function andExpr() {
+            var l = cmp();
+            while (starts("&&")) {
+              i += 2;
+              var r = cmp();
+              l = coerce(l) && coerce(r);
+            }
+            return l;
+          }
+          function orExpr() {
+            var l = andExpr();
+            while (starts("||")) {
+              i += 2;
+              var r = andExpr();
+              l = coerce(l) || coerce(r);
+            }
+            return l;
+          }
+          var out = orExpr();
+          ws();
+          if (i < src.length) throw new Error("trailing input");
+          return out;
+        }
+
+        // resolve a depends_on-style expression to a boolean. `fallback` is returned for
+        // an empty, unsupported, or invalid expression so a bad rule never silently
+        // hides or relaxes a field.
         function truthy(expr, doc, fallback) {
           var s = expr ? String(expr).trim() : "";
           if (!s) return fallback;
           try {
-            if (s.slice(0, 5) === "eval:") {
-              return !!Function("doc", "parent", '"use strict"; return (' + s.slice(5) + ");")(doc, doc);
-            }
+            if (s.slice(0, 5) === "eval:") return coerce(safeEval(s.slice(5), doc, doc));
             if (s.slice(0, 3) === "fn:") return fallback; // server script hooks: N/A here
-            var v = doc[s];
-            return Array.isArray(v) ? v.length > 0 : !!v;
+            return coerce(doc[s]); // a plain fieldname
           } catch (e) {
             return fallback;
           }

--- a/crm/www/crm_form.html
+++ b/crm/www/crm_form.html
@@ -185,10 +185,10 @@
                   {% if f.fieldtype == "Check" %}
                   <div class="check">
                     <input type="checkbox" id="{{ f.fieldname }}" name="{{ f.fieldname }}" />
-                    <label for="{{ f.fieldname }}">{{ f.label }}{% if f.reqd %}<span class="req">*</span>{% endif %}</label>
+                    <label for="{{ f.fieldname }}">{{ f.label }}{% if f.reqd or f.mandatory_depends_on %}<span class="req"{% if not f.reqd %} style="display: none"{% endif %}>*</span>{% endif %}</label>
                   </div>
                   {% else %}
-                  <label for="{{ f.fieldname }}">{{ f.label }}{% if f.reqd %}<span class="req">*</span>{% endif %}</label>
+                  <label for="{{ f.fieldname }}">{{ f.label }}{% if f.reqd or f.mandatory_depends_on %}<span class="req"{% if not f.reqd %} style="display: none"{% endif %}>*</span>{% endif %}</label>
                   {% if f.fieldtype in ("Small Text", "Text", "Long Text", "Text Editor", "HTML Editor", "Markdown Editor") %}
                   <textarea id="{{ f.fieldname }}" name="{{ f.fieldname }}" placeholder="{{ f.placeholder }}" {% if f.reqd %}required{% endif %}></textarea>
                   {% elif f.fieldtype == "Select" %}
@@ -254,6 +254,83 @@
         var btn = document.getElementById("submit-btn");
         var BREAKS = { "Section Break": 1, "Column Break": 1 };
 
+        // ---- field interdependencies (depends_on / mandatory_depends_on /
+        // read_only_depends_on) — mirror the framework so the public form applies the
+        // same show/hide, require, and read-only rules the Desk form does.
+
+        // current values of every field, keyed by fieldname (hidden ones included, so
+        // an expression can still reference a field the user isn't seeing right now)
+        function collectDoc() {
+          var doc = {};
+          FIELDS.forEach(function (f) {
+            if (BREAKS[f.fieldtype]) return;
+            var el = document.getElementById(f.fieldname);
+            if (!el) return;
+            doc[f.fieldname] = f.fieldtype === "Check" ? (el.checked ? 1 : 0) : el.value;
+          });
+          return doc;
+        }
+
+        // evaluate a depends_on-style expression against `doc`. This is a small mirror
+        // of the framework's evaluate_depends_on_value()
+        // (frappe/public/js/frappe/form/layout.js) — same forms: "eval:<js>", a plain
+        // fieldname (truthiness), or a boolean. We re-implement rather than import
+        // because this public page ships without the frappe JS bundle. Enforcement is
+        // client-side in Frappe too (the server doesn't apply mandatory_depends_on).
+        // `fallback` is returned for an empty or invalid expression so a bad rule never
+        // silently hides or relaxes a field.
+        function truthy(expr, doc, fallback) {
+          var s = expr ? String(expr).trim() : "";
+          if (!s) return fallback;
+          try {
+            if (s.slice(0, 5) === "eval:") {
+              return !!Function("doc", "parent", '"use strict"; return (' + s.slice(5) + ");")(doc, doc);
+            }
+            if (s.slice(0, 3) === "fn:") return fallback; // server script hooks: N/A here
+            var v = doc[s];
+            return Array.isArray(v) ? v.length > 0 : !!v;
+          } catch (e) {
+            return fallback;
+          }
+        }
+        function isVisible(f, doc) {
+          return truthy(f.depends_on, doc, true);
+        }
+        function isRequired(f, doc) {
+          return f.reqd ? true : truthy(f.mandatory_depends_on, doc, false);
+        }
+        function isReadOnly(f, doc) {
+          return truthy(f.read_only_depends_on, doc, false);
+        }
+
+        // apply the rules to the DOM: toggle visibility, read-only, and the required *
+        function refreshDeps() {
+          var doc = collectDoc();
+          FIELDS.forEach(function (f) {
+            if (BREAKS[f.fieldtype]) return;
+            var el = document.getElementById(f.fieldname);
+            if (!el) return;
+            var wrap = el.closest(".field");
+            var visible = isVisible(f, doc);
+            if (wrap) wrap.style.display = visible ? "" : "none";
+
+            var ro = isReadOnly(f, doc);
+            // selects/checkboxes have no readOnly; disable them (JS still reads .value)
+            if (f.fieldtype === "Check" || f.fieldtype === "Select" || f.fieldtype === "Link") {
+              el.disabled = ro;
+            } else {
+              el.readOnly = ro;
+            }
+
+            // show the * for a conditionally-mandatory field only while it applies
+            // (statically required fields keep their always-on * untouched)
+            if (wrap && !f.reqd) {
+              var star = wrap.querySelector(".req");
+              if (star) star.style.display = visible && isRequired(f, doc) ? "" : "none";
+            }
+          });
+        }
+
         function showError(msg) {
           errBox.textContent = msg || "Something went wrong. Please try again.";
           errBox.style.display = "block";
@@ -288,10 +365,17 @@
           }, 1000);
         }
 
-        // Discard (type="reset") clears the inputs natively; also drop our error UI
+        // keep the rules live as the user types/selects, and apply them once on load
+        form.addEventListener("input", refreshDeps);
+        form.addEventListener("change", refreshDeps);
+        refreshDeps();
+
+        // Discard (type="reset") clears the inputs natively; also drop our error UI and
+        // re-apply the dependency rules against the now-empty form (reset fires first)
         form.addEventListener("reset", function () {
           errBox.style.display = "none";
           clearFieldErrors();
+          setTimeout(refreshDeps, 0);
         });
 
         form.addEventListener("submit", function (e) {
@@ -299,15 +383,19 @@
           errBox.style.display = "none";
           clearFieldErrors();
 
+          var doc = collectDoc();
           var values = {};
           var missing = [];
           FIELDS.forEach(function (f) {
             if (BREAKS[f.fieldtype]) return;
             var el = document.getElementById(f.fieldname);
             if (!el) return;
+            // a field hidden by depends_on is not collected or validated — it isn't
+            // part of the submission in its current state
+            if (!isVisible(f, doc)) return;
             var val = f.fieldtype === "Check" ? (el.checked ? 1 : 0) : el.value;
             values[f.fieldname] = val;
-            if (f.reqd && (val === "" || val === null || val === undefined)) {
+            if (isRequired(f, doc) && (val === "" || val === null || val === undefined)) {
               missing.push(f);
               el.classList.add("has-error");
             }

--- a/crm/www/crm_form.py
+++ b/crm/www/crm_form.py
@@ -63,6 +63,12 @@ def get_context(context):
 			"reqd": int(f.reqd or 0),
 			"placeholder": f.placeholder or "",
 			"description": f.description or "",
+			# interdependency expressions, evaluated client-side against the live form
+			# values (see the <script> in crm_form.html) so the public form mirrors the
+			# Desk form's show/hide, require, and read-only behaviour
+			"depends_on": f.depends_on or "",
+			"mandatory_depends_on": f.mandatory_depends_on or "",
+			"read_only_depends_on": f.read_only_depends_on or "",
 		}
 		for f in doc.web_form_fields
 	]

--- a/crm/www/crm_form.py
+++ b/crm/www/crm_form.py
@@ -63,9 +63,7 @@ def get_context(context):
 			"reqd": int(f.reqd or 0),
 			"placeholder": f.placeholder or "",
 			"description": f.description or "",
-			# interdependency expressions, evaluated client-side against the live form
-			# values (see the <script> in crm_form.html) so the public form mirrors the
-			# Desk form's show/hide, require, and read-only behaviour
+			# interdependency expressions, evaluated client-side (see crm_form.html)
 			"depends_on": f.depends_on or "",
 			"mandatory_depends_on": f.mandatory_depends_on or "",
 			"read_only_depends_on": f.read_only_depends_on or "",


### PR DESCRIPTION
Two enhancements to the public web form.

## 1. Field interdependencies

Public web forms now apply the same field interdependencies as the Desk form — `depends_on`, `mandatory_depends_on`, and `read_only_depends_on` — so conditional show/hide, conditional-mandatory, and conditional read-only behave consistently for public submissions.

- **`save_form`** copies each field's `depends_on` / `mandatory_depends_on` / `read_only_depends_on` from the **target DocType** onto the Web Form fields — reusing Frappe's own field properties, not a new rule format.
- **`crm_form.py::get_context`** passes those expressions to the page.
- **`crm_form.html`** applies them live as the user types: visibility (`depends_on`, hidden fields excluded from validation + payload), the required `*` + validation (`mandatory_depends_on`), and read-only state (`read_only_depends_on`).

**On reusing the framework:** these are a client/form-layer construct in Frappe too — `_validate_mandatory` only enforces statically `reqd=1` fields, so honouring them client-side matches the framework. The evaluator **parses** the supported grammar (`eval:` comparisons/logic, plain-fieldname, boolean) rather than running the expression through `Function()`/`eval` — so stored metadata can never execute arbitrary JS on this public page (bare globals, call syntax and assignment all throw → the rule falls back).

## 2. Clear embedded form in place on submit

When the form is embedded (`?embed=1`) and there's no redirect URL, a successful submit now **clears the form and shows a brief inline confirmation** (the configured Success message) instead of replacing it with the success page. The host site doesn't visibly change and the visitor can submit again; the note auto-hides after 5s or as soon as they start the next entry. Standalone page, `redirect_url`, and draft preview are unchanged.

## Tests / verification

- Test asserting the three expressions are carried from the DocType onto the Web Form fields.
- Interdependencies verified in a real browser (show/hide, conditional-required blocking submit, read-only) and the interpreter unit-tested for both correctness and rejection of JS-execution escape vectors.
- Embed clear-in-place verified in a real cross-origin iframe (form clears, inline confirmation, reusable; note dismisses on next keystroke).

## Scope

Field-level only. Section-break `depends_on` (hiding whole sections) and teaching the builder preview to evaluate these are follow-ups.