### PR TITLE
fix: stop FormattedInput from rendering description twice

### DIFF
--- a/frontend/src/components/Controls/FormattedInput.vue
+++ b/frontend/src/components/Controls/FormattedInput.vue
@@ -6,22 +6,17 @@
     @focus="handleFocus"
     @blur="isFocused = false"
   />
-  <slot name="description">
-    <p v-if="attrs.description" class="mt-1.5" :class="descriptionClasses">
-      {{ attrs.description }}
-    </p>
-  </slot>
 </template>
 <script setup>
 import { TextInput } from 'frappe-ui'
-import { ref, computed, nextTick, useAttrs } from 'vue'
+import { ref, computed, nextTick } from 'vue'
+
+defineOptions({ inheritAttrs: false })
 
 const props = defineProps({
   value: { type: [String, Number], default: '' },
   formattedValue: { type: [String, Number], default: '' },
 })
-
-const attrs = useAttrs()
 
 const isFocused = ref(false)
 const inputRef = ref(null)
@@ -38,15 +33,5 @@ function handleFocus() {
 
 const displayValue = computed(() => {
   return isFocused.value ? props.value : props.formattedValue || props.value
-})
-
-const descriptionClasses = computed(() => {
-  return [
-    {
-      sm: 'text-xs',
-      md: 'text-base',
-    }[attrs.size || 'sm'],
-    'text-ink-gray-5',
-  ]
 })
 </script>


### PR DESCRIPTION
## Summary
- Int/Float/Currency/Percent fields were showing field descriptions twice because `FormattedInput` forwarded `description` to frappe-ui `TextInput` and also rendered its own copy.
- Removed the duplicate local description so only `TextInput`'s built-in helper text is shown.

Fixes #2647

## Test plan
- [x] Open a Deal **Data** fields view with an Int/Float/Currency/Percent field that has a description (e.g. Net Total)
- [x] Confirm the description appears exactly once, with consistent styling
- [x] Confirm Data/Select/Text fields with descriptions still render once

## Evidence
### Before
<img width="583" height="187" alt="Before" src="https://github.com/user-attachments/assets/fce37b8b-d487-47fb-ba39-68a28728b23f" />

### After
<img width="583" height="187" alt="After" src="https://github.com/user-attachments/assets/0cdbea23-e86b-4dc6-b184-6ae237c3bc20" />