### PR TITLE
fix(comment): only notify mentions on CRM documents

### DIFF
--- a/crm/api/comment.py
+++ b/crm/api/comment.py
@@ -18,6 +18,10 @@ def notify_mentions(doc):
 	Extract mentions from `content`, and notify.
 	`content` must have `HTML` content.
 	"""
+	# Comment is a core doctype: other apps write comments on their own
+	# documents, which have no lead_name/organization to read below
+	if doc.reference_doctype not in ["CRM Lead", "CRM Deal"]:
+		return
 	content = getattr(doc, "content", None)
 	if not content:
 		return

--- a/crm/api/comment.py
+++ b/crm/api/comment.py
@@ -18,8 +18,6 @@ def notify_mentions(doc):
 	Extract mentions from `content`, and notify.
 	`content` must have `HTML` content.
 	"""
-	# Comment is a core doctype: other apps write comments on their own
-	# documents, which have no lead_name/organization to read below
 	if doc.reference_doctype not in ["CRM Lead", "CRM Deal"]:
 		return
 	content = getattr(doc, "content", None)


### PR DESCRIPTION
**Issue**

`Comment` is a core doctype, so any installed app can write comments on its own documents. CRM hooks `on_update` on Comment globally and `notify_mentions` assumes every comment belongs to a CRM Lead or Deal, reading `lead_name` / `organization` off the reference document.

On a site with both CRM and Helpdesk installed, commenting with a mention on a Helpdesk ticket throws:

```
File "apps/crm/crm/api/comment.py", line 34, in notify_mentions
    else reference_doc.organization or reference_doc.lead_name
AttributeError: 'HDTicket' object has no attribute 'organization'
```

It only fails when the comment contains a mention, since the attribute access sits inside the mentions loop.

**Solution**

Return early when `reference_doctype` is not a CRM Lead or Deal, the same guard `crm.utils.on_comment_insert` already applies to the sibling `after_insert` hook.

**How to test**

1. Install CRM and Helpdesk on the same site.
2. Open a ticket in the Helpdesk agent portal and post a comment that mentions a user.
3. Before: `AttributeError`. After: the comment saves, and CRM notifications are unaffected for Lead / Deal comments.
