### PR TITLE
fix: prevent negative values in currency fields on Lead, Deal, Organization 

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -101,6 +101,7 @@
    "fieldname": "annual_revenue",
    "fieldtype": "Currency",
    "label": "Annual Revenue",
+   "non_negative": 1,
    "options": "currency"
   },
   {
@@ -381,6 +382,7 @@
    "fieldname": "total",
    "fieldtype": "Currency",
    "label": "Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },
@@ -389,6 +391,7 @@
    "fieldname": "net_total",
    "fieldtype": "Currency",
    "label": "Net Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },
@@ -400,6 +403,7 @@
    "fieldname": "deal_value",
    "fieldtype": "Currency",
    "label": "Deal Value",
+   "non_negative": 1,
    "options": "currency"
   },
   {
@@ -429,6 +433,7 @@
    "fieldname": "expected_deal_value",
    "fieldtype": "Currency",
    "label": "Expected Deal Value",
+   "non_negative": 1,
    "options": "currency"
   },
   {

--- a/crm/fcrm/doctype/crm_deal/test_crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/test_crm_deal.py
@@ -420,6 +420,12 @@ class TestCRMDeal(IntegrationTestCase):
 		deal.reload()
 		self.assertEqual(deal.contacts[0].is_primary, 1)
 
+	def test_negative_currency_fields_rejected(self):
+		"""Test that Currency fields reject negative values"""
+		for fieldname in ("annual_revenue", "deal_value", "expected_deal_value", "total", "net_total"):
+			with self.subTest(fieldname=fieldname), self.assertRaises(frappe.NonNegativeError):
+				create_test_deal(organization=f"Negative {fieldname}", **{fieldname: -100})
+
 
 def create_test_deal(**kwargs):
 	"""Helper function to create a CRM Deal for testing"""

--- a/crm/fcrm/doctype/crm_lead/crm_lead.json
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -165,7 +165,8 @@
   {
    "fieldname": "annual_revenue",
    "fieldtype": "Currency",
-   "label": "Annual Revenue"
+   "label": "Annual Revenue",
+   "non_negative": 1
   },
   {
    "fieldname": "lead_owner",
@@ -334,6 +335,7 @@
    "fieldname": "total",
    "fieldtype": "Currency",
    "label": "Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },
@@ -346,6 +348,7 @@
    "fieldname": "net_total",
    "fieldtype": "Currency",
    "label": "Net Total",
+   "non_negative": 1,
    "options": "currency",
    "read_only": 1
   },

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -562,6 +562,16 @@ class TestCRMLead(IntegrationTestCase):
 		assign_add({"assign_to": ["crm.user2@example.com"], "doctype": "CRM Lead", "name": lead.name})
 		self.assertEqual(frappe.db.get_value("CRM Lead", lead.name, "lead_owner"), "crm.user2@example.com")
 
+	def test_negative_currency_fields_rejected(self):
+		"""Test that Currency fields reject negative values"""
+		for fieldname in ("annual_revenue", "total", "net_total"):
+			with self.subTest(fieldname=fieldname), self.assertRaises(frappe.NonNegativeError):
+				create_lead(
+					first_name="Negative",
+					email=f"negative.{fieldname}@example.com",
+					**{fieldname: -100},
+				)
+
 
 def create_lead(**kwargs):
 	"""Helper function to create a CRM Lead for testing"""

--- a/crm/fcrm/doctype/crm_organization/crm_organization.json
+++ b/crm/fcrm/doctype/crm_organization/crm_organization.json
@@ -56,6 +56,7 @@
    "fieldname": "annual_revenue",
    "fieldtype": "Currency",
    "label": "Annual Revenue",
+   "non_negative": 1,
    "options": "currency"
   },
   {

--- a/crm/fcrm/doctype/crm_organization/test_crm_organization.py
+++ b/crm/fcrm/doctype/crm_organization/test_crm_organization.py
@@ -1,9 +1,21 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import UnitTestCase
+import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestCRMOrganization(UnitTestCase):
-	pass
+class TestCRMOrganization(IntegrationTestCase):
+	def tearDown(self) -> None:
+		frappe.db.rollback()
+
+	def test_negative_annual_revenue_rejected(self):
+		"""Test that annual_revenue rejects negative values"""
+		with self.assertRaises(frappe.NonNegativeError):
+			frappe.get_doc(
+				{
+					"doctype": "CRM Organization",
+					"organization_name": "Negative Revenue Org",
+					"annual_revenue": -100,
+				}
+			).insert()


### PR DESCRIPTION
Fixes #2654

Adds non_negative: 1 to the affected Currency fields, which enables Frappe core's existing _validate_non_negative() check .

Fields updated:

CRM Lead: annual_revenue, total, net_total
CRM Deal: annual_revenue, deal_value, expected_deal_value, total, net_total
CRM Organization: annual_revenue