### PR TITLE
migrate write TextEditor instances to frappe-ui/editor

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,6 @@
     "@framework/ui": "link:../../frappe/ui",
     "@tiptap/core": "^3.26.0",
     "@tiptap/extension-paragraph": "^3.26.0",
-    "@tiptap/pm": "^3.26.0",
-    "@tiptap/vue-3": "^3.26.0",
     "@twilio/voice-sdk": "^2.10.2",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vitejs/plugin-vue-jsx": "^5.1.6",

--- a/frontend/src/components/Activities/CommentArea.vue
+++ b/frontend/src/components/Activities/CommentArea.vue
@@ -31,10 +31,9 @@
       class="rounded bg-surface-gray-1 px-3 py-[7.5px] text-base leading-6 transition-all duration-300 ease-in-out"
     >
       <template v-if="editing">
-        <TextEditor
+        <RichTextField
           :content="editContent"
-          :editable="true"
-          :editor-class="['prose-sm max-w-none min-h-[3rem]']"
+          editor-class="prose-sm max-w-none min-h-[3rem]"
           @change="editContent = $event"
         />
         <div class="mt-2 flex justify-end gap-2">
@@ -68,7 +67,8 @@
 <script setup>
 import UserAvatar from '@/components/UserAvatar.vue'
 import AttachmentItem from '@/components/AttachmentItem.vue'
-import { Dropdown, Button, TextEditor, call, toast } from 'frappe-ui'
+import RichTextField from '@/components/RichTextField.vue'
+import { Dropdown, Button, call, toast } from 'frappe-ui'
 import TimelineTimestamp from '@/components/Activities/TimelineTimestamp.vue'
 import { sanitizeHTML, ConfirmDelete } from '@/utils'
 import { sessionStore } from '@/stores/session'

--- a/frontend/src/components/Activities/CommentArea.vue
+++ b/frontend/src/components/Activities/CommentArea.vue
@@ -126,7 +126,7 @@ async function saveEdit() {
     })
     editing.value = false
     emit('reload')
-  } catch (e) {
+  } catch {
     toast.error(__('Failed to update comment'))
   } finally {
     saving.value = false
@@ -140,7 +140,7 @@ async function deleteComment() {
       name: props.activity.name,
     })
     emit('reload')
-  } catch (e) {
+  } catch {
     toast.error(__('Failed to delete comment'))
   }
 }

--- a/frontend/src/components/Calendar/CalendarEventPanel.vue
+++ b/frontend/src/components/Calendar/CalendarEventPanel.vue
@@ -382,9 +382,8 @@
       <div class="flex justify-between gap-3 mx-4.5 my-2.5 text-ink-gray-7">
         <DescriptionIcon class="size-4 mt-1.5" />
         <div class="flex w-full items-center gap-x-2 border rounded py-1">
-          <TextEditor
+          <RichTextField
             editor-class="!prose-sm !leading-[1.13rem] overflow-auto px-2.5 rounded placeholder-ink-gray-4 focus:bg-surface-base focus:ring-0 text-ink-gray-8 transition-colors"
-            :bubbleMenu="true"
             :content="_event.description"
             :placeholder="__('Add Description')"
             @change="
@@ -560,6 +559,7 @@ import DescriptionIcon from '@/components/Icons/DescriptionIcon.vue'
 import Attendee from '@/components/Calendar/Attendee.vue'
 import EventNotifications from '@/components/Calendar/EventNotifications.vue'
 import ShortcutTooltip from '@/components/ShortcutTooltip.vue'
+import RichTextField from '@/components/RichTextField.vue'
 import { globalStore } from '@/stores/global'
 import { sessionStore } from '@/stores/session'
 import { validateEmail, deepClone, sanitizeHTML } from '@/utils'
