### PR TITLE
fix: authorize arbitrary notification creation

### DIFF
--- a/crm/fcrm/doctype/crm_notification/crm_notification.py
+++ b/crm/fcrm/doctype/crm_notification/crm_notification.py
@@ -49,7 +49,10 @@ def has_permission(doc, ptype, user):
 	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
 		return True
 
-	if ptype == "create" or not doc.to_user:
+	if ptype == "create":
+		return False
+
+	if not doc.to_user:
 		return True
 
 	return doc.to_user == user


### PR DESCRIPTION
This was resolved via greptile in https://github.com/frappe/crm/pull/2640/changes/1af82ba9cf2d6d926431bb6936cee52dc01b8592, hence cherry-picking this in develop as well