### PR TITLE
fix: set all the currency fields to non-negative in Lead/Deal/Organization

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -101,6 +101,7 @@
    "fieldname": "annual_revenue",
    "fieldtype": "Currency",
    "label": "Annual Revenue",
+   "non_negative": 1,
    "options": "currency"
   },
   {
@@ -381,6 +382,7 @@
    "fieldname": "total",
    "fieldtype": "Currency",
    "label": "Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },
@@ -389,6 +391,7 @@
    "fieldname": "net_total",
    "fieldtype": "Currency",
    "label": "Net Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },
@@ -400,6 +403,7 @@
    "fieldname": "deal_value",
    "fieldtype": "Currency",
    "label": "Deal Value",
+   "non_negative": 1,
    "options": "currency"
   },
   {
@@ -429,6 +433,7 @@
    "fieldname": "expected_deal_value",
    "fieldtype": "Currency",
    "label": "Expected Deal Value",
+   "non_negative": 1,
    "options": "currency"
   },
   {
@@ -477,18 +482,18 @@
    "label": "Lost Details"
   },
   {
+   "description": "Company logo discovered by Domain Enrichment.",
    "fieldname": "organization_logo",
    "fieldtype": "Attach Image",
    "label": "Organization Logo",
-   "no_copy": 1,
-   "description": "Company logo discovered by Domain Enrichment."
+   "no_copy": 1
   },
   {
+   "description": "Company description discovered by Domain Enrichment.",
    "fieldname": "company_description",
    "fieldtype": "Small Text",
    "label": "Company Description",
-   "no_copy": 1,
-   "description": "Company description discovered by Domain Enrichment."
+   "no_copy": 1
   },
   {
    "depends_on": "eval:doc.linkedin",
@@ -515,7 +520,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-04 12:34:10.808282",
+ "modified": "2026-08-14 10:35:43.663500",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Deal",

--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -19,18 +19,16 @@ class CRMDeal(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
 		from crm.fcrm.doctype.crm_contacts.crm_contacts import CRMContacts
 		from crm.fcrm.doctype.crm_products.crm_products import CRMProducts
-		from crm.fcrm.doctype.crm_rolling_response_time.crm_rolling_response_time import (
-			CRMRollingResponseTime,
-		)
+		from crm.fcrm.doctype.crm_rolling_response_time.crm_rolling_response_time import CRMRollingResponseTime
 		from crm.fcrm.doctype.crm_status_change_log.crm_status_change_log import CRMStatusChangeLog
+		from frappe.types import DF
 
 		annual_revenue: DF.Currency
 		closed_date: DF.Date | None
 		communication_status: DF.Link | None
+		company_description: DF.SmallText | None
 		contact: DF.Link | None
 		contacts: DF.Table[CRMContacts]
 		currency: DF.Link | None
@@ -40,6 +38,7 @@ class CRMDeal(Document):
 		exchange_rate: DF.Float
 		expected_closure_date: DF.Date | None
 		expected_deal_value: DF.Currency
+		facebook: DF.Data | None
 		first_name: DF.Data | None
 		first_responded_on: DF.Datetime | None
 		first_response_time: DF.Duration | None
@@ -51,6 +50,7 @@ class CRMDeal(Document):
 		last_response_time: DF.Duration | None
 		lead: DF.Link | None
 		lead_name: DF.Data | None
+		linkedin: DF.Data | None
 		lost_notes: DF.Text | None
 		lost_reason: DF.Link | None
 		mobile_no: DF.Data | None
@@ -59,6 +59,7 @@ class CRMDeal(Document):
 		next_step: DF.Data | None
 		no_of_employees: DF.Literal["1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"]
 		organization: DF.Link | None
+		organization_logo: DF.AttachImage | None
 		organization_name: DF.Data | None
 		phone: DF.Data | None
 		probability: DF.Percent
@@ -74,6 +75,7 @@ class CRMDeal(Document):
 		status_change_log: DF.Table[CRMStatusChangeLog]
 		territory: DF.Link | None
 		total: DF.Currency
+		twitter: DF.Data | None
 		website: DF.Data | None
 	# end: auto-generated types
 

--- a/crm/fcrm/doctype/crm_lead/crm_lead.json
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -165,7 +165,8 @@
   {
    "fieldname": "annual_revenue",
    "fieldtype": "Currency",
-   "label": "Annual Revenue"
+   "label": "Annual Revenue",
+   "non_negative": 1
   },
   {
    "fieldname": "lead_owner",
@@ -334,6 +335,7 @@
    "fieldname": "total",
    "fieldtype": "Currency",
    "label": "Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },
@@ -346,6 +348,7 @@
    "fieldname": "net_total",
    "fieldtype": "Currency",
    "label": "Net Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },
@@ -426,18 +429,18 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Company logo discovered by Domain Enrichment.",
    "fieldname": "organization_logo",
    "fieldtype": "Attach Image",
    "label": "Organization Logo",
-   "no_copy": 1,
-   "description": "Company logo discovered by Domain Enrichment."
+   "no_copy": 1
   },
   {
+   "description": "Company description discovered by Domain Enrichment.",
    "fieldname": "company_description",
    "fieldtype": "Small Text",
    "label": "Company Description",
-   "no_copy": 1,
-   "description": "Company description discovered by Domain Enrichment."
+   "no_copy": 1
   },
   {
    "depends_on": "eval:doc.linkedin",
@@ -465,7 +468,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-04 12:33:17.177897",
+ "modified": "2026-08-14 10:33:31.925457",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Lead",

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -25,18 +25,17 @@ class CRMLead(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
 		from crm.fcrm.doctype.crm_products.crm_products import CRMProducts
-		from crm.fcrm.doctype.crm_rolling_response_time.crm_rolling_response_time import (
-			CRMRollingResponseTime,
-		)
+		from crm.fcrm.doctype.crm_rolling_response_time.crm_rolling_response_time import CRMRollingResponseTime
 		from crm.fcrm.doctype.crm_status_change_log.crm_status_change_log import CRMStatusChangeLog
+		from frappe.types import DF
 
 		annual_revenue: DF.Currency
 		communication_status: DF.Link | None
+		company_description: DF.SmallText | None
 		converted: DF.Check
 		email: DF.Data | None
+		facebook: DF.Data | None
 		facebook_form_id: DF.Data | None
 		facebook_lead_id: DF.Data | None
 		first_name: DF.Data
@@ -51,6 +50,7 @@ class CRMLead(Document):
 		last_response_time: DF.Duration | None
 		lead_name: DF.Data | None
 		lead_owner: DF.Link | None
+		linkedin: DF.Data | None
 		lost_notes: DF.Text | None
 		lost_reason: DF.Link | None
 		middle_name: DF.Data | None
@@ -59,6 +59,7 @@ class CRMLead(Document):
 		net_total: DF.Currency
 		no_of_employees: DF.Literal["1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"]
 		organization: DF.Data | None
+		organization_logo: DF.AttachImage | None
 		phone: DF.Data | None
 		products: DF.Table[CRMProducts]
 		response_by: DF.Datetime | None
@@ -72,6 +73,7 @@ class CRMLead(Document):
 		status_change_log: DF.Table[CRMStatusChangeLog]
 		territory: DF.Link | None
 		total: DF.Currency
+		twitter: DF.Data | None
 		website: DF.Data | None
 	# end: auto-generated types
 

--- a/crm/fcrm/doctype/crm_organization/crm_organization.json
+++ b/crm/fcrm/doctype/crm_organization/crm_organization.json
@@ -56,6 +56,7 @@
    "fieldname": "annual_revenue",
    "fieldtype": "Currency",
    "label": "Annual Revenue",
+   "non_negative": 1,
    "options": "currency"
   },
   {
@@ -91,11 +92,11 @@
    "label": "Exchange Rate"
   },
   {
+   "description": "Company description discovered by Domain Enrichment.",
    "fieldname": "company_description",
    "fieldtype": "Small Text",
    "label": "Company Description",
-   "no_copy": 1,
-   "description": "Company description discovered by Domain Enrichment."
+   "no_copy": 1
   },
   {
    "depends_on": "eval:doc.linkedin",
@@ -122,8 +123,8 @@
  "image_field": "organization_logo",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-26 12:51:34.002222",
- "modified_by": "shariq@frappe.io",
+ "modified": "2026-08-14 10:32:49.123406",
+ "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Organization",
  "naming_rule": "By fieldname",

--- a/crm/fcrm/doctype/crm_organization/crm_organization.py
+++ b/crm/fcrm/doctype/crm_organization/crm_organization.py
@@ -18,13 +18,17 @@ class CRMOrganization(Document):
 
 		address: DF.Link | None
 		annual_revenue: DF.Currency
+		company_description: DF.SmallText | None
 		currency: DF.Link | None
 		exchange_rate: DF.Float
+		facebook: DF.Data | None
 		industry: DF.Link | None
+		linkedin: DF.Data | None
 		no_of_employees: DF.Literal["1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"]
 		organization_logo: DF.AttachImage | None
 		organization_name: DF.Data | None
 		territory: DF.Link | None
+		twitter: DF.Data | None
 		website: DF.Data | None
 	# end: auto-generated types
 


### PR DESCRIPTION
#2654 
Fixed the CRM Lead, CRM Deal, CRM Organization doctype currency fields to accept non-negative values only.

`"non_negative": 1`