### PR TITLE
feat: next follow up date on leads & deals with reminder notification

### DIFF
--- a/crm/api/follow_up.py
+++ b/crm/api/follow_up.py
@@ -59,13 +59,13 @@ def trigger_follow_up_reminders():
 	# instead of leaving records marked as reminded but never notified.
 	for doctype in FOLLOW_UP_DOCTYPES:
 		for record in get_due_records(doctype, cutoff):
-			try:
-				send_reminder(doctype, record, send_email=send_email)
-			except Exception:
-				frappe.log_error(title=f"Follow up reminder failed for {doctype} {record.name}")
-			finally:
-				# Marked either way: a reminder that failed to send is logged, but
-				# retrying it on every tick would just repeat the same failure.
+			# send_reminder isolates each recipient, so what reaches here is a
+			# failure to work out *who* to notify at all -- nothing was sent, and
+			# the flag stays clear so the next tick tries the record again.
+			if run_in_savepoint(
+				lambda record=record: send_reminder(doctype, record, send_email=send_email),
+				title=f"Follow up reminder failed for {doctype} {record.name}",
+			):
 				frappe.db.set_value(doctype, record.name, "follow_up_reminder_sent", 1, update_modified=False)
 
 
@@ -117,7 +117,13 @@ def get_due_records(doctype, cutoff):
 
 
 def send_reminder(doctype, record, send_email=False):
-	"""Notify everyone responsible for ``record`` that its follow up is due."""
+	"""Notify everyone responsible for ``record`` that its follow up is due.
+
+	The record is marked reminded once, so every recipient gets their own
+	savepoint: one user whose notification blows up must not swallow the
+	reminder for the others, and must not poison the surrounding transaction.
+	Whoever failed is left in the Error Log rather than retried forever.
+	"""
 	recipients = get_recipients(doctype, record)
 	if not recipients:
 		return
@@ -125,26 +131,63 @@ def send_reminder(doctype, record, send_email=False):
 	title = get_record_title(doctype, record)
 	follow_up_on = get_datetime(record.next_follow_up)
 
+	notified = []
 	for user in recipients:
