### PR TITLE
fix: range filter not working in dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -145,7 +145,12 @@ import LayoutHeader from '@/components/LayoutHeader.vue'
 import Link from '@/components/Controls/Link.vue'
 import { usersStore } from '@/stores/users'
 import { copy } from '@/utils'
-import { getLastXDays, formatter, formatRange } from '@/utils/dashboard'
+import {
+  getLastXDays,
+  formatter,
+  formatRange,
+  parseDateRange,
+} from '@/utils/dashboard'
 import {
   usePageMeta,
   createResource,
@@ -170,13 +175,11 @@ const filters = reactive({
 })
 
 const fromDate = computed(() => {
-  if (!filters.period) return null
-  return filters.period.split(',')[0]
+  return parseDateRange(filters.period)[0] || null
 })
 
 const toDate = computed(() => {
-  if (!filters.period) return null
-  return filters.period.split(',')[1]
+  return parseDateRange(filters.period)[1] || null
 })
 
 function updateFilter(key: string, value: unknown, callback?: () => void) {

--- a/frontend/src/utils/dashboard.ts
+++ b/frontend/src/utils/dashboard.ts
@@ -1,5 +1,7 @@
 import { dayjs } from 'frappe-ui'
 
+export type DashboardDateRange = string | [string, string] | [] | null
+
 export function getLastXDays(range: number = 30): string | null {
   const today = new Date()
   const lastXDate = new Date(today)
@@ -10,8 +12,14 @@ export function getLastXDays(range: number = 30): string | null {
   )}`
 }
 
-export function formatter(range: string) {
-  const [from, to] = range.split(',')
+export function parseDateRange(range: DashboardDateRange): [string, string] {
+  if (!range) return ['', '']
+  const dates = Array.isArray(range) ? range : range.split(',')
+  return [dates[0] || '', dates[1] || '']
+}
+
+export function formatter(range: DashboardDateRange) {
+  const [from, to] = parseDateRange(range)
   return `${formatRange(from)} to ${formatRange(to)}`
 }
 


### PR DESCRIPTION
`DateRangePicker` now emits [from, to] but the dashboard expected a comma separated string and threw before calling dashboardItems.reload(). fixed it by parsing comma separated string in [from,to] format