### PR TITLE
fix: assignment respects the acting user's permissions

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -172,7 +172,7 @@ class CRMDeal(Document):
 					# the agent is already set as an assignee
 					return
 
-		assign({"assign_to": [agent], "doctype": "CRM Deal", "name": self.name}, ignore_permissions=True)
+		assign({"assign_to": [agent], "doctype": "CRM Deal", "name": self.name})
 
 	def share_with_agent(self, agent):
 		if not agent:

--- a/crm/fcrm/doctype/crm_deal/test_crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/test_crm_deal.py
@@ -410,6 +410,29 @@ class TestCRMDeal(IntegrationTestCase):
 			settings.enable_forecasting = original_value
 			settings.save()
 
+	def test_assign_agent_respects_permissions(self):
+		"""assign_agent must not bypass the acting user's permissions on the deal"""
+		deal = create_test_deal(organization="Assign Permission Org", status="Qualification")
+
+		if not frappe.db.exists("User", "no-crm-access@example.com"):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": "no-crm-access@example.com",
+					"first_name": "No",
+					"last_name": "Access",
+				}
+			).insert(ignore_permissions=True)
+
+		try:
+			frappe.set_user("no-crm-access@example.com")
+			with self.assertRaises(frappe.PermissionError):
+				deal.assign_agent("Administrator")
+		finally:
+			frappe.set_user("Administrator")
+
+		self.assertNotIn("Administrator", deal.get_assigned_users())
+
 	def test_single_contact_auto_primary(self):
 		"""Test that single contact is automatically set as primary"""
 		contact = create_test_contact(first_name="Auto", email="auto@example.com")

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -177,7 +177,7 @@ class CRMLead(Document):
 					# the agent is already set as an assignee
 					return
 
-		assign({"assign_to": [agent], "doctype": "CRM Lead", "name": self.name}, ignore_permissions=True)
+		assign({"assign_to": [agent], "doctype": "CRM Lead", "name": self.name})
 
 	def share_with_agent(self, agent):
 		if not agent:


### PR DESCRIPTION
assign_agent() called frappe.desk.form.assign_to.assign with ignore_permissions=True on both CRM Deal and CRM Lead, so changing deal_owner/lead_owner created a ToDo assignment even when the acting user had no permission on the document.

Drop the flag so the normal permission check applies.