### PR TITLE
docs: rename User Hierarchy to Sales Hierarchy

### DIFF
--- a/docs/user-hierarchy.md
+++ b/docs/user-hierarchy.md
@@ -3,7 +3,7 @@
 Arrange your sales team into a reporting tree so managers see the leads and
 deals owned by their team, while everyone else sees only their own.
 
-Open it from **Settings → User Hierarchy**.
+Open it from **Settings → Sales Hierarchy**.
 
 ## Turning it on
 


### PR DESCRIPTION
## Summary
- Update `docs/user-hierarchy.md` so the settings path matches the UI label (**Settings → Sales Hierarchy** instead of User Hierarchy).

## Test plan
- [ ] Confirm the CRM Settings nav shows "Sales Hierarchy"
- [ ] Open the doc and verify the path text matches the UI


Made with <3