-		notify_user(
-			{
-				# No from_user: this is the system reminding you, not a colleague.
-				# It also keeps notify_user's "don't notify yourself" guard from
-				# swallowing the reminder, which is almost always self-directed.
-				"owner": None,
-				"assigned_to": user,
-				"notification_type": "Follow Up",
-				"message": _("Follow up on {0} {1} is due").format(doctype, record.name),
-				"notification_text": get_notification_text(doctype, title, follow_up_on),
-				"reference_doctype": doctype,
-				"reference_docname": record.name,
-				"redirect_to_doctype": doctype,
-				"redirect_to_docname": record.name,
-			}
+		if run_in_savepoint(
+			lambda user=user: notify_user(
+				{
+					# No from_user: this is the system reminding you, not a
+					# colleague. It also keeps notify_user's "don't notify
+					# yourself" guard from swallowing the reminder, which is
+					# almost always self-directed.
+					"owner": None,
+					"assigned_to": user,
+					"notification_type": "Follow Up",
+					"message": _("Follow up on {0} {1} is due").format(doctype, record.name),
+					"notification_text": get_notification_text(doctype, title, follow_up_on),
+					"reference_doctype": doctype,
+					"reference_docname": record.name,
+					"redirect_to_doctype": doctype,
+					"redirect_to_docname": record.name,
+				}
+			),
+			title=f"Follow up reminder failed for {doctype} {record.name} ({user})",
+		):
+			notified.append(user)
+
+	# Email only the people whose in-app reminder actually landed, and never let
+	# a mail failure cost them that reminder -- sendmail only queues, so a raise
+	# here means the queue row itself failed.
+	if send_email and notified:
+		run_in_savepoint(
+			lambda: send_reminder_email(doctype, record, notified, title, follow_up_on),
+			title=f"Follow up reminder email failed for {doctype} {record.name}",
 		)
 
-	if send_email:
-		send_reminder_email(doctype, record, recipients, title, follow_up_on)
+
+def run_in_savepoint(fn, title):
+	"""Run ``fn``, returning whether it succeeded and undoing its writes if not.
+
+	The savepoint matters as much as the ``try``: without it a failed statement
+	leaves the surrounding transaction dirty, so the caller's later writes (the
+	``follow_up_reminder_sent`` flag, the next recipient's notification) would go
+	down with it. ``frappe.database.database.savepoint`` can't be used here
+	because it swallows the exception, and the caller needs to know.
+	"""
+	# Unique per call: these nest (a per-recipient savepoint inside the
+	# per-record one) and re-using a name would make MySQL drop the outer
+	# savepoint, so releasing it afterwards fails.
+	sp = f"crm_follow_up_{frappe.generate_hash(length=8)}"
+	frappe.db.savepoint(sp)
+	try:
+		fn()
+	except Exception:
+		frappe.db.rollback(save_point=sp)
+		frappe.log_error(title=title)
+		return False
+
+	frappe.db.release_savepoint(sp)
+	return True
 
 
 def get_recipients(doctype, record):

--- a/crm/api/follow_up.py
+++ b/crm/api/follow_up.py
@@ -1,0 +1,231 @@
+"""Follow-up reminders for CRM Lead and CRM Deal.
+
+A rep records the next touch on the record itself via the ``next_follow_up``
+Datetime field. This module is the part that makes that field act: a scheduler
+job picks up records whose follow up is due (optionally a configurable lead time
+early) and notifies whoever is on the hook for it.
+
+Delivery is an in-app ``CRM Notification`` -- the same channel used for mentions,
+assignments and task notifications -- plus an optional email, both configured in
+FCRM Settings under "Follow Up Reminders".
+
+Bookkeeping is a single ``follow_up_reminder_sent`` checkbox on the record rather
+than a queue of pending reminder rows, which keeps the three lifecycle rules the
+feature needs almost free:
+
+* rescheduled -- ``next_follow_up`` changed, so :func:`reset_follow_up_reminder`
+  clears the flag on save and the new time gets its own reminder;
+* cleared -- no ``next_follow_up``, so the record never matches the query;
+* closed -- won/lost (or a converted lead) is filtered out, so a dead deal never
+  fires a reminder that is still technically due.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import add_to_date, get_datetime, now_datetime
+
+from crm.fcrm.doctype.crm_notification.crm_notification import notify_user
+
+FOLLOW_UP_DOCTYPES = ("CRM Lead", "CRM Deal")
+
+# Statuses that mean "there is nothing left to follow up on".
+CLOSED_STATUS_TYPES = ("Won", "Lost")
+
+# Cap per scheduler tick so a large backlog (a bulk import of back-dated follow
+# ups, or a scheduler that was down for a while) can't monopolise the worker.
+# The remainder is picked up on the next tick, oldest first.
+BATCH_SIZE = 200
+
+VALID_INTERVALS = ("minutes", "hours", "days")
+
+
+def trigger_follow_up_reminders():
+	"""Scheduler entry point: notify assignees about follow ups that are now due."""
+	if frappe.flags.in_import or frappe.flags.in_patch or frappe.flags.in_install:
+		return
+
+	settings = frappe.get_cached_doc("FCRM Settings")
+	if not settings.get("enable_follow_up_reminders"):
+		return
+
+	# Reminders fire `before` ahead of the follow up time, so anything due up to
+	# that far in the future is already actionable.
+	cutoff = add_to_date(now_datetime(), **get_lead_time(settings))
+	send_email = bool(settings.get("send_follow_up_reminder_email"))
+
+	for doctype in FOLLOW_UP_DOCTYPES:
+		for record in get_due_records(doctype, cutoff):
+			try:
+				send_reminder(doctype, record, send_email=send_email)
+			except Exception:
+				frappe.log_error(title=f"Follow up reminder failed for {doctype} {record.name}")
+			finally:
+				# Marked either way: a reminder that failed to send is logged, but
+				# retrying it on every tick would just repeat the same failure.
+				frappe.db.set_value(doctype, record.name, "follow_up_reminder_sent", 1, update_modified=False)
+
+		# Batch job: keep the sent flags already written if a later doctype blows up.
+		frappe.db.commit()
+
+
+def get_lead_time(settings):
+	"""Return ``add_to_date`` kwargs for how far ahead of the follow up to remind."""
+	before = frappe.utils.cint(settings.get("follow_up_reminder_before"))
+	interval = settings.get("follow_up_reminder_interval") or "minutes"
+
+	if before <= 0:
+		return {"minutes": 0}
+	if interval not in VALID_INTERVALS:
+		interval = "minutes"
+
+	return {interval: before}
+
+
+def get_due_records(doctype, cutoff):
+	"""Records with a follow up due by ``cutoff`` that haven't been reminded yet."""
+	owner_field = get_owner_field(doctype)
+
+	# `is set` is load-bearing, not belt-and-braces: the query builder compiles a
+	# `<=` on a Datetime to `IFNULL(next_follow_up, '0001-01-01') <= cutoff`, so
+	# without it every record that has *no* follow up date matches and the first
+	# scheduler tick reminds every lead and deal in the system. Filters are a list
+	# rather than a dict because both conditions are on the same fieldname.
+	filters = [
+		["next_follow_up", "is", "set"],
+		["next_follow_up", "<=", cutoff],
+		["follow_up_reminder_sent", "=", 0],
+	]
+
+	closed_statuses = frappe.get_all(
+		f"{doctype} Status", filters={"type": ("in", CLOSED_STATUS_TYPES)}, pluck="name"
+	)
+	if closed_statuses:
+		filters.append(["status", "not in", closed_statuses])
+
+	if doctype == "CRM Lead":
+		# A converted lead lives on as a deal; the deal carries the follow up.
+		filters.append(["converted", "=", 0])
+
+	return frappe.get_all(
+		doctype,
+		filters=filters,
+		fields=["name", "next_follow_up", "owner", "_assign", owner_field, *get_title_fields(doctype)],
+		order_by="next_follow_up asc",
+		limit=BATCH_SIZE,
+	)
+
+
+def send_reminder(doctype, record, send_email=False):
+	"""Notify everyone responsible for ``record`` that its follow up is due."""
+	recipients = get_recipients(doctype, record)
+	if not recipients:
+		return
+
+	title = get_record_title(doctype, record)
+	follow_up_on = get_datetime(record.next_follow_up)
+
+	for user in recipients:
+		notify_user(
+			{
+				# No from_user: this is the system reminding you, not a colleague.
+				# It also keeps notify_user's "don't notify yourself" guard from
+				# swallowing the reminder, which is almost always self-directed.
+				"owner": None,
+				"assigned_to": user,
+				"notification_type": "Follow Up",
+				"message": _("Follow up on {0} {1} is due").format(doctype, record.name),
+				"notification_text": get_notification_text(doctype, title, follow_up_on),
+				"reference_doctype": doctype,
+				"reference_docname": record.name,
+				"redirect_to_doctype": doctype,
+				"redirect_to_docname": record.name,
+			}
+		)
+
+	if send_email:
+		send_reminder_email(doctype, record, recipients, title, follow_up_on)
+
+
+def get_recipients(doctype, record):
+	"""Assigned users, falling back to the record owner so a reminder is never lost."""
+	users = frappe.parse_json(record.get("_assign") or "[]") or []
+
+	if not users:
+		# Nobody assigned -- the issue asks that we fall back rather than send
+		# nothing. Lead/deal owner first, then whoever created the record.
+		users = [record.get(get_owner_field(doctype)) or record.get("owner")]
+
+	seen = {}
+	for user in users:
+		if user and user not in seen and frappe.db.get_value("User", user, "enabled"):
+			seen[user] = True
+
+	return list(seen)
+
+
+def get_owner_field(doctype):
+	return "lead_owner" if doctype == "CRM Lead" else "deal_owner"
+
+
+def get_title_fields(doctype):
+	return ["lead_name"] if doctype == "CRM Lead" else ["organization", "lead_name"]
+
+
+def get_record_title(doctype, record):
+	if doctype == "CRM Lead":
+		return record.get("lead_name") or record.name
+	return record.get("organization") or record.get("lead_name") or record.name
+
+
+def get_notification_text(doctype, title, follow_up_on):
+	label = _("lead") if doctype == "CRM Lead" else _("deal")
+	formatted = frappe.utils.format_datetime(follow_up_on)
+
+	return f"""
+		<div class="mb-2 leading-5 text-ink-gray-5">
+			<span>{
+		_("Follow up on {0} {1} is due on {2}").format(
+			label,
+			f'<span class="font-medium text-ink-gray-9">{ frappe.utils.escape_html(title) }</span>',
+			f'<span class="font-medium text-ink-gray-9">{ formatted }</span>',
+		)
+	}</span>
+		</div>
+	"""
+
+
+def send_reminder_email(doctype, record, recipients, title, follow_up_on):
+	label = _("Lead") if doctype == "CRM Lead" else _("Deal")
+	link = frappe.utils.get_url(f"/crm/{'leads' if doctype == 'CRM Lead' else 'deals'}/{record.name}")
+	safe_title = frappe.utils.escape_html(title)
+
+	message = f"""
+		<div style="font-family: Arial, sans-serif; max-width: 600px;">
+			<h2 style="color: #333;">{_("Follow Up Reminder")}</h2>
+			<p>{_("A follow up you are responsible for is due:")}</p>
+			<div style="background-color: #f8f9fa; padding: 15px; border-left: 4px solid #007bff; margin: 20px 0;">
+				<h3 style="margin: 0; color: #007bff;">{safe_title}</h3>
+				<p style="margin: 5px 0;"><strong>{label}:</strong> {record.name}</p>
+				<p style="margin: 5px 0;"><strong>{_("Follow up on")}:</strong> {frappe.utils.format_datetime(follow_up_on)}</p>
+			</div>
+			<p><a href="{link}">{_("Open in CRM")}</a></p>
+		</div>
+	"""
+
+	frappe.sendmail(
+		recipients=recipients,
+		subject=_("Follow up due: {0}").format(title),
+		message=message,
+		reference_doctype=doctype,
+		reference_name=record.name,
+	)
+
+
+def reset_follow_up_reminder(doc):
+	"""Clear the sent flag whenever the follow up is rescheduled or cleared.
+
+	Called from CRM Lead / CRM Deal ``validate`` so the new time gets its own
+	reminder instead of inheriting the previous one's "already sent" state.
+	"""
+	if doc.has_value_changed("next_follow_up"):
+		doc.follow_up_reminder_sent = 0

--- a/crm/api/follow_up.py
+++ b/crm/api/follow_up.py
@@ -53,6 +53,10 @@ def trigger_follow_up_reminders():
 	cutoff = add_to_date(now_datetime(), **get_lead_time(settings))
 	send_email = bool(settings.get("send_follow_up_reminder_email"))
 
+	# No explicit commit: the whole run is one transaction, so a failure that
+	# escapes the per-record handler rolls back the sent flags *and* the
+	# notifications they were paired with. The next tick then re-sends cleanly
+	# instead of leaving records marked as reminded but never notified.
 	for doctype in FOLLOW_UP_DOCTYPES:
 		for record in get_due_records(doctype, cutoff):
 			try:
@@ -63,9 +67,6 @@ def trigger_follow_up_reminders():
 				# Marked either way: a reminder that failed to send is logged, but
 				# retrying it on every tick would just repeat the same failure.
 				frappe.db.set_value(doctype, record.name, "follow_up_reminder_sent", 1, update_modified=False)
-
-		# Batch job: keep the sent flags already written if a later doctype blows up.
-		frappe.db.commit()
 
 
 def get_lead_time(settings):

--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -11,6 +11,8 @@
   "naming_series",
   "organization",
   "next_step",
+  "next_follow_up",
+  "follow_up_reminder_sent",
   "column_break_ijan",
   "status",
   "deal_owner",
@@ -113,6 +115,22 @@
    "fieldname": "next_step",
    "fieldtype": "Data",
    "label": "Next Step"
+  },
+  {
+   "description": "When to next reach out on this deal. The assigned users get a reminder when it is due.",
+   "fieldname": "next_follow_up",
+   "fieldtype": "Datetime",
+   "label": "Next Follow Up",
+   "search_index": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "follow_up_reminder_sent",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Follow Up Reminder Sent",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "fieldname": "lead",

--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -7,6 +7,7 @@ from frappe.desk.form.assign_to import _add as assign
 from frappe.model.document import Document
 
 from crm.api.exchange_rate import get_exchange_rate
+from crm.api.follow_up import reset_follow_up_reminder
 from crm.fcrm.doctype.crm_service_level_agreement.utils import get_sla
 from crm.fcrm.doctype.crm_status_change_log.crm_status_change_log import add_status_change_log
 from crm.fcrm.doctype.utils import add_or_remove_lost_reason_section_in_sidepanel
@@ -43,6 +44,7 @@ class CRMDeal(Document):
 		first_name: DF.Data | None
 		first_responded_on: DF.Datetime | None
 		first_response_time: DF.Duration | None
+		follow_up_reminder_sent: DF.Check
 		gender: DF.Link | None
 		industry: DF.Link | None
 		job_title: DF.Data | None
@@ -56,6 +58,7 @@ class CRMDeal(Document):
 		mobile_no: DF.Data | None
 		naming_series: DF.Literal["CRM-DEAL-.YYYY.-"]
 		net_total: DF.Currency
+		next_follow_up: DF.Datetime | None
 		next_step: DF.Data | None
 		no_of_employees: DF.Literal["1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"]
 		organization: DF.Link | None
@@ -99,6 +102,7 @@ class CRMDeal(Document):
 				self.closed_date = frappe.utils.nowdate()
 		self.validate_forecasting_fields()
 		self.validate_lost_reason()
+		reset_follow_up_reminder(self)
 		self.update_exchange_rate()
 		if self.organization and (self.is_new() or self.has_value_changed("organization")):
 			self.copy_enrichment_from_organization()
@@ -335,6 +339,12 @@ class CRMDeal(Document):
 				"width": "11rem",
 			},
 			{
+				"label": "Next Follow Up",
+				"type": "Datetime",
+				"key": "next_follow_up",
+				"width": "10rem",
+			},
+			{
 				"label": "Assigned To",
 				"type": "Text",
 				"key": "_assign",
@@ -356,6 +366,7 @@ class CRMDeal(Document):
 			"currency",
 			"mobile_no",
 			"deal_owner",
+			"next_follow_up",
 			"sla_status",
 			"response_by",
 			"first_response_time",

--- a/crm/fcrm/doctype/crm_lead/crm_lead.json
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -31,6 +31,8 @@
   "job_title",
   "source",
   "lead_owner",
+  "next_follow_up",
+  "follow_up_reminder_sent",
   "organization_tab",
   "section_break_uixv",
   "naming_series",
@@ -172,6 +174,22 @@
    "fieldtype": "Link",
    "label": "Lead Owner",
    "options": "User"
+  },
+  {
+   "description": "When to next reach out to this lead. The assigned users get a reminder when it is due.",
+   "fieldname": "next_follow_up",
+   "fieldtype": "Datetime",
+   "label": "Next Follow Up",
+   "search_index": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "follow_up_reminder_sent",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Follow Up Reminder Sent",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "fieldname": "source",

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -9,6 +9,7 @@ from frappe.desk.form.assign_to import _add as assign
 from frappe.model.document import Document
 from frappe.utils import validate_email_address
 
+from crm.api.follow_up import reset_follow_up_reminder
 from crm.fcrm.doctype.crm_service_level_agreement.utils import get_sla
 from crm.fcrm.doctype.crm_status_change_log.crm_status_change_log import (
 	add_status_change_log,
@@ -42,6 +43,7 @@ class CRMLead(Document):
 		first_name: DF.Data
 		first_responded_on: DF.Datetime | None
 		first_response_time: DF.Duration | None
+		follow_up_reminder_sent: DF.Check
 		gender: DF.Link | None
 		image: DF.AttachImage | None
 		industry: DF.Link | None
@@ -57,6 +59,7 @@ class CRMLead(Document):
 		mobile_no: DF.Data | None
 		naming_series: DF.Literal["CRM-LEAD-.YYYY.-"]
 		net_total: DF.Currency
+		next_follow_up: DF.Datetime | None
 		no_of_employees: DF.Literal["1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"]
 		organization: DF.Data | None
 		phone: DF.Data | None
@@ -91,6 +94,7 @@ class CRMLead(Document):
 		self.set_title()
 		self.validate_email()
 		self.validate_lost_reason()
+		reset_follow_up_reminder(self)
 		if not self.is_new() and self.has_value_changed("lead_owner") and self.lead_owner:
 			self.share_with_agent(self.lead_owner)
 			self.assign_agent(self.lead_owner)
@@ -479,6 +483,12 @@ class CRMLead(Document):
 				"width": "11rem",
 			},
 			{
+				"label": "Next Follow Up",
+				"type": "Datetime",
+				"key": "next_follow_up",
+				"width": "10rem",
+			},
+			{
 				"label": "Assigned To",
 				"type": "Text",
 				"key": "_assign",
@@ -499,6 +509,7 @@ class CRMLead(Document):
 			"email",
 			"mobile_no",
 			"lead_owner",
+			"next_follow_up",
 			"first_name",
 			"sla_status",
 			"response_by",

--- a/crm/fcrm/doctype/crm_notification/crm_notification.json
+++ b/crm/fcrm/doctype/crm_notification/crm_notification.json
@@ -34,7 +34,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Type",
-   "options": "Mention\nTask\nAssignment\nWhatsApp",
+   "options": "Mention\nTask\nAssignment\nWhatsApp\nFollow Up",
    "reqd": 1
   },
   {

--- a/crm/fcrm/doctype/crm_notification/crm_notification.py
+++ b/crm/fcrm/doctype/crm_notification/crm_notification.py
@@ -24,7 +24,7 @@ class CRMNotification(Document):
 		reference_doctype: DF.Link | None
 		reference_name: DF.DynamicLink | None
 		to_user: DF.Link
-		type: DF.Literal["Mention", "Task", "Assignment", "WhatsApp"]
+		type: DF.Literal["Mention", "Task", "Assignment", "WhatsApp", "Follow Up"]
 	# end: auto-generated types
 
 	def on_update(self):

--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.json
@@ -14,6 +14,11 @@
   "update_timestamp_on_new_communication",
   "auto_mark_replied_on_response",
   "auto_reopen_on_new_communication",
+  "follow_up_reminders_section",
+  "enable_follow_up_reminders",
+  "follow_up_reminder_before",
+  "follow_up_reminder_interval",
+  "send_follow_up_reminder_email",
   "activity_timeline_section",
   "crm_timeline_timestamp_format",
   "crm_timeline_sort_order",
@@ -190,6 +195,43 @@
    "fieldname": "restore_demo_data",
    "fieldtype": "Button",
    "label": "Restore Demo Data"
+  },
+  {
+   "fieldname": "follow_up_reminders_section",
+   "fieldtype": "Section Break",
+   "label": "Follow Up Reminders"
+  },
+  {
+   "default": "1",
+   "description": "Notify the users assigned to a lead or deal when its Next Follow Up is due",
+   "fieldname": "enable_follow_up_reminders",
+   "fieldtype": "Check",
+   "label": "Enable follow up reminders"
+  },
+  {
+   "default": "30",
+   "depends_on": "enable_follow_up_reminders",
+   "description": "How much ahead of the follow up time the reminder is sent",
+   "fieldname": "follow_up_reminder_before",
+   "fieldtype": "Int",
+   "label": "Remind before",
+   "non_negative": 1
+  },
+  {
+   "default": "minutes",
+   "depends_on": "enable_follow_up_reminders",
+   "fieldname": "follow_up_reminder_interval",
+   "fieldtype": "Select",
+   "label": "Remind before (unit)",
+   "options": "minutes\nhours\ndays"
+  },
+  {
+   "default": "0",
+   "depends_on": "enable_follow_up_reminders",
+   "description": "Also email the reminder, in addition to the in-app notification",
+   "fieldname": "send_follow_up_reminder_email",
+   "fieldtype": "Check",
+   "label": "Send follow up reminder email"
   },
   {
    "fieldname": "activity_timeline_section",

--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
@@ -34,9 +34,13 @@ class FCRMSettings(Document):
 		currency: DF.Link | None
 		default_calendar_view: DF.Literal["Daily", "Weekly", "Monthly"]
 		dropdown_items: DF.Table[CRMDropdownItem]
+		enable_follow_up_reminders: DF.Check
 		enable_forecasting: DF.Check
 		event_notifications: DF.Table[EventNotifications]
 		favicon: DF.Attach | None
+		follow_up_reminder_before: DF.Int
+		follow_up_reminder_interval: DF.Literal["minutes", "hours", "days"]
+		send_follow_up_reminder_email: DF.Check
 		service_provider: DF.Literal[
 			"frankfurter.app", "fawazahmed-exchange-api", "exchangerate.host", "exchangerate-api"
 		]

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -222,7 +222,10 @@ doc_events = {
 # ---------------
 
 scheduler_events = {
-	"all": ["crm.api.event.trigger_offset_event_notifications"],
+	"all": [
+		"crm.api.event.trigger_offset_event_notifications",
+		"crm.api.follow_up.trigger_follow_up_reminders",
+	],
 	"hourly": ["crm.api.event.trigger_hourly_event_notifications"],
 	"daily": [
 		"crm.api.event.trigger_daily_event_notifications",

--- a/crm/install.py
+++ b/crm/install.py
@@ -198,11 +198,11 @@ def add_default_fields_layout(force=False):
 	sidebar_fields_layouts = {
 		"CRM Lead-Side Panel": {
 			"doctype": "CRM Lead",
-			"layout": '[{"label": "Details", "name": "details_section", "opened": true, "columns": [{"name": "column_kl92", "fields": ["organization", "company_description", "website", "territory", "industry", "no_of_employees", "job_title", "source", "lead_owner", "linkedin", "twitter", "facebook"]}]}, {"label": "Person", "name": "person_section", "opened": true, "columns": [{"name": "column_XmW2", "fields": ["salutation", "first_name", "last_name", "email", "mobile_no"]}]}]',
+			"layout": '[{"label": "Details", "name": "details_section", "opened": true, "columns": [{"name": "column_kl92", "fields": ["organization", "company_description", "website", "territory", "industry", "no_of_employees", "job_title", "source", "lead_owner", "next_follow_up", "linkedin", "twitter", "facebook"]}]}, {"label": "Person", "name": "person_section", "opened": true, "columns": [{"name": "column_XmW2", "fields": ["salutation", "first_name", "last_name", "email", "mobile_no"]}]}]',
 		},
 		"CRM Deal-Side Panel": {
 			"doctype": "CRM Deal",
-			"layout": '[{"label": "Contacts", "name": "contacts_section", "opened": true, "editable": false, "contacts": []}, {"label": "Organization Details", "name": "organization_section", "opened": true, "columns": [{"name": "column_na2Q", "fields": ["organization", "company_description", "industry", "no_of_employees", "website", "territory", "annual_revenue", "closed_date", "probability", "next_step", "deal_owner", "linkedin", "twitter", "facebook"]}]}]',
+			"layout": '[{"label": "Contacts", "name": "contacts_section", "opened": true, "editable": false, "contacts": []}, {"label": "Organization Details", "name": "organization_section", "opened": true, "columns": [{"name": "column_na2Q", "fields": ["organization", "company_description", "industry", "no_of_employees", "website", "territory", "annual_revenue", "closed_date", "probability", "next_step", "next_follow_up", "deal_owner", "linkedin", "twitter", "facebook"]}]}]',
 		},
 		"Contact-Side Panel": {
 			"doctype": "Contact",

--- a/crm/patches.txt
+++ b/crm/patches.txt
@@ -30,3 +30,5 @@ crm.patches.v1_0.add_forecasting_section_in_quick_entry
 crm.patches.v1_0.set_persona_captured_for_existing_sites
 crm.patches.v1_0.add_enrichment_fields_to_layouts
 crm.patches.v1_0.reorder_address_quick_entry_layout
+crm.patches.v1_0.add_next_follow_up_to_layouts
+crm.patches.v1_0.set_follow_up_reminder_defaults

--- a/crm/patches/v1_0/add_next_follow_up_to_layouts.py
+++ b/crm/patches/v1_0/add_next_follow_up_to_layouts.py
@@ -1,0 +1,68 @@
+"""Expose the Next Follow Up field on existing sites.
+
+``next_follow_up`` was added to the default Lead/Deal Side Panel layouts in
+``crm/install.py``, but that seeder is skip-if-exists -- so sites installed
+before this feature would get the field and its reminders without anywhere to
+set the date. This patch appends it to the relevant layouts.
+
+Idempotent: a layout that already lists the field (or a doctype that doesn't
+have it) is left untouched.
+"""
+
+import json
+
+import frappe
+
+FIELDNAME = "next_follow_up"
+
+TARGET_LAYOUTS = [
+	"CRM Lead-Side Panel",
+	"CRM Deal-Side Panel",
+]
+
+
+def _iter_columns(layout):
+	"""Yield every column dict in a layout tree (handles tabbed layouts that nest
+	sections under a top-level section's ``sections`` key)."""
+	for section in layout:
+		yield from section.get("columns", [])
+		for nested in section.get("sections", []):
+			yield from nested.get("columns", [])
+
+
+def _visible_columns(layout):
+	"""Columns of the first non-hidden section that has any -- the field has to
+	land somewhere the user can actually see it."""
+	for section in layout:
+		if section.get("hidden"):
+			continue
+		if section.get("columns"):
+			return section["columns"]
+		for nested in section.get("sections", []):
+			if not nested.get("hidden") and nested.get("columns"):
+				return nested["columns"]
+	return None
+
+
+def execute():
+	for name in TARGET_LAYOUTS:
+		if not frappe.db.exists("CRM Fields Layout", name):
+			continue
+
+		doc = frappe.get_doc("CRM Fields Layout", name)
+		try:
+			layout = json.loads(doc.layout or "[]")
+		except (ValueError, TypeError):
+			continue
+
+		present = {f for col in _iter_columns(layout) for f in col.get("fields", [])}
+		if FIELDNAME in present or not frappe.get_meta(doc.dt).has_field(FIELDNAME):
+			continue
+
+		target = _visible_columns(layout)
+		if not target:
+			continue
+
+		target[0].setdefault("fields", []).append(FIELDNAME)
+		doc.layout = json.dumps(layout)
+		doc.save()

--- a/crm/patches/v1_0/set_follow_up_reminder_defaults.py
+++ b/crm/patches/v1_0/set_follow_up_reminder_defaults.py
@@ -1,0 +1,34 @@
+"""Seed the follow up reminder settings on existing sites.
+
+The defaults declared on the FCRM Settings fields only apply when the Single is
+first created. A site that already has an FCRM Settings row gets NULL/0 for the
+newly added fields instead -- which would leave reminders switched off, and the
+lead time at 0, on every existing install.
+
+``follow_up_reminder_interval`` is the sentinel for "never configured": it is a
+Select with no falsy value of its own, so unlike the two Check fields it can't
+be confused with a deliberate opt-out. If it is already set, an admin has been
+here and we leave everything alone.
+
+Enabling by default is safe: nothing fires until someone sets a
+``next_follow_up`` on a lead or deal, and that field ships empty.
+"""
+
+import frappe
+
+DEFAULTS = {
+	"enable_follow_up_reminders": 1,
+	"follow_up_reminder_before": 30,
+	"follow_up_reminder_interval": "minutes",
+}
+
+
+def execute():
+	if not frappe.db.exists("DocType", "FCRM Settings"):
+		return
+
+	if frappe.db.get_single_value("FCRM Settings", "follow_up_reminder_interval"):
+		return
+
+	for field, value in DEFAULTS.items():
+		frappe.db.set_single_value("FCRM Settings", field, value)

--- a/crm/tests/test_follow_up.py
+++ b/crm/tests/test_follow_up.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.desk.form.assign_to import add as assign_add
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime
 
+from crm.api import follow_up
 from crm.api.follow_up import (
 	get_due_records,
 	get_lead_time,
@@ -180,6 +183,55 @@ class TestFollowUpReminders(IntegrationTestCase):
 		lead.reload()
 		recipients = get_recipients("CRM Lead", frappe._dict(lead.as_dict()))
 		self.assertEqual(recipients, [lead.owner])
+
+	# failure isolation ------------------------------------------------------
+
+	def test_one_failing_recipient_does_not_cost_the_others(self):
+		good = create_test_user("follow.up.good@example.com")
+		bad = create_test_user("follow.up.bad@example.com")
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		frappe.db.set_value(
+			"CRM Lead", lead.name, "_assign", frappe.as_json([bad.name, good.name]), update_modified=False
+		)
+
+		real_notify = follow_up.notify_user
+
+		def flaky(notification):
+			if notification["assigned_to"] == bad.name:
+				raise ValueError("boom")
+			return real_notify(notification)
+
+		with patch.object(follow_up, "notify_user", side_effect=flaky):
+			trigger_follow_up_reminders()
+
+		notified = [r.to_user for r in self.reminders_for("CRM Lead", lead.name)]
+		self.assertEqual(notified, [good.name])
+		# the good recipient's reminder survived, so the record is done
+		self.assertEqual(self.flag("CRM Lead", lead.name), 1)
+
+	def test_record_is_retried_when_nothing_could_be_sent(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+
+		with patch.object(follow_up, "get_recipients", side_effect=ValueError("boom")):
+			trigger_follow_up_reminders()
+
+		self.assertEqual(self.reminders_for("CRM Lead", lead.name), [])
+		# nothing went out, so the flag stays clear and the next tick retries
+		self.assertEqual(self.flag("CRM Lead", lead.name), 0)
+
+		trigger_follow_up_reminders()
+		self.assertEqual(len(self.reminders_for("CRM Lead", lead.name)), 1)
+
+	def test_email_failure_does_not_cost_the_in_app_reminder(self):
+		frappe.db.set_single_value("FCRM Settings", "send_follow_up_reminder_email", 1)
+		frappe.clear_cache(doctype="FCRM Settings")
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+
+		with patch.object(follow_up, "send_reminder_email", side_effect=ValueError("boom")):
+			trigger_follow_up_reminders()
+
+		self.assertEqual(len(self.reminders_for("CRM Lead", lead.name)), 1)
+		self.assertEqual(self.flag("CRM Lead", lead.name), 1)
 
 	def test_disabled_users_are_dropped(self):
 		user = create_test_user("follow.up.gone@example.com")

--- a/crm/tests/test_follow_up.py
+++ b/crm/tests/test_follow_up.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+from frappe.desk.form.assign_to import add as assign_add
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_to_date, now_datetime
+
+from crm.api.follow_up import (
+	get_due_records,
+	get_lead_time,
+	get_recipients,
+	trigger_follow_up_reminders,
+)
+
+
+class TestFollowUpReminders(IntegrationTestCase):
+	def setUp(self) -> None:
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value("FCRM Settings", "enable_follow_up_reminders", 1)
+		frappe.db.set_single_value("FCRM Settings", "follow_up_reminder_before", 30)
+		frappe.db.set_single_value("FCRM Settings", "follow_up_reminder_interval", "minutes")
+		frappe.db.set_single_value("FCRM Settings", "send_follow_up_reminder_email", 0)
+		frappe.clear_cache(doctype="FCRM Settings")
+
+	def tearDown(self) -> None:
+		frappe.db.rollback()
+		frappe.clear_cache(doctype="FCRM Settings")
+
+	# helpers -----------------------------------------------------------------
+
+	def make_lead(self, **kwargs):
+		values = {
+			"doctype": "CRM Lead",
+			"first_name": "Follow",
+			"last_name": "Up",
+			"lead_owner": "Administrator",
+		}
+		values.update(kwargs)
+		return frappe.get_doc(values).insert(ignore_permissions=True)
+
+	def reminders_for(self, doctype, name):
+		return frappe.get_all(
+			"CRM Notification",
+			filters={"type": "Follow Up", "reference_doctype": doctype, "reference_name": name},
+			fields=["to_user"],
+		)
+
+	def flag(self, doctype, name):
+		return frappe.db.get_value(doctype, name, "follow_up_reminder_sent")
+
+	# lead time ---------------------------------------------------------------
+
+	def test_lead_time_kwargs(self):
+		self.assertEqual(get_lead_time({"follow_up_reminder_before": 30}), {"minutes": 30})
+		self.assertEqual(
+			get_lead_time({"follow_up_reminder_before": 2, "follow_up_reminder_interval": "hours"}),
+			{"hours": 2},
+		)
+		self.assertEqual(get_lead_time({"follow_up_reminder_before": 0}), {"minutes": 0})
+		# an unexpected interval falls back rather than blowing up the scheduler
+		self.assertEqual(
+			get_lead_time({"follow_up_reminder_before": 5, "follow_up_reminder_interval": "fortnights"}),
+			{"minutes": 5},
+		)
+
+	# due selection -----------------------------------------------------------
+
+	def test_record_without_follow_up_is_never_due(self):
+		lead = self.make_lead()
+		cutoff = add_to_date(now_datetime(), minutes=30)
+		self.assertNotIn(lead.name, [d.name for d in get_due_records("CRM Lead", cutoff)])
+
+	def test_follow_up_beyond_lead_time_is_not_due(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), hours=5))
+		trigger_follow_up_reminders()
+		self.assertEqual(self.reminders_for("CRM Lead", lead.name), [])
+		self.assertEqual(self.flag("CRM Lead", lead.name), 0)
+
+	def test_follow_up_within_lead_time_notifies_and_marks_sent(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		trigger_follow_up_reminders()
+
+		self.assertEqual([r.to_user for r in self.reminders_for("CRM Lead", lead.name)], ["Administrator"])
+		self.assertEqual(self.flag("CRM Lead", lead.name), 1)
+
+	def test_overdue_follow_up_still_notifies(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), hours=-3))
+		trigger_follow_up_reminders()
+		self.assertEqual(len(self.reminders_for("CRM Lead", lead.name)), 1)
+
+	def test_reminder_is_not_sent_twice(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		trigger_follow_up_reminders()
+		trigger_follow_up_reminders()
+		self.assertEqual(len(self.reminders_for("CRM Lead", lead.name)), 1)
+
+	# lifecycle ---------------------------------------------------------------
+
+	def test_rescheduling_clears_the_sent_flag(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		trigger_follow_up_reminders()
+		self.assertEqual(self.flag("CRM Lead", lead.name), 1)
+
+		lead.reload()
+		lead.next_follow_up = add_to_date(now_datetime(), days=2)
+		lead.save(ignore_permissions=True)
+		self.assertEqual(self.flag("CRM Lead", lead.name), 0)
+
+	def test_clearing_the_date_drops_the_reminder(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		trigger_follow_up_reminders()
+		sent = len(self.reminders_for("CRM Lead", lead.name))
+
+		lead.reload()
+		lead.next_follow_up = None
+		lead.save(ignore_permissions=True)
+		self.assertEqual(self.flag("CRM Lead", lead.name), 0)
+
+		trigger_follow_up_reminders()
+		self.assertEqual(len(self.reminders_for("CRM Lead", lead.name)), sent)
+		# a record with no date must never be picked up, flag or not
+		self.assertEqual(self.flag("CRM Lead", lead.name), 0)
+
+	def test_closed_deal_is_skipped(self):
+		lost = frappe.get_all("CRM Deal Status", filters={"type": "Lost"}, pluck="name")
+		if not lost:
+			self.skipTest("no Lost deal status configured")
+
+		deal = frappe.get_doc(
+			{
+				"doctype": "CRM Deal",
+				"deal_owner": "Administrator",
+				"next_follow_up": add_to_date(now_datetime(), minutes=10),
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value("CRM Deal", deal.name, "status", lost[0], update_modified=False)
+
+		trigger_follow_up_reminders()
+		self.assertEqual(self.reminders_for("CRM Deal", deal.name), [])
+		self.assertEqual(self.flag("CRM Deal", deal.name), 0)
+
+	def test_converted_lead_is_skipped(self):
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		frappe.db.set_value("CRM Lead", lead.name, "converted", 1, update_modified=False)
+
+		trigger_follow_up_reminders()
+		self.assertEqual(self.reminders_for("CRM Lead", lead.name), [])
+
+	def test_disabled_setting_is_a_no_op(self):
+		frappe.db.set_single_value("FCRM Settings", "enable_follow_up_reminders", 0)
+		frappe.clear_cache(doctype="FCRM Settings")
+
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		trigger_follow_up_reminders()
+
+		self.assertEqual(self.reminders_for("CRM Lead", lead.name), [])
+		self.assertEqual(self.flag("CRM Lead", lead.name), 0)
+
+	# recipients --------------------------------------------------------------
+
+	def test_assigned_users_get_the_reminder(self):
+		user = create_test_user("follow.up.rep@example.com")
+		lead = self.make_lead(next_follow_up=add_to_date(now_datetime(), minutes=10))
+		assign_add(
+			{
+				"doctype": "CRM Lead",
+				"name": lead.name,
+				"assign_to": [user.name],
+			}
+		)
+
+		trigger_follow_up_reminders()
+		self.assertIn(user.name, [r.to_user for r in self.reminders_for("CRM Lead", lead.name)])
+
+	def test_falls_back_to_owner_when_unassigned(self):
+		lead = self.make_lead(lead_owner=None, next_follow_up=add_to_date(now_datetime(), minutes=10))
+		frappe.db.set_value("CRM Lead", lead.name, "_assign", None, update_modified=False)
+
+		lead.reload()
+		recipients = get_recipients("CRM Lead", frappe._dict(lead.as_dict()))
+		self.assertEqual(recipients, [lead.owner])
+
+	def test_disabled_users_are_dropped(self):
+		user = create_test_user("follow.up.gone@example.com")
+		frappe.db.set_value("User", user.name, "enabled", 0)
+
+		record = frappe._dict(name="dummy", _assign=frappe.as_json([user.name]), owner="Administrator")
+		self.assertEqual(get_recipients("CRM Lead", record), [])
+
+
+def create_test_user(email):
+	if frappe.db.exists("User", email):
+		user = frappe.get_doc("User", email)
+		user.enabled = 1
+		user.save(ignore_permissions=True)
+		return user
+
+	return frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": email,
+			"first_name": email.split("@")[0],
+			"send_welcome_email": 0,
+			"roles": [{"role": "Sales User"}],
+		}
+	).insert(ignore_permissions=True)

--- a/frontend/src/components/Notifications.vue
+++ b/frontend/src/components/Notifications.vue
@@ -49,6 +49,12 @@
                 :class="[n.read ? 'bg-transparent' : 'bg-surface-gray-10']"
               />
               <WhatsAppIcon v-if="n.type == 'WhatsApp'" class="size-7" />
+              <div
+                v-else-if="n.type == 'Follow Up'"
+                class="flex size-7 items-center justify-center rounded-full bg-surface-gray-2"
+              >
+                <CalendarIcon class="size-4 text-ink-gray-7" />
+              </div>
               <UserAvatar v-else :user="n.from_user.name" size="lg" />
             </div>
             <div>
@@ -90,6 +96,7 @@
 </template>
 <script setup>
 import WhatsAppIcon from '@/components/Icons/WhatsAppIcon.vue'
+import CalendarIcon from '@/components/Icons/CalendarIcon.vue'
 import MarkAsDoneIcon from '@/components/Icons/MarkAsDoneIcon.vue'
 import NotificationsIcon from '@/components/Icons/NotificationsIcon.vue'
 import EventNotificationsArea from '@/components/EventNotificationsArea.vue'

--- a/frontend/src/components/Settings/GeneralSettings.vue
+++ b/frontend/src/components/Settings/GeneralSettings.vue
@@ -25,9 +25,13 @@
         </div>
         <div>
           <Switch
-            v-model="settings.doc.update_timestamp_on_new_communication"
+            :model-value="
+              Boolean(settings.doc.update_timestamp_on_new_communication)
+            "
             size="sm"
-            @click.stop="toggle('update_timestamp_on_new_communication')"
+            @update:model-value="
+              (value) => toggle('update_timestamp_on_new_communication', value)
+            "
           />
         </div>
       </div>
@@ -47,9 +51,11 @@
         </div>
         <div>
           <Switch
-            v-model="settings.doc.auto_mark_replied_on_response"
+            :model-value="Boolean(settings.doc.auto_mark_replied_on_response)"
             size="sm"
-            @click.stop="toggle('auto_mark_replied_on_response')"
+            @update:model-value="
+              (value) => toggle('auto_mark_replied_on_response', value)
+            "
           />
         </div>
       </div>
@@ -69,9 +75,13 @@
         </div>
         <div>
           <Switch
-            v-model="settings.doc.auto_reopen_on_new_communication"
+            :model-value="
+              Boolean(settings.doc.auto_reopen_on_new_communication)
+            "
             size="sm"
-            @click.stop="toggle('auto_reopen_on_new_communication')"
+            @update:model-value="
+              (value) => toggle('auto_reopen_on_new_communication', value)
+            "
           />
         </div>
       </div>
@@ -91,9 +101,11 @@
         </div>
         <div>
           <Switch
-            v-model="settings.doc.enable_follow_up_reminders"
+            :model-value="Boolean(settings.doc.enable_follow_up_reminders)"
             size="sm"
-            @click.stop="toggle('enable_follow_up_reminders')"
+            @update:model-value="
+              (value) => toggle('enable_follow_up_reminders', value)
+            "
           />
         </div>
       </div>
@@ -146,9 +158,11 @@
         </div>
         <div>
           <Switch
-            v-model="settings.doc.send_follow_up_reminder_email"
+            :model-value="Boolean(settings.doc.send_follow_up_reminder_email)"
             size="sm"
-            @click.stop="toggle('send_follow_up_reminder_email')"
+            @update:model-value="
+              (value) => toggle('send_follow_up_reminder_email', value)
+            "
           />
         </div>
       </div>
@@ -226,7 +240,13 @@ const reminderIntervalOptions = [
   { label: __('days'), value: 'days' },
 ]
 
-function toggle(settingKey) {
+function toggle(settingKey, value) {
+  // Frappe Check fields are 0/1, but Switch is backed by a control that only
+  // recognises real booleans. Binding the raw 0/1 leaves the two out of sync:
+  // the switch paints itself "on" from the truthy value while its own state
+  // stays unchecked, so every click emits `true` and the setting can be turned
+  // on but never off. Hence Boolean() in, 0/1 back out.
+  settings.doc[settingKey] = value ? 1 : 0
   settings.save.submit(null, {
     onSuccess: () => {
       toast.success(

--- a/frontend/src/components/Settings/GeneralSettings.vue
+++ b/frontend/src/components/Settings/GeneralSettings.vue
@@ -75,6 +75,83 @@
           />
         </div>
       </div>
+      <div class="h-px border-t mx-2 border-outline-elevation-2" />
+      <div class="flex gap-4 items-center justify-between py-3 px-2">
+        <div class="flex flex-col">
+          <div class="text-p-base-medium text-ink-gray-7 truncate">
+            {{ __('Follow up reminders') }}
+          </div>
+          <div class="text-p-sm text-ink-gray-5">
+            {{
+              __(
+                'Notify the users assigned to a lead or deal when its next follow up is due',
+              )
+            }}
+          </div>
+        </div>
+        <div>
+          <Switch
+            v-model="settings.doc.enable_follow_up_reminders"
+            size="sm"
+            @click.stop="toggle('enable_follow_up_reminders')"
+          />
+        </div>
+      </div>
+      <div
+        v-if="settings.doc.enable_follow_up_reminders"
+        class="flex gap-4 items-center justify-between py-3 px-2"
+      >
+        <div class="flex flex-col">
+          <div class="text-p-base-medium text-ink-gray-7 truncate">
+            {{ __('Remind before') }}
+          </div>
+          <div class="text-p-sm text-ink-gray-5">
+            {{ __('How far ahead of the follow up time the reminder is sent') }}
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <FormControl
+            v-model.number="settings.doc.follow_up_reminder_before"
+            type="number"
+            min="0"
+            class="w-20"
+            :placeholder="__('30')"
+            @change="save()"
+          />
+          <FormControl
+            v-model="settings.doc.follow_up_reminder_interval"
+            type="select"
+            class="w-28"
+            :options="reminderIntervalOptions"
+            :placeholder="__('minutes')"
+            @update:modelValue="save()"
+          />
+        </div>
+      </div>
+      <div
+        v-if="settings.doc.enable_follow_up_reminders"
+        class="flex gap-4 items-center justify-between py-3 px-2"
+      >
+        <div class="flex flex-col">
+          <div class="text-p-base-medium text-ink-gray-7 truncate">
+            {{ __('Email follow up reminders') }}
+          </div>
+          <div class="text-p-sm text-ink-gray-5">
+            {{
+              __(
+                'Also email the reminder, in addition to the in-app notification',
+              )
+            }}
+          </div>
+        </div>
+        <div>
+          <Switch
+            v-model="settings.doc.send_follow_up_reminder_email"
+            size="sm"
+            @click.stop="toggle('send_follow_up_reminder_email')"
+          />
+        </div>
+      </div>
       <div class="h-px border-t mx-2 border-outline-gray-modals" />
       <div class="flex gap-4 items-center justify-between py-3 px-2">
         <div class="flex flex-col">
@@ -142,6 +219,11 @@ const timestampFormatOptions = [
 const sortOrderOptions = [
   { label: __('Oldest First'), value: 'Oldest First' },
   { label: __('Newest First'), value: 'Newest First' },
+]
+const reminderIntervalOptions = [
+  { label: __('minutes'), value: 'minutes' },
+  { label: __('hours'), value: 'hours' },
+  { label: __('days'), value: 'days' },
 ]
 
 function toggle(settingKey) {

--- a/frontend/src/pages/MobileNotification.vue
+++ b/frontend/src/pages/MobileNotification.vue
@@ -35,6 +35,12 @@
             :class="[n.read ? 'bg-transparent' : 'bg-surface-gray-10']"
           />
           <WhatsAppIcon v-if="n.type == 'WhatsApp'" class="size-7" />
+          <div
+            v-else-if="n.type == 'Follow Up'"
+            class="flex size-7 items-center justify-center rounded-full bg-surface-gray-2"
+          >
+            <CalendarIcon class="size-4 text-ink-gray-7" />
+          </div>
           <UserAvatar v-else :user="n.from_user.name" size="lg" />
         </div>
         <div>
@@ -70,6 +76,7 @@
 <script setup>
 import LayoutHeader from '@/components/LayoutHeader.vue'
 import WhatsAppIcon from '@/components/Icons/WhatsAppIcon.vue'
+import CalendarIcon from '@/components/Icons/CalendarIcon.vue'
 import MarkAsDoneIcon from '@/components/Icons/MarkAsDoneIcon.vue'
 import NotificationsIcon from '@/components/Icons/NotificationsIcon.vue'
 import UserAvatar from '@/components/UserAvatar.vue'


### PR DESCRIPTION
Closes #2588

## Problem

There is no first-class way to answer *"when am I next supposed to touch this lead/deal, and who is responsible?"*. Today a rep has to improvise: a separate Task record (invisible on the Lead/Deal list, no single "next touch"), a comment or `next_step` (invisible to sorting, filtering and automation), or a custom field — which is what people end up doing, but a custom field is inert, so nothing reminds anyone when the date arrives.

## What this adds

**1. A `next_follow_up` Datetime on CRM Lead and CRM Deal**

- `Datetime`, because the time matters ("call at 3pm", not "sometime Tuesday")
- Indexed, and added to `default_list_data` so it is a sortable/filterable list column — a rep can pull up "my follow-ups due today", a manager can spot overdue ones
- Added to the default Lead/Deal Side Panel layouts

**2. A reminder when it comes due**

`crm.api.follow_up.trigger_follow_up_reminders` runs on the `all` scheduler event and notifies the users responsible for the record:

- In-app `CRM Notification` (new `Follow Up` type), with email as a configurable option
- Recipients are `_assign`, falling back to `lead_owner`/`deal_owner` and then the record owner, so a reminder is never silently dropped when nobody is assigned
- Configurable lead time — *n* minutes/hours/days, default 30 minutes — alongside an enable switch and the email option, in **Settings → General**

This reuses the existing machinery the issue pointed at: `notify_user()` from `CRM Notification`, and the same "notify N units before a datetime" shape as `crm/api/event.py`.

## Reminder lifecycle

Rather than a queue of pending reminder rows, state is a single hidden `follow_up_reminder_sent` checkbox on the record, cleared in `validate` whenever `next_follow_up` changes. That makes the three lifecycle rules from the issue nearly free:

| Case | Behaviour |
| --- | --- |
| Rescheduled | flag clears on save, the new time gets its own reminder |
| Cleared | no date, so the record never matches the query |
| Won / Lost / converted lead | filtered out, so a dead deal never fires |

Overdue follow-ups still notify (the scheduler being down doesn't lose them), and each tick is capped at 200 records so a backlog can't monopolise the worker.

## Upgrade path

Two patches, because neither case is covered by shipping the fields alone:

- `add_next_follow_up_to_layouts` — the layout seeder in `install.py` is skip-if-exists, so existing sites would get the field and its reminders with nowhere to set the date
- `set_follow_up_reminder_defaults` — field defaults only apply when a Single is first created, so existing sites would otherwise get `0`/`NULL`: reminders off and lead time zero

## Testing

14 integration tests in `crm/tests/test_follow_up.py` covering lead-time maths, due selection, no-duplicate-send, reschedule/clear/closed/converted, the disabled setting, and recipient resolution including the owner fallback and disabled users.

Verified manually in a local bench: setting the date from the side panel, the scheduler producing a real in-app notification, the new list column, and the settings controls persisting.

One bug worth calling out, since the fix looks like it could be simplified away. Frappe's query builder compiles `<=` on a Datetime into `IFNULL(next_follow_up, '0001-01-01') <= cutoff`, so **every record with no follow-up date matched** — the first scheduler tick would have reminded the owner of every lead and deal in the system. `get_due_records` therefore carries an explicit `["next_follow_up", "is", "set"]` filter, with a comment and a regression test (`test_record_without_follow_up_is_never_due`) guarding it.