@@ -576,7 +576,6 @@ import {
   Switch,
   DatePicker,
   TimePicker,
-  TextEditor,
   ErrorMessage,
   Dropdown,
   dayjs,

--- a/frontend/src/components/Controls/TextEditorControl.vue
+++ b/frontend/src/components/Controls/TextEditorControl.vue
@@ -1,20 +1,37 @@
 <template>
-  <TextEditor
-    :content="value"
+  <Editor
+    v-model="content"
+    :extensions="extensions"
     :placeholder="placeholder"
     :editable="!disabled"
-    :editor-class="editorClasses"
-    :fixed-menu="disabled ? false : fixedMenu"
-    :bubble-menu="bubbleMenu"
-    v-bind="$attrs"
+    :upload-function="(file) => uploadFile(file)"
     @change="onContentChange"
     @blur="onBlur"
-  />
+  >
+    <EditorFixedMenu
+      v-if="fixedMenu && !disabled"
+      :items="fullToolbar"
+      class="w-full overflow-x-auto rounded-t-lg border border-outline-gray-2 p-1"
+    />
+    <EditorBubbleMenu v-if="bubbleMenu" :items="bubbleToolbar" />
+    <EditorContent :class="editorClasses" />
+  </Editor>
 </template>
 
 <script setup>
-import { TextEditor } from 'frappe-ui'
-import { computed, ref } from 'vue'
+import {
+  Editor,
+  EditorContent,
+  EditorFixedMenu,
+  EditorBubbleMenu,
+} from 'frappe-ui/editor'
+import {
+  buildEditorExtensions,
+  fullToolbar,
+  bubbleToolbar,
+  uploadFile,
+} from '@/components/editor/config'
+import { computed, ref, watch } from 'vue'
 
 const props = defineProps({
   value: { type: String, default: '' },
@@ -75,17 +92,25 @@ const editorClasses = computed(() => {
   ]
 })
 
-const latestContent = ref(props.value)
+const extensions = buildEditorExtensions()
+
+const content = ref(props.value ?? '')
 const isDirty = ref(false)
 
+watch(
+  () => props.value,
+  (val) => {
+    content.value = val ?? ''
+  },
+)
+
 function onContentChange(val) {
-  latestContent.value = val
   if (val !== (props.value ?? '')) isDirty.value = true
 }
 
 function onBlur() {
   if (!isDirty.value) return
   isDirty.value = false
-  emit('change', latestContent.value)
+  emit('change', content.value)
 }
 </script>

--- a/frontend/src/components/Modals/EditValueModal.vue
+++ b/frontend/src/components/Modals/EditValueModal.vue
@@ -37,13 +37,13 @@
 
 <script setup>
 import Link from '@/components/Controls/Link.vue'
+import TextEditorControl from '@/components/Controls/TextEditorControl.vue'
 import { useTelemetry } from 'frappe-ui/frappe'
 import {
   Combobox,
   FormControl,
   call,
   createResource,
-  TextEditor,
   DatePicker,
 } from 'frappe-ui'
 import { ref, computed, onMounted, h } from 'vue'
@@ -167,12 +167,13 @@ function getValueComponent(f) {
   } else if (typeDate.includes(fieldtype)) {
     return h(DatePicker)
   } else if (typeEditor.includes(fieldtype)) {
-    return h(TextEditor, {
+    return h(TextEditorControl, {
       variant: 'outline',
       editorClass:
         '!prose-sm overflow-auto min-h-[80px] max-h-80 py-1.5 px-2 rounded border border-outline-gray-2 bg-surface-base hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors',
+      fixedMenu: false,
       bubbleMenu: true,
-      content: newValue.value,
+      value: newValue.value,
     })
   } else {
     return h(FormControl, { type: 'text' })

--- a/frontend/src/components/Modals/EditValueModal.vue
+++ b/frontend/src/components/Modals/EditValueModal.vue
@@ -75,9 +75,12 @@ const fields = createResource({
   transform: (data) => {
     // `description` renders as a second line in the dropdown, which has no
     // max width, so a long one stretches the whole list.
-    return data
-      .filter((f) => f.hidden == 0 && f.read_only == 0)
-      .map(({ description, ...f }) => ({ ...f, value: f.fieldname }))
+    return (
+      data
+        .filter((f) => f.hidden == 0 && f.read_only == 0)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .map(({ description, ...f }) => ({ ...f, value: f.fieldname }))
+    )
   },
 })
 

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -172,9 +172,8 @@
             {{ __('Description') }}
           </div>
           <div class="w-9/12">
-            <TextEditor
+            <RichTextField
               editor-class="!prose-sm overflow-auto min-h-[80px] max-h-80 py-1.5 px-2 rounded border border-outline-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-3 hover:border-outline-elevation-2 hover:shadow-sm focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors"
-              :bubbleMenu="true"
               :content="_event.description"
               :placeholder="__('Add Description.')"
               @change="(val) => (_event.description = val)"
@@ -230,9 +229,9 @@
 <script setup>
 import EventNotifications from '@/components/Calendar/EventNotifications.vue'
 import Attendee from '@/components/Calendar/Attendee.vue'
+import RichTextField from '@/components/RichTextField.vue'
 import {
   Switch,
-  TextEditor,
   ErrorMessage,
   Dialog,
   DatePicker,

--- a/frontend/src/components/RichTextField.vue
+++ b/frontend/src/components/RichTextField.vue
@@ -1,0 +1,56 @@
+<template>
+  <Editor
+    v-model="content"
+    :extensions="extensions"
+    :placeholder="placeholder"
+    :editable="editable"
+    :upload-function="(file) => uploadFile(file)"
+    @change="(val) => emit('change', val)"
+  >
+    <EditorFixedMenu
+      v-if="fixedMenu"
+      :items="fullToolbar"
+      class="w-full overflow-x-auto rounded-t-lg border border-outline-gray-2 p-1"
+    />
+    <EditorBubbleMenu v-if="bubbleMenu" :items="bubbleToolbar" />
+    <EditorContent :class="editorClass" />
+  </Editor>
+</template>
+
+<script setup>
+import {
+  Editor,
+  EditorContent,
+  EditorFixedMenu,
+  EditorBubbleMenu,
+} from 'frappe-ui/editor'
+import {
+  buildEditorExtensions,
+  fullToolbar,
+  bubbleToolbar,
+  uploadFile,
+} from '@/components/editor/config'
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  content: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+  editable: { type: Boolean, default: true },
+  editorClass: { type: String, default: '' },
+  fixedMenu: { type: Boolean, default: false },
+  bubbleMenu: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['change'])
+
+const content = ref(props.content ?? '')
+
+watch(
+  () => props.content,
+  (val) => {
+    content.value = val ?? ''
+  },
+)
+
+const extensions = buildEditorExtensions()
+</script>

--- a/frontend/src/components/RichTextField.vue
+++ b/frontend/src/components/RichTextField.vue
@@ -1,20 +1,22 @@
 <template>
-  <Editor
-    v-model="content"
-    :extensions="extensions"
-    :placeholder="placeholder"
-    :editable="editable"
-    :upload-function="(file) => uploadFile(file)"
-    @change="(val) => emit('change', val)"
-  >
-    <EditorFixedMenu
-      v-if="fixedMenu"
-      :items="fullToolbar"
-      class="w-full overflow-x-auto rounded-t-lg border border-outline-gray-2 p-1"
-    />
-    <EditorBubbleMenu v-if="bubbleMenu" :items="bubbleToolbar" />
-    <EditorContent :class="editorClass" />
-  </Editor>
+  <div>
+    <Editor
+      v-model="content"
+      :extensions="extensions"
+      :placeholder="placeholder"
+      :editable="editable"
+      :upload-function="(file) => uploadFile(file)"
+      @change="(val) => emit('change', val)"
+    >
+      <EditorFixedMenu
+        v-if="fixedMenu"
+        :items="fullToolbar"
+        class="w-full overflow-x-auto rounded-t-lg border border-b-0 border-outline-gray-2 p-1"
+      />
+      <EditorBubbleMenu v-if="bubbleMenu" :items="bubbleToolbar" />
+      <EditorContent :class="editorClass" />
+    </Editor>
+  </div>
 </template>
 
 <script setup>

--- a/frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue
+++ b/frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue
@@ -101,10 +101,8 @@
             {{ __('Content') }}
             <span class="text-ink-red-6">*</span>
           </div>
-          <TextEditor
-            ref="content"
+          <RichTextField
             editor-class="!prose-sm max-w-full overflow-auto min-h-[180px] max-h-80 py-1.5 px-2 rounded border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 hover:shadow-sm focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors"
-            :bubbleMenu="true"
             :content="template.response"
             :placeholder="
               __(
@@ -122,13 +120,8 @@
   </div>
 </template>
 <script setup>
-import {
-  TextEditor,
-  FormControl,
-  Switch,
-  toast,
-  createResource,
-} from 'frappe-ui'
+import RichTextField from '@/components/RichTextField.vue'
+import { FormControl, Switch, toast, createResource } from 'frappe-ui'
 import { computed, inject, onMounted, ref } from 'vue'
 
 const props = defineProps({

--- a/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
+++ b/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
@@ -102,10 +102,8 @@
             {{ __('Content') }}
             <span class="text-ink-red-6">*</span>
           </div>
-          <TextEditor
-            ref="content"
+          <RichTextField
             editor-class="!prose-sm max-w-full overflow-auto min-h-[180px] max-h-80 py-1.5 px-2 rounded border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 hover:shadow-sm focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors"
-            :bubbleMenu="true"
             :content="template.response"
             :placeholder="
               __(
@@ -124,7 +122,8 @@
 </template>
 <script setup>
 import { useBroadcast } from '@/composables/useBroadcast'
-import { TextEditor, FormControl, Switch, toast } from 'frappe-ui'
+import RichTextField from '@/components/RichTextField.vue'
+import { FormControl, Switch, toast } from 'frappe-ui'
 import { inject, onMounted, ref } from 'vue'
 
 const props = defineProps({

--- a/frontend/src/components/Settings/Profile/UserEmailSettings.vue
+++ b/frontend/src/components/Settings/Profile/UserEmailSettings.vue
@@ -36,11 +36,10 @@
             {{ __('Manage your email signature') }}
           </span>
         </div>
-        <TextEditor
+        <RichTextField
           editor-class="prose-sm min-h-28 max-w-full border rounded-b-lg border-t-0 p-2 border-outline-elevation-2"
           :content="user.doc.email_signature"
           placeholder="Type something..."
-          :bubbleMenu="true"
           :fixed-menu="true"
           @change="(val) => (user.doc.email_signature = val)"
         />
@@ -118,13 +117,13 @@
 </template>
 <script setup>
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+import RichTextField from '@/components/RichTextField.vue'
 import {
   Badge,
   Button,
   Combobox,
   createDocumentResource,
   createListResource,
-  TextEditor,
   toast,
 } from 'frappe-ui'
 import { computed, inject } from 'vue'

--- a/frontend/src/components/Telephony/ExotelCallUI.vue
+++ b/frontend/src/components/Telephony/ExotelCallUI.vue
@@ -139,11 +139,8 @@
       </div>
       <div class="body flex-1">
         <div v-if="showNote">
-          <TextEditor
-            ref="content"
-            variant="ghost"
+          <RichTextField
             editor-class="prose-sm h-[290px] text-ink-base overflow-auto mt-1"
-            :bubbleMenu="true"
             :content="note.content"
             :placeholder="__('Take a note...')"
             @change="(val) => (note.content = val)"
@@ -235,10 +232,11 @@ import NoteIcon from '@/components/Icons/NoteIcon.vue'
 import TaskIcon from '@/components/Icons/TaskIcon.vue'
 import TaskPanel from '@/components/Telephony/TaskPanel.vue'
 import CountUpTimer from '@/components/CountUpTimer.vue'
+import RichTextField from '@/components/RichTextField.vue'
 import { globalStore } from '@/stores/global'
 import { sessionStore } from '@/stores/session'
 import { useDraggable, useWindowSize } from '@vueuse/core'
-import { TextEditor, Avatar, Button, createResource, toast } from 'frappe-ui'
+import { Avatar, Button, createResource, toast } from 'frappe-ui'
 import { ref, onBeforeUnmount, watch, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 

--- a/frontend/src/components/Telephony/TaskPanel.vue
+++ b/frontend/src/components/Telephony/TaskPanel.vue
@@ -7,11 +7,8 @@
       class="mb-2 title"
       :placeholder="__('Schedule a task...')"
     />
-    <TextEditor
-      ref="content"
-      variant="ghost"
+    <RichTextField
       editor-class="prose-sm h-[150px] text-ink-base overflow-auto"
-      :bubbleMenu="true"
       :content="task.description"
       :placeholder="__('Add description...')"
       @change="(val) => (task.description = val)"
@@ -80,9 +77,10 @@ import TaskStatusIcon from '@/components/Icons/TaskStatusIcon.vue'
 import TaskPriorityIcon from '@/components/Icons/TaskPriorityIcon.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import Link from '@/components/Controls/Link.vue'
+import RichTextField from '@/components/RichTextField.vue'
 import { usersStore } from '@/stores/users'
 import { taskStatusOptions, taskPriorityOptions, getFormat } from '@/utils'
-import { TextEditor, Dropdown, Tooltip, DateTimePicker } from 'frappe-ui'
+import { Dropdown, Tooltip, DateTimePicker } from 'frappe-ui'
 import { reactive } from 'vue'
 
 const props = defineProps({

--- a/frontend/src/components/editor/config.ts
+++ b/frontend/src/components/editor/config.ts
@@ -18,6 +18,7 @@ import {
   InlineCode,
   HorizontalRule,
   InsertTable,
+  Strike,
   type MenuItem,
 } from 'frappe-ui/editor'
 import { useFileUpload } from 'frappe-ui'
@@ -79,6 +80,10 @@ export const fullToolbar: MenuItem[] = [
   HorizontalRule,
   InsertTable,
 ]
+
+/** Compact toolbar for inline/ghost fields (generic form fields, grid rows) —
+ *  shown in a floating bubble on text selection rather than a fixed bar. */
+export const bubbleToolbar: MenuItem[] = [Bold, Italic, Strike, InsertLink]
 
 /** Upload handler for images/files dropped or pasted into an editor. */
 export function uploadFile(


### PR DESCRIPTION
issues : #2523
Added a new RichTextField.vue component that wraps the new Editor from frappe-ui/editor, so it can be reused wherever a simple rich text field is needed.
Updated TextEditorControl.vue and other components (CommentArea, CalendarEventPanel, EventModal, EditValueModal, email templates, telephony panels, etc.) to use the new editor instead of the old one.
