### PR TITLE
fix(router): stop the persona-check crashing server-side on Frappe v15

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -25,7 +25,7 @@ export async function shouldCapturePersona() {
   // "telemetry is not enabled": this call gates nothing but the onboarding
   // wizard, so the safe default is to skip it, not to let a missing
   // whitelisted method surface as a server-side error on every navigation.
-  let enabled = false
+  let enabled
   try {
     const config = await call('frappe.utils.telemetry.pulse.client.boot_config')
     enabled = config?.enabled

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -7,7 +7,7 @@ import { viewsStore } from '@/stores/views'
 let personaChecked = false
 export const PERSONA_DONE_KEY = 'crm_persona_captured'
 
-async function shouldCapturePersona() {
+export async function shouldCapturePersona() {
   // Client-side flag guards against re-prompting if the server persist failed.
   if (localStorage.getItem(PERSONA_DONE_KEY)) return false
   const captured = await call('frappe.client.get_single_value', {
@@ -16,8 +16,22 @@ async function shouldCapturePersona() {
   })
   if (captured) return false
   // The wizard only feeds telemetry; skip it entirely if the user opted out.
-  const { enabled } =
-    (await call('frappe.utils.telemetry.pulse.client.boot_config')) || {}
+  //
+  // boot_config is whitelisted on newer Frappe (the pulse telemetry client's
+  // replacement for is_enabled), but is_enabled itself stopped being
+  // whitelisted on the same release — so there is no single endpoint that
+  // exists on both an older stable site and a newer one. Rather than pick a
+  // version to break, treat "can't tell if telemetry is enabled" as
+  // "telemetry is not enabled": this call gates nothing but the onboarding
+  // wizard, so the safe default is to skip it, not to let a missing
+  // whitelisted method surface as a server-side error on every navigation.
+  let enabled = false
+  try {
+    const config = await call('frappe.utils.telemetry.pulse.client.boot_config')
+    enabled = config?.enabled
+  } catch {
+    enabled = false
+  }
   return !!enabled
 }
 

--- a/frontend/tests/unit/shouldCapturePersona.test.js
+++ b/frontend/tests/unit/shouldCapturePersona.test.js
@@ -17,7 +17,9 @@ vi.mock('@/stores/users', () => ({ usersStore: vi.fn() }))
 vi.mock('@/stores/session', () => ({ sessionStore: vi.fn() }))
 vi.mock('@/stores/views', () => ({ viewsStore: vi.fn() }))
 
-const { shouldCapturePersona, PERSONA_DONE_KEY } = await import('../../src/router.js')
+const { shouldCapturePersona, PERSONA_DONE_KEY } = await import(
+  '../../src/router.js'
+)
 
 describe('shouldCapturePersona', () => {
   beforeEach(() => {
@@ -66,7 +68,7 @@ describe('shouldCapturePersona', () => {
       .mockResolvedValueOnce(false) // persona_captured
       .mockRejectedValueOnce(
         new Error(
-          "ValidationError: Failed to get method for command frappe.utils.telemetry.pulse.client.boot_config",
+          'ValidationError: Failed to get method for command frappe.utils.telemetry.pulse.client.boot_config',
         ),
       )
     await expect(shouldCapturePersona()).resolves.toBe(false)

--- a/frontend/tests/unit/shouldCapturePersona.test.js
+++ b/frontend/tests/unit/shouldCapturePersona.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// `call` must be mocked before importing the module under test, since
+// router.js reads it at module-eval time via the `import { call } from
+// 'frappe-ui'` at the top of the file.
+const callMock = vi.fn()
+vi.mock('frappe-ui', () => ({ call: (...args) => callMock(...args) }))
+
+// createRouter/createWebHistory run at module scope in router.js (outside
+// shouldCapturePersona), so they need a working implementation too, not a
+// bare mock — otherwise importing the module throws before any test runs.
+vi.mock('vue-router', () => ({
+  createRouter: () => ({ beforeEach: vi.fn() }),
+  createWebHistory: () => ({}),
+}))
+vi.mock('@/stores/users', () => ({ usersStore: vi.fn() }))
+vi.mock('@/stores/session', () => ({ sessionStore: vi.fn() }))
+vi.mock('@/stores/views', () => ({ viewsStore: vi.fn() }))
+
+const { shouldCapturePersona, PERSONA_DONE_KEY } = await import('../../src/router.js')
+
+describe('shouldCapturePersona', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns false without calling the server when already captured locally', async () => {
+    localStorage.setItem(PERSONA_DONE_KEY, '1')
+    expect(await shouldCapturePersona()).toBe(false)
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('returns false when persona_captured is already set server-side', async () => {
+    callMock.mockResolvedValueOnce(true) // get_single_value
+    expect(await shouldCapturePersona()).toBe(false)
+    expect(callMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns true when boot_config resolves enabled', async () => {
+    callMock
+      .mockResolvedValueOnce(false) // persona_captured
+      .mockResolvedValueOnce({ enabled: true }) // boot_config
+    expect(await shouldCapturePersona()).toBe(true)
+  })
+
+  it('returns false when boot_config resolves disabled', async () => {
+    callMock
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce({ enabled: false })
+    expect(await shouldCapturePersona()).toBe(false)
+  })
+
+  /**
+   * The regression case: boot_config isn't whitelisted on every Frappe
+   * version CRM supports (see the comment in router.js), so the call
+   * rejects. Before this fix, that rejection propagated out of
+   * shouldCapturePersona uncaught.
+   */
+  it('returns false, without throwing, when boot_config is not available', async () => {
+    callMock
+      .mockResolvedValueOnce(false) // persona_captured
+      .mockRejectedValueOnce(
+        new Error(
+          "ValidationError: Failed to get method for command frappe.utils.telemetry.pulse.client.boot_config",
+        ),
+      )
+    await expect(shouldCapturePersona()).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
## What's actually still wrong here, vs. #2653 as filed

#2653 reports that `boot_config` is missing on Frappe v15 and that this breaks logged-in navigation. Before writing anything I checked both halves against real source, and they don't fully hold up as stated — worth being precise about, since it changes what this PR is:

- **`boot_config` missing on v15 is real.** `frappe/frappe`'s `version-15` branch has no `boot_config` in `pulse/client.py` at all (only `is_enabled`, `capture`, `bulk_capture`, …). `develop` has it, whitelisted.
- **But `is_enabled` — the endpoint CRM called before #142e7a07 — has the opposite problem: it's no longer whitelisted on `develop`.** So there is currently no single endpoint that's callable from both an older stable Frappe site and a newer one. Whichever one CRM calls, some real deployment breaks.
- **"Breaks logged-in navigation" isn't reproducible on current `develop`.** #ffcc3032 wrapped the whole `shouldCapturePersona()` call site (both call sites in the router guard) in try/catch back in July, for an unrelated reason, before the `boot_config` switch landed. That catch is still there, so the promise rejection this issue describes is already caught and doesn't propagate to break routing.

What's real and still unfixed: **every navigation on a v15 site throws a server-side `ValidationError`/`AttributeError` for a method that will never resolve, gets silently swallowed by the outer catch, and nothing about it is visible anywhere** — not the console, not a log line, nothing. The onboarding wizard just silently never fires on any v15 install, and no one can tell why. That's what this PR fixes.

## Fix

Move the try/catch to wrap the `boot_config` call specifically, rather than relying on the outer router guard's broader catch to mask it. Default `enabled` to `false` on failure — the check gates nothing but an onboarding wizard, so "can't tell if telemetry is enabled" safely means "don't show it," matching what the outer catch was already doing by accident, just now intentional and scoped to the one call that can actually fail.

Not attempting the harder, more general problem (Frappe having no client-callable endpoint that works across both branches) — that's a decision for Frappe core, not something to work around further in CRM's router.

## Testing

`shouldCapturePersona` wasn't exported or covered by any test. Exported it and added `frontend/tests/unit/shouldCapturePersona.test.js` — mocks `frappe-ui`'s `call`, no server needed. **Actually run**, not just reasoned about:

```
✓ tests/unit/shouldCapturePersona.test.js (5)
  ✓ returns false without calling the server when already captured locally
  ✓ returns false when persona_captured is already set server-side
  ✓ returns true when boot_config resolves enabled
  ✓ returns false when boot_config resolves disabled
  ✓ returns false, without throwing, when boot_config is not available
```

The last case is the regression test: rejects the `boot_config` call the way a v15 site's server actually does, and asserts the function resolves `false` rather than the rejection propagating.
