### PR TITLE
fix: count unique deals per funnel stage

### DIFF
--- a/crm/api/dashboard.py
+++ b/crm/api/dashboard.py
@@ -1162,8 +1162,11 @@ def get_deal_status_change_counts(
 	filters: dict | None = None,
 ):
 	"""
-	Get count of each status change (to) for each deal, excluding deals with current status type 'Lost'.
-	Order results by status position.
+	Get count of unique deals that ever reached each status (to), excluding deals with current status
+	type 'Lost'. Order results by status position.
+
+	Counts distinct deals per stage rather than status-change events, so a deal that re-enters a stage
+	(e.g. Won -> Negotiation -> Won) is counted once per stage and does not inflate the funnel.
 	Returns:
 	[
 	  {"status": "Qualification", "count": 120},
@@ -1185,7 +1188,7 @@ def get_deal_status_change_counts(
 		.on(CRMDeal.status == CurrentStatus.name)
 		.join(TargetStatus)
 		.on(CRMStatusChangeLog.to == TargetStatus.name)
-		.select(CRMStatusChangeLog.to.as_("stage"), Count("*").as_("count"))
+		.select(CRMStatusChangeLog.to.as_("stage"), Count(CRMStatusChangeLog.parent).distinct().as_("count"))
 		.where(
 			(CRMStatusChangeLog.to.isnotnull())
 			& (CRMStatusChangeLog.to != "")

--- a/crm/tests/test_dashboard.py
+++ b/crm/tests/test_dashboard.py
@@ -444,6 +444,34 @@ class TestDashboard(IntegrationTestCase):
 			for entry in result:
 				self.assertIsInstance(entry, dict)
 
+	def test_status_change_counts_deduplicate_reentered_stages(self):
+		"""Re-entering a stage (Won -> Negotiation -> Won) must not double-count the deal"""
+		# Baseline counts before adding the toggled deal
+		baseline = {r["stage"]: r["count"] for r in get_deal_status_change_counts(self.from_date, self.to_date)}
+
+		deal = frappe.get_doc(
+			{
+				"doctype": "CRM Deal",
+				"organization": "Acme Corp",
+				"status": "Qualification",
+				"currency": "USD",
+				"exchange_rate": 1,
+				"deal_owner": "Administrator",
+			}
+		).insert()
+
+		# Toggle the status back and forth: this appends multiple status change log rows,
+		# including two "Won" transitions and one "Negotiation" transition.
+		for status in ["Negotiation", "Won", "Negotiation", "Won"]:
+			deal.status = status
+			deal.save()
+
+		counts = {r["stage"]: r["count"] for r in get_deal_status_change_counts(self.from_date, self.to_date)}
+
+		# Despite reaching each stage multiple times, the single deal adds exactly one to each stage.
+		self.assertEqual(counts.get("Negotiation", 0), baseline.get("Negotiation", 0) + 1)
+		self.assertEqual(counts.get("Won", 0), baseline.get("Won", 0) + 1)
+
 	def test_user_filtering_isolation(self):
 		"""Test that user filtering correctly isolates data across metrics"""
 		result_crm_user = get_total_leads(self.from_date, self.to_date, self.user2_email)


### PR DESCRIPTION
get_deal_status_change_counts counted rows in CRM Status Change Log, so a deal moved back and forth between stages (e.g. Won -> Negotiation -> Won) was counted twice in the same funnel stage. That inflates the funnel chart and suggests more pipeline progress than actually happened.

Count distinct deals per stage instead, so each deal contributes at most one to every stage it ever reached.