### PR TITLE
fix(rtl): use logical spacing/text-align classes instead of physical ones

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -229,7 +229,7 @@
                   aria-hidden="true"
                 />
               </div>
-              <div class="ml-auto whitespace-nowrap">
+              <div class="ms-auto whitespace-nowrap">
                 <TimelineTimestamp :date="activity.creation" />
               </div>
             </div>
@@ -310,7 +310,7 @@
                 </span>
               </div>
 
-              <div class="ml-auto whitespace-nowrap">
+              <div class="ms-auto whitespace-nowrap">
                 <TimelineTimestamp :date="activity.creation" />
               </div>
             </div>
@@ -373,7 +373,7 @@
                   </span>
                 </div>
 
-                <div class="ml-auto whitespace-nowrap">
+                <div class="ms-auto whitespace-nowrap">
                   <TimelineTimestamp :date="a.creation" />
                 </div>
               </div>

--- a/frontend/src/components/Activities/CallArea.vue
+++ b/frontend/src/components/Activities/CallArea.vue
@@ -7,7 +7,7 @@
           :label="call._caller.label"
           size="md"
         />
-        <span class="font-medium text-ink-gray-8 ml-1">
+        <span class="font-medium text-ink-gray-8 ms-1">
           {{ call._caller.label }}
         </span>
         <span>{{
@@ -16,7 +16,7 @@
             : __('has made a call')
         }}</span>
       </div>
-      <div class="ml-auto whitespace-nowrap">
+      <div class="ms-auto whitespace-nowrap">
         <TimelineTimestamp :date="call.creation" />
       </div>
     </div>

--- a/frontend/src/components/Activities/CommentArea.vue
+++ b/frontend/src/components/Activities/CommentArea.vue
@@ -2,7 +2,7 @@
   <div :id="activity.name">
     <div class="mb-1 flex items-center justify-stretch gap-2 py-1 text-base">
       <div class="inline-flex items-center flex-wrap gap-1 text-ink-gray-5">
-        <UserAvatar class="mr-1" :user="activity.owner" size="md" />
+        <UserAvatar class="me-1" :user="activity.owner" size="md" />
         <span class="font-medium text-ink-gray-8">
           {{ activity.owner_name }}
         </span>
@@ -11,7 +11,7 @@
           {{ __('comment') }}
         </span>
       </div>
-      <div class="ml-auto flex items-center gap-1 whitespace-nowrap">
+      <div class="ms-auto flex items-center gap-1 whitespace-nowrap">
         <TimelineTimestamp :date="activity.creation" />
         <Dropdown
           v-if="isOwner && !editing"

--- a/frontend/src/components/Activities/DataFields.vue
+++ b/frontend/src/components/Activities/DataFields.vue
@@ -6,7 +6,7 @@
       {{ __('Data') }}
       <Badge
         v-if="document.isDirty"
-        class="ml-3"
+        class="ms-3"
         :label="__('Not Saved')"
         theme="orange"
       />

--- a/frontend/src/components/Activities/EmailArea.vue
+++ b/frontend/src/components/Activities/EmailArea.vue
@@ -46,15 +46,15 @@
     <div class="flex flex-col gap-1 text-base leading-5 text-ink-gray-8">
       <div>{{ activity.data.subject }}</div>
       <div>
-        <span class="mr-1 text-ink-gray-5"> {{ __('To') }}: </span>
+        <span class="me-1 text-ink-gray-5"> {{ __('To') }}: </span>
         <span>{{ activity.data.recipients }}</span>
         <span v-if="activity.data.cc">, </span>
-        <span v-if="activity.data.cc" class="mr-1 text-ink-gray-5">
+        <span v-if="activity.data.cc" class="me-1 text-ink-gray-5">
           {{ __('CC') }}:
         </span>
         <span v-if="activity.data.cc">{{ activity.data.cc }}</span>
         <span v-if="activity.data.bcc">, </span>
-        <span v-if="activity.data.bcc" class="mr-1 text-ink-gray-5">
+        <span v-if="activity.data.bcc" class="me-1 text-ink-gray-5">
           {{ __('BCC') }}:
         </span>
         <span v-if="activity.data.bcc">{{ activity.data.bcc }}</span>

--- a/frontend/src/components/Activities/EventArea.vue
+++ b/frontend/src/components/Activities/EventArea.vue
@@ -25,12 +25,12 @@
               :label="event.owner.label"
               size="md"
             />
-            <span class="font-medium text-ink-gray-8 ml-1">
+            <span class="font-medium text-ink-gray-8 ms-1">
               {{ event.owner.label }}
             </span>
             <span>{{ 'has created an event' }}</span>
           </div>
-          <div class="ml-auto whitespace-nowrap">
+          <div class="ms-auto whitespace-nowrap">
             <TimelineTimestamp :date="event.creation" />
           </div>
         </div>

--- a/frontend/src/components/Activities/WhatsAppArea.vue
+++ b/frontend/src/components/Activities/WhatsAppArea.vue
@@ -12,7 +12,7 @@
     >
       <div
         :id="whatsapp.name"
-        class="group/message relative max-w-[90%] rounded-md bg-surface-gray-1 text-ink-gray-9 p-1.5 pl-2 text-base shadow-sm"
+        class="group/message relative max-w-[90%] rounded-md bg-surface-gray-1 text-ink-gray-9 p-1.5 ps-2 text-base shadow-sm"
       >
         <Badge
           v-if="whatsapp.status == 'failed'"
@@ -53,7 +53,7 @@
         <div class="flex gap-2 justify-between">
           <div
             v-if="whatsapp.status != 'failed'"
-            class="absolute -right-0.5 -top-0.5 flex cursor-pointer gap-1 rounded-full bg-surface-base pb-2 pl-2 pr-1.5 pt-1.5 opacity-0 group-hover/message:opacity-100"
+            class="absolute -right-0.5 -top-0.5 flex cursor-pointer gap-1 rounded-full bg-surface-base pb-2 ps-2 pe-1.5 pt-1.5 opacity-0 group-hover/message:opacity-100"
             :style="{
               background:
                 'radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 35%, rgba(238, 130, 238, 0) 100%)',

--- a/frontend/src/components/Activities/WhatsAppBox.vue
+++ b/frontend/src/components/Activities/WhatsAppBox.vue
@@ -5,7 +5,7 @@
     class="flex items-center justify-around gap-2 px-3 pt-2 sm:px-10"
   >
     <div
-      class="mb-1 ml-13 flex-1 cursor-pointer rounded border-0 border-l-4 border-green-500 bg-surface-gray-2 p-2 text-base text-ink-gray-5"
+      class="mb-1 ms-13 flex-1 cursor-pointer rounded border-0 border-l-4 border-green-500 bg-surface-gray-2 p-2 text-base text-ink-gray-5"
       :class="reply.type == 'Incoming' ? 'border-green-500' : 'border-blue-400'"
     >
       <div

--- a/frontend/src/components/AssignToBody.vue
+++ b/frontend/src/components/AssignToBody.vue
@@ -31,7 +31,7 @@
               @click.stop
             >
               <UserAvatar :user="assignee.name" size="sm" />
-              <div class="ml-1">{{ getUser(assignee.name).full_name }}</div>
+              <div class="ms-1">{{ getUser(assignee.name).full_name }}</div>
               <Button
                 variant="ghost"
                 class="rounded-full !size-4 m-1"
@@ -49,7 +49,7 @@
         </div>
       </template>
       <template #item-prefix="{ option }">
-        <UserAvatar class="mr-2" :user="option.value" size="sm" />
+        <UserAvatar class="me-2" :user="option.value" size="sm" />
       </template>
       <template #item-label="{ option }">
         <Tooltip :text="option.value">

--- a/frontend/src/components/Calendar/Attendee.vue
+++ b/frontend/src/components/Calendar/Attendee.vue
@@ -56,7 +56,7 @@
                 class="text-base leading-none text-ink-gray-7 rounded flex items-center px-2 py-1 relative select-none data-[highlighted]:outline-none data-[highlighted]:bg-surface-gray-3 cursor-pointer"
                 @mousedown.prevent="onSelect(option.value, option)"
               >
-                <UserAvatar class="mr-2" :user="option.value" size="lg" />
+                <UserAvatar class="me-2" :user="option.value" size="lg" />
                 <div class="flex flex-col gap-1 p-1 text-ink-gray-8">
                   <div class="text-base-medium">{{ option.label }}</div>
                   <div class="text-sm text-ink-gray-5">{{ option.value }}</div>
@@ -84,7 +84,7 @@
         :tooltip="getTooltip(att.email)"
       >
         <template #prefix>
-          <UserAvatar :user="att.email" class="-ml-1 !size-5.5" />
+          <UserAvatar :user="att.email" class="-ms-1 !size-5.5" />
         </template>
         <template #suffix>
           <span
@@ -94,7 +94,7 @@
           />
         </template>
       </Button>
-      <ErrorMessage v-if="error" class="mt-2 pl-2" :message="error" />
+      <ErrorMessage v-if="error" class="mt-2 ps-2" :message="error" />
     </div>
   </div>
 </template>

--- a/frontend/src/components/Calendar/CalendarEventPanel.vue
+++ b/frontend/src/components/Calendar/CalendarEventPanel.vue
@@ -137,12 +137,12 @@
             <div class="text-p-base">{{ attendees }}</div>
           </div>
         </div>
-        <div class="flex flex-col gap-2 -ml-1">
+        <div class="flex flex-col gap-2 -ms-1">
           <Button
             :key="_event.owner"
             variant="ghost"
             theme="gray"
-            class="rounded-full w-fit !h-8.5 !pr-3"
+            class="rounded-full w-fit !h-8.5 !pe-3"
             :tooltip="__('Owner: {0}', [_event.owner?.label])"
           >
             <template #default>
@@ -153,7 +153,7 @@
             </template>
             <template #prefix>
               <div class="relative">
-                <UserAvatar :user="_event.owner?.value" class="-ml-1 !size-5" />
+                <UserAvatar :user="_event.owner?.value" class="-ms-1 !size-5" />
                 <div
                   v-if="_event.attending"
                   class="flex items-center justify-center absolute -bottom-[2px] -right-[2px] ring-1 ring-outline-base size-2.5 rounded-full"
@@ -195,7 +195,7 @@
           >
             <template #prefix>
               <div class="relative">
-                <UserAvatar :user="att.email" class="-ml-1 !size-5" />
+                <UserAvatar :user="att.email" class="-ms-1 !size-5" />
                 <div
                   v-if="att.attending"
                   class="flex items-center justify-center absolute -bottom-[2px] -right-[2px] ring-1 ring-outline-base size-2.5 rounded-full"
@@ -263,7 +263,7 @@
     <!-- Event new, duplicate & edit -->
     <div v-else class="flex flex-col flex-1 overflow-y-auto">
       <div class="flex gap-2 items-center px-4.5 py-3">
-        <Dropdown class="ml-1" :options="colors">
+        <Dropdown class="ms-1" :options="colors">
           <div
             class="flex items-center justify-center size-8 shrink-0 border border-outline-gray-2 bg-surface-base hover:border-outline-gray-3 hover:shadow-sm rounded cursor-pointer"
           >
@@ -290,7 +290,7 @@
       <div class="flex justify-between py-2.5 px-4.5 text-ink-gray-6">
         <div class="flex items-center">
           <Switch v-model="_event.isFullDay" @update:model-value="sync" />
-          <div class="ml-2">
+          <div class="ms-2">
             {{ __('All Day') }}
           </div>
         </div>

--- a/frontend/src/components/Controls/AttachControl.vue
+++ b/frontend/src/components/Controls/AttachControl.vue
@@ -21,7 +21,7 @@
   </div>
 
   <!-- Has value -->
-  <div v-else :class="[containerClasses, '!pr-1']">
+  <div v-else :class="[containerClasses, '!pe-1']">
     <span
       class="lucide-paperclip size-4"
       :class="[iconClasses, 'text-ink-gray-7']"
@@ -54,7 +54,7 @@
     </Tooltip>
     <button
       v-if="!disabled"
-      class="ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded text-ink-gray-4 hover:bg-surface-gray-2 hover:text-ink-gray-7 dark:hover:bg-surface-gray-4"
+      class="ms-auto flex h-5 w-5 shrink-0 items-center justify-center rounded text-ink-gray-4 hover:bg-surface-gray-2 hover:text-ink-gray-7 dark:hover:bg-surface-gray-4"
       :title="__('Clear')"
       @click.prevent="clearAttachment"
     >

--- a/frontend/src/components/Controls/EmailMultiSelect.vue
+++ b/frontend/src/components/Controls/EmailMultiSelect.vue
@@ -77,7 +77,7 @@
                   class="text-base leading-none text-ink-gray-7 rounded flex items-center px-2 py-1 relative select-none data-[highlighted]:outline-none data-[highlighted]:bg-surface-gray-3 cursor-pointer"
                   @mousedown.prevent="onSelect(option.value)"
                 >
-                  <UserAvatar class="mr-2" :user="option.value" size="lg" />
+                  <UserAvatar class="me-2" :user="option.value" size="lg" />
                   <div class="flex flex-col gap-1 p-1 text-ink-gray-8">
                     <div class="text-base-medium">{{ option.label }}</div>
                     <div class="text-sm text-ink-gray-5">
@@ -91,10 +91,10 @@
         </ComboboxRoot>
       </div>
     </div>
-    <ErrorMessage v-if="error" class="mt-2 pl-2" :message="error" />
+    <ErrorMessage v-if="error" class="mt-2 ps-2" :message="error" />
     <div
       v-if="info"
-      class="whitespace-pre-line text-sm text-ink-blue-6 mt-2 pl-2"
+      class="whitespace-pre-line text-sm text-ink-blue-6 mt-2 ps-2"
     >
       {{ info }}
     </div>

--- a/frontend/src/components/Controls/GeolocationControl.vue
+++ b/frontend/src/components/Controls/GeolocationControl.vue
@@ -23,7 +23,7 @@
   <!-- Has value -->
   <div
     v-else
-    :class="[containerClasses, '!pr-1', 'cursor-pointer']"
+    :class="[containerClasses, '!pe-1', 'cursor-pointer']"
     @click="openModal"
   >
     <span

--- a/frontend/src/components/Controls/Grid.vue
+++ b/frontend/src/components/Controls/Grid.vue
@@ -36,7 +36,7 @@
             class="border-r border-outline-gray-2 p-2 truncate"
             :class="
               ['Int', 'Float', 'Currency', 'Percent'].includes(field.fieldtype)
-                ? 'text-right'
+                ? 'text-end'
                 : ''
             "
             :title="field.label"
@@ -167,14 +167,14 @@
                       >
                         <template #prefix>
                           <UserAvatar
-                            class="mr-2"
+                            class="me-2"
                             :user="row[field.fieldname]"
                             size="sm"
                           />
                         </template>
                         <template #item-prefix="{ option }">
                           <UserAvatar
-                            class="mr-2"
+                            class="me-2"
                             :user="option.value"
                             size="sm"
                           />
@@ -254,7 +254,7 @@
                       />
                       <FormattedInput
                         v-else-if="field.fieldtype === 'Int'"
-                        class="[&_input]:text-right"
+                        class="[&_input]:text-end"
                         type="text"
                         variant="outline"
                         :value="row[field.fieldname] || '0'"
@@ -263,7 +263,7 @@
                       />
                       <FormattedInput
                         v-else-if="field.fieldtype === 'Percent'"
-                        class="[&_input]:text-right"
+                        class="[&_input]:text-end"
                         type="text"
                         variant="outline"
                         :value="getFloatWithPrecision(field.fieldname, row)"
@@ -275,7 +275,7 @@
                       />
                       <FormattedInput
                         v-else-if="field.fieldtype === 'Float'"
-                        class="[&_input]:text-right"
+                        class="[&_input]:text-end"
                         type="text"
                         variant="outline"
                         :value="getFloatWithPrecision(field.fieldname, row)"
@@ -287,7 +287,7 @@
                       />
                       <FormattedInput
                         v-else-if="field.fieldtype === 'Currency'"
-                        class="[&_input]:text-right"
+                        class="[&_input]:text-end"
                         type="text"
                         variant="outline"
                         :value="getCurrencyWithPrecision(field.fieldname, row)"

--- a/frontend/src/components/Controls/Password.vue
+++ b/frontend/src/components/Controls/Password.vue
@@ -31,7 +31,7 @@
           <FeatherIcon
             v-show="showEye"
             :name="show ? 'eye-off' : 'eye'"
-            class="h-3 cursor-pointer mr-1"
+            class="h-3 cursor-pointer me-1"
             @click="show = !show"
           />
         </div>

--- a/frontend/src/components/Controls/TableMultiselectInput.vue
+++ b/frontend/src/components/Controls/TableMultiselectInput.vue
@@ -41,7 +41,7 @@
         </Link>
       </div>
     </div>
-    <ErrorMessage v-if="error" class="mt-2 pl-2" :message="error" />
+    <ErrorMessage v-if="error" class="mt-2 ps-2" :message="error" />
   </div>
 </template>
 

--- a/frontend/src/components/EmailEditor.vue
+++ b/frontend/src/components/EmailEditor.vue
@@ -27,7 +27,7 @@
           class="mx-4 flex items-center gap-2"
           :class="from.length ? '' : 'border-t pt-2.5'"
         >
-          <span class="text-xs text-ink-gray-4 mr-2">{{ __('TO') }}:</span>
+          <span class="text-xs text-ink-gray-4 me-2">{{ __('TO') }}:</span>
           <EmailMultiSelect
             v-model="toEmails"
             class="flex-1"

--- a/frontend/src/components/EventNotificationsArea.vue
+++ b/frontend/src/components/EventNotificationsArea.vue
@@ -52,7 +52,7 @@
                     </div>
                     <div class="font-medium text-ink-gray-7">{{ e.title }}</div>
                   </div>
-                  <div class="text-ink-gray-6 ml-1">
+                  <div class="text-ink-gray-6 ms-1">
                     {{ formattedDateTime(e) }}
                   </div>
                 </div>

--- a/frontend/src/components/FieldLayout/Field.vue
+++ b/frontend/src/components/FieldLayout/Field.vue
@@ -133,13 +133,13 @@
       <template #prefix>
         <UserAvatar
           v-if="data[field.fieldname]"
-          class="mr-2"
+          class="me-2"
           :user="data[field.fieldname]"
           size="sm"
         />
       </template>
       <template #item-prefix="{ option }">
-        <UserAvatar class="mr-2" :user="option.value" size="sm" />
+        <UserAvatar class="me-2" :user="option.value" size="sm" />
       </template>
       <template #item-label="{ option }">
         <Tooltip :text="option.value">

--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -80,7 +80,7 @@
               </div>
               <div v-else class="flex items-center justify-between gap-2">
                 <div class="flex items-center gap-2">
-                  <div class="w-13 pl-2 text-end text-base text-ink-gray-5">
+                  <div class="w-13 ps-2 text-end text-base text-ink-gray-5">
                     {{ i == 0 ? __('Where') : __('And') }}
                   </div>
                   <div id="fieldname" class="!min-w-[140px]">

--- a/frontend/src/components/Kanban/KanbanView.vue
+++ b/frontend/src/components/Kanban/KanbanView.vue
@@ -157,7 +157,7 @@
       >
         <template #trigger="{ open, setOpen }">
           <Button
-            class="w-full mt-2.5 mb-1 mr-5"
+            class="w-full mt-2.5 mb-1 me-5"
             :label="__('Add Column')"
             iconLeft="plus"
             @click="setOpen(!open)"

--- a/frontend/src/components/LayoutHeader.vue
+++ b/frontend/src/components/LayoutHeader.vue
@@ -2,7 +2,7 @@
   <Teleport v-if="showHeader" to="#app-header">
     <slot>
       <header
-        class="flex h-10.5 items-center justify-between py-[7px] sm:pl-5 pl-2"
+        class="flex h-10.5 items-center justify-between py-[7px] sm:ps-5 ps-2"
       >
         <div class="flex items-center gap-2">
           <slot name="left-header" />

--- a/frontend/src/components/Layouts/AppHeader.vue
+++ b/frontend/src/components/Layouts/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex border-b pr-5">
+  <div class="flex border-b pe-5">
     <div id="app-header" class="flex-1"></div>
     <div class="flex items-center justify-center">
       <CallUI />

--- a/frontend/src/components/Layouts/AppSidebar.vue
+++ b/frontend/src/components/Layouts/AppSidebar.vue
@@ -41,7 +41,7 @@
             <template #suffix>
               <Badge
                 v-if="unreadNotificationsCount"
-                class="mr-2"
+                class="me-2"
                 :label="unreadNotificationsCount"
                 variant="subtle"
               />
@@ -65,7 +65,7 @@
               >
                 <span class="flex items-center gap-1.5">
                   <span
-                    class="lucide-chevron-right -ml-0.5 size-4 shrink-0 text-ink-gray-9 transition-transform duration-300 ease-in-out"
+                    class="lucide-chevron-right -ms-0.5 size-4 shrink-0 text-ink-gray-9 transition-transform duration-300 ease-in-out"
                     :class="{ 'rotate-90': opened }"
                     aria-hidden="true"
                   />

--- a/frontend/src/components/Mobile/MobileAppHeader.vue
+++ b/frontend/src/components/Mobile/MobileAppHeader.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex pr-3">
-    <div class="z-20 ml-2 flex items-center justify-center">
+  <div class="flex pe-3">
+    <div class="z-20 ms-2 flex items-center justify-center">
       <Button
         class="size-7"
         variant="ghost"
@@ -11,7 +11,7 @@
     </div>
     <div id="app-header" class="flex-1" />
   </div>
-  <CallUI class="mr-3 mt-2" />
+  <CallUI class="me-3 mt-2" />
 </template>
 
 <script setup>

--- a/frontend/src/components/Modals/AboutModal.vue
+++ b/frontend/src/components/Modals/AboutModal.vue
@@ -20,7 +20,7 @@
             <component
               :is="link.icon"
               v-if="link.icon"
-              class="size-4 mr-2 text-ink-gray-7"
+              class="size-4 me-2 text-ink-gray-7"
             />
             <span class="text-base text-ink-gray-8">
               {{ link.label }}

--- a/frontend/src/components/Modals/AssignmentModal.vue
+++ b/frontend/src/components/Modals/AssignmentModal.vue
@@ -35,7 +35,7 @@
                   @click.stop
                 >
                   <UserAvatar :user="assignee.name" size="sm" />
-                  <div class="ml-1">{{ getUser(assignee.name).full_name }}</div>
+                  <div class="ms-1">{{ getUser(assignee.name).full_name }}</div>
                   <Button
                     variant="ghost"
                     class="rounded-full !size-4 m-1"
@@ -54,7 +54,7 @@
           </div>
         </template>
         <template #item-prefix="{ option }">
-          <UserAvatar class="mr-2" :user="option.value" size="sm" />
+          <UserAvatar class="me-2" :user="option.value" size="sm" />
         </template>
         <template #item-label="{ option }">
           <Tooltip :text="option.value">

--- a/frontend/src/components/Modals/CallLogDetailModal.vue
+++ b/frontend/src/components/Modals/CallLogDetailModal.vue
@@ -69,7 +69,7 @@
                   :label="field.value.caller.label"
                   size="sm"
                 />
-                <div class="ml-1 flex flex-col gap-1">
+                <div class="ms-1 flex flex-col gap-1">
                   {{ field.value.caller.label }}
                 </div>
                 <span
@@ -81,7 +81,7 @@
                   :label="field.value.receiver.label"
                   size="sm"
                 />
-                <div class="ml-1 flex flex-col gap-1">
+                <div class="ms-1 flex flex-col gap-1">
                   {{ field.value.receiver.label }}
                 </div>
               </div>

--- a/frontend/src/components/Modals/ConvertToDealModal.vue
+++ b/frontend/src/components/Modals/ConvertToDealModal.vue
@@ -24,7 +24,7 @@
         <OrganizationsIcon class="h-4 w-4" />
         <label class="block text-base">{{ __('Organization') }}</label>
       </div>
-      <div class="ml-6 text-ink-gray-9">
+      <div class="ms-6 text-ink-gray-9">
         <div class="flex items-center justify-between text-base">
           <div>{{ __('Choose Existing') }}</div>
           <Switch v-model="existingOrganizationChecked" />
@@ -50,7 +50,7 @@
         <ContactsIcon class="h-4 w-4" />
         <label class="block text-base">{{ __('Contact') }}</label>
       </div>
-      <div class="ml-6 text-ink-gray-9">
+      <div class="ms-6 text-ink-gray-9">
         <div class="flex items-center justify-between text-base">
           <div>{{ __('Choose Existing') }}</div>
           <Switch v-model="existingContactChecked" />

--- a/frontend/src/components/Modals/SidePanelModal.vue
+++ b/frontend/src/components/Modals/SidePanelModal.vue
@@ -33,7 +33,7 @@
         <div v-if="tabs.data?.[0]?.sections" class="flex gap-4">
           <SidePanelLayoutEditor
             v-model="tabs.data[0].sections"
-            class="flex flex-1 flex-col pr-2"
+            class="flex flex-1 flex-col pe-2"
             :doctype="_doctype"
           />
           <div v-if="preview" class="flex flex-1 flex-col border rounded">

--- a/frontend/src/components/MultiActionButton.vue
+++ b/frontend/src/components/MultiActionButton.vue
@@ -22,7 +22,7 @@
         variant: $attrs.variant,
         size: $attrs.size,
         class:
-          '!w-6 justify-start rounded-bl-none rounded-tl-none border-0 pr-0 text-xs',
+          '!w-6 justify-start rounded-bl-none rounded-tl-none border-0 pe-0 text-xs',
       }"
     />
   </div>

--- a/frontend/src/components/MultipleAvatar.vue
+++ b/frontend/src/components/MultipleAvatar.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="avatars?.length"
-    class="mr-1.5 flex cursor-pointer items-center"
+    class="me-1.5 flex cursor-pointer items-center"
     :class="[
       avatars?.length > 1 ? 'flex-row-reverse' : 'truncate [&>div]:truncate',
     ]"
@@ -24,7 +24,7 @@
       :text="avatar.name"
     >
       <Avatar
-        class="user-avatar -mr-1.5 transform ring-2 ring-outline-base transition hover:z-10 hover:scale-110"
+        class="user-avatar -me-1.5 transform ring-2 ring-outline-base transition hover:z-10 hover:scale-110"
         shape="circle"
         :image="avatar.image"
         :label="avatar.label"

--- a/frontend/src/components/Notifications.vue
+++ b/frontend/src/components/Notifications.vue
@@ -16,7 +16,7 @@
         <div class="text-lg-medium text-ink-gray-8 px-4 pt-[15px] pb-3">
           {{ __('Notifications') }}
         </div>
-        <div class="flex gap-1 mr-3">
+        <div class="flex gap-1 me-3">
           <Button
             v-if="activeTab == 'all' && notifications.data?.length"
             :tooltip="__('Mark all as read')"

--- a/frontend/src/components/PrimaryDropdown.vue
+++ b/frontend/src/components/PrimaryDropdown.vue
@@ -37,7 +37,7 @@
             :validate="validate"
           />
           <div v-if="!options.length && !draft">
-            <div class="p-1.5 pl-3 pr-4 text-base text-ink-gray-4">
+            <div class="p-1.5 ps-3 pe-4 text-base text-ink-gray-4">
               {{ __('No {0} available', [label]) }}
             </div>
           </div>

--- a/frontend/src/components/PrimaryDropdownItem.vue
+++ b/frontend/src/components/PrimaryDropdownItem.vue
@@ -82,10 +82,10 @@
       </template>
     </ItemListRow>
 
-    <!-- pl-8 = the row's px-2 + prefix + gap, so it lines up with the label -->
+    <!-- ps-8 = the row's px-2 + prefix + gap, so it lines up with the label -->
     <ErrorMessage
       v-if="errorMessage"
-      class="pl-8 pr-2 pt-1"
+      class="ps-8 pe-2 pt-1"
       :message="errorMessage"
     />
   </div>

--- a/frontend/src/components/SLASection.vue
+++ b/frontend/src/components/SLASection.vue
@@ -10,10 +10,10 @@
       </div>
       <div class="grid min-h-[28px] items-center">
         <Tooltip v-if="s.tooltipText" :text="__(s.tooltipText)">
-          <div class="ml-2 cursor-pointer">
+          <div class="ms-2 cursor-pointer">
             <Badge
               v-if="s.type == 'Badge'"
-              class="-ml-1"
+              class="-ms-1"
               :label="s.value"
               variant="subtle"
               :theme="s.color"

--- a/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
+++ b/frontend/src/components/Settings/AssignmentRules/AssigneeRules.vue
@@ -33,7 +33,7 @@
         <Popover placement="bottom-end">
           <template #target="{ togglePopover }">
             <div
-              class="flex items-center justify-between text-base rounded h-7 py-1.5 pl-2 pr-2 border border-outline-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] select-none min-w-40"
+              class="flex items-center justify-between text-base rounded h-7 py-1.5 ps-2 pe-2 border border-outline-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] select-none min-w-40"
               @click="togglePopover()"
             >
               <div>

--- a/frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue
+++ b/frontend/src/components/Settings/AssignmentRules/AssignmentRuleListItem.vue
@@ -14,7 +14,7 @@
     <div class="w-3/12">
       <select
         v-model="localData.priority"
-        class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 pl-2 pr-5 bg-transparent -ml-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
+        class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 ps-2 pe-5 bg-transparent -ms-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
         @update:modelValue="onPriorityChange"
         @change="onPriorityChange"
       >

--- a/frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue
+++ b/frontend/src/components/Settings/AssignmentRules/AssignmentRuleView.vue
@@ -12,7 +12,7 @@
             assignmentRuleData.assignmentRuleName || __('New Assignment Rule')
           "
           size="md"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer -ms-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="goBack()"
         />
         <Badge
@@ -65,7 +65,7 @@
           <Popover>
             <template #target="{ togglePopover }">
               <div
-                class="flex items-center justify-between text-base rounded h-7 py-1.5 pl-2 pr-2 border border-outline-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] cursor-default"
+                class="flex items-center justify-between text-base rounded h-7 py-1.5 ps-2 pe-2 border border-outline-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] cursor-default"
                 @click="togglePopover()"
               >
                 <div>

--- a/frontend/src/components/Settings/EmailAdd.vue
+++ b/frontend/src/components/Settings/EmailAdd.vue
@@ -71,7 +71,7 @@
             </div>
           </template>
         </div>
-        <ErrorMessage class="ml-1" :message="error" />
+        <ErrorMessage class="ms-1" :message="error" />
       </div>
     </div>
     <!-- action button -->

--- a/frontend/src/components/Settings/EmailEdit.vue
+++ b/frontend/src/components/Settings/EmailEdit.vue
@@ -60,7 +60,7 @@
           </div>
         </template>
       </div>
-      <ErrorMessage v-if="error" class="ml-1" :message="error" />
+      <ErrorMessage v-if="error" class="ms-1" :message="error" />
     </div>
     <!-- action buttons -->
     <div class="flex justify-between mt-auto">

--- a/frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue
+++ b/frontend/src/components/Settings/EmailTemplate/EditEmailTemplate.vue
@@ -2,13 +2,13 @@
   <div class="flex h-full flex-col gap-6 p-8 text-ink-gray-8">
     <!-- Header -->
     <div class="flex justify-between">
-      <div class="flex gap-1 -ml-4 w-9/12">
+      <div class="flex gap-1 -ms-4 w-9/12">
         <Button
           variant="ghost"
           icon-left="lucide-chevron-left"
           :label="__(template.name)"
           size="md"
-          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="() => emit('updateStep', 'template-list')"
         />
       </div>

--- a/frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue
+++ b/frontend/src/components/Settings/EmailTemplate/EmailTemplates.vue
@@ -90,7 +90,7 @@
             class="flex items-center justify-between p-3 cursor-pointer hover:bg-surface-sidebar rounded"
             @click="() => emit('updateStep', 'edit-template', { ...template })"
           >
-            <div class="flex flex-col w-4/6 pr-5">
+            <div class="flex flex-col w-4/6 pe-5">
               <div class="text-p-base-medium text-ink-gray-7 truncate">
                 {{ template.name }}
               </div>

--- a/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
+++ b/frontend/src/components/Settings/EmailTemplate/NewEmailTemplate.vue
@@ -2,7 +2,7 @@
   <div class="flex h-full flex-col gap-6 p-8 text-ink-gray-8">
     <!-- Header -->
     <div class="flex justify-between">
-      <div class="flex gap-1 -ml-4 w-9/12">
+      <div class="flex gap-1 -ms-4 w-9/12">
         <Button
           variant="ghost"
           icon-left="lucide-chevron-left"
@@ -10,7 +10,7 @@
             templateData?.name ? __('Duplicate Template') : __('New Template')
           "
           size="md"
-          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="() => emit('updateStep', 'template-list')"
         />
       </div>

--- a/frontend/src/components/Settings/Forms/FieldCard.vue
+++ b/frontend/src/components/Settings/Forms/FieldCard.vue
@@ -29,7 +29,7 @@
         @click="beginEdit"
       >
         <span
-          class="-ml-1 inline-flex min-w-0 max-w-full items-center gap-1 rounded px-1 py-0.5 transition-colors group-hover/label:bg-surface-gray-3"
+          class="-ms-1 inline-flex min-w-0 max-w-full items-center gap-1 rounded px-1 py-0.5 transition-colors group-hover/label:bg-surface-gray-3"
         >
           <span
             class="min-w-0 truncate text-base"

--- a/frontend/src/components/Settings/Forms/FormBuilderPanel.vue
+++ b/frontend/src/components/Settings/Forms/FormBuilderPanel.vue
@@ -8,7 +8,7 @@
           icon-left="lucide-chevron-left"
           :label="form.title || __('Untitled')"
           size="md"
-          class="-ml-4 cursor-pointer !max-w-96 !justify-start !pr-0 text-lg-semibold text-ink-gray-7 no-underline hover:bg-transparent hover:no-underline hover:opacity-70 focus:bg-transparent focus:outline-none focus:ring-0"
+          class="-ms-4 cursor-pointer !max-w-96 !justify-start !pe-0 text-lg-semibold text-ink-gray-7 no-underline hover:bg-transparent hover:no-underline hover:opacity-70 focus:bg-transparent focus:outline-none focus:ring-0"
           @click="goBack"
         />
         <Badge
@@ -441,7 +441,7 @@
                       <textarea
                         readonly
                         rows="3"
-                        class="w-full resize-none rounded-md border border-outline-gray-2 bg-surface-gray-1 py-2 pl-3 pr-10 font-mono text-xs text-ink-gray-7 focus:border-outline-gray-4 focus:outline-none focus:ring-0 focus-visible:outline-none"
+                        class="w-full resize-none rounded-md border border-outline-gray-2 bg-surface-gray-1 py-2 ps-3 pe-10 font-mono text-xs text-ink-gray-7 focus:border-outline-gray-4 focus:outline-none focus:ring-0 focus-visible:outline-none"
                         :value="iframeSnippet"
                       />
                       <button

--- a/frontend/src/components/Settings/Hierarchy/HierarchyRow.vue
+++ b/frontend/src/components/Settings/Hierarchy/HierarchyRow.vue
@@ -52,7 +52,7 @@
 
       <div
         v-if="canEdit"
-        class="ml-auto flex gap-1 transition-opacity"
+        class="ms-auto flex gap-1 transition-opacity"
         :class="
           isHighlighted ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
         "

--- a/frontend/src/components/Settings/Hierarchy/HierarchyTree.vue
+++ b/frontend/src/components/Settings/Hierarchy/HierarchyTree.vue
@@ -27,7 +27,7 @@
       </div>
 
       <slot name="label" v-bind="{ node, hasChildren, isCollapsed }">
-        <div class="text-base truncate" :class="hasChildren ? '' : 'pl-3.5'">
+        <div class="text-base truncate" :class="hasChildren ? '' : 'ps-3.5'">
           {{ node.label }}
         </div>
       </slot>

--- a/frontend/src/components/Settings/Hierarchy/UserMultiSelect.vue
+++ b/frontend/src/components/Settings/Hierarchy/UserMultiSelect.vue
@@ -52,7 +52,7 @@
           </span>
         </div>
         <CheckIcon
-          class="size-4 shrink-0 ml-auto"
+          class="size-4 shrink-0 ms-auto"
           :class="isSelected(user) ? 'opacity-100' : 'opacity-0'"
         />
       </li>

--- a/frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue
+++ b/frontend/src/components/Settings/LeadSyncing/LeadSyncSourceForm.vue
@@ -2,13 +2,13 @@
   <div class="flex h-full flex-col text-ink-gray-8">
     <!-- Header -->
     <div class="flex justify-between px-2 pt-2">
-      <div class="flex gap-1 -ml-4 w-9/12">
+      <div class="flex gap-1 -ms-4 w-9/12">
         <Button
           variant="ghost"
           icon-left="lucide-chevron-left"
           :label="isLocal ? __('New Lead Sync Source') : syncSource.name"
           size="md"
-          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="() => emit('updateStep', 'source-list')"
         />
       </div>
@@ -57,7 +57,7 @@
               :placeholder="__('Select Source Type')"
             >
               <template v-if="selectedSourceType" #prefix>
-                <component :is="selectedSourceType.icon" class="mr-2 size-4" />
+                <component :is="selectedSourceType.icon" class="me-2 size-4" />
               </template>
 
               <template #item-prefix="{ item }">

--- a/frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue
+++ b/frontend/src/components/Settings/LeadSyncing/LeadSyncSources.vue
@@ -63,13 +63,13 @@
             class="flex items-center justify-between p-3 cursor-pointer hover:bg-surface-sidebar rounded"
             @click="() => emit('updateStep', 'edit-source', { ...source })"
           >
-            <div class="flex flex-col w-4/6 pr-5">
+            <div class="flex flex-col w-4/6 pe-5">
               <div class="text-p-base-medium text-ink-gray-7 truncate">
                 {{ source.name }}
               </div>
             </div>
 
-            <div class="flex flex-col w-1/6 pr-5">
+            <div class="flex flex-col w-1/6 pe-5">
               <div class="text-p-base-medium text-ink-gray-7 truncate">
                 {{ source.type }}
               </div>

--- a/frontend/src/components/Settings/Profile/UserEmailSettings.vue
+++ b/frontend/src/components/Settings/Profile/UserEmailSettings.vue
@@ -7,7 +7,7 @@
           icon-left="lucide-chevron-left"
           :label="__('Email Settings')"
           size="md"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer -ms-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="emit('updateStep', 'profile-settings')"
         />
         <Badge

--- a/frontend/src/components/Settings/SettingsPage.vue
+++ b/frontend/src/components/Settings/SettingsPage.vue
@@ -9,7 +9,7 @@
             icon-left="lucide-chevron-left"
             :label="title || __(doctype)"
             size="md"
-            class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+            class="cursor-pointer -ms-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
             @click="back"
           />
           <h2

--- a/frontend/src/components/Settings/Sla/SlaHolidays.vue
+++ b/frontend/src/components/Settings/Sla/SlaHolidays.vue
@@ -86,7 +86,7 @@
           :key="column.key"
           class="text-ink-gray-5 overflow-hidden whitespace-nowrap text-ellipsis"
           :class="{
-            'ml-2': column.key === 'workday',
+            'ms-2': column.key === 'workday',
           }"
         >
           {{ column.label }}
@@ -118,10 +118,10 @@
             >
               {{ formatTime(row[column.key]) }}
             </div>
-            <div v-else class="ml-2">
+            <div v-else class="ms-2">
               <select
                 v-model="row[column.key]"
-                class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 pl-2 pr-5 bg-transparent -ml-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
+                class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 ps-2 pe-5 bg-transparent -ms-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
               >
                 <option
                   v-for="option in workDayOptions"

--- a/frontend/src/components/Settings/Sla/SlaPolicyList.vue
+++ b/frontend/src/components/Settings/Sla/SlaPolicyList.vue
@@ -23,7 +23,7 @@
           class="bg-surface-gray-2 hover:bg-surface-gray-2 focus:ring-0 border-outline-gray-2 rounded"
           icon-left="search"
           debounce="300"
-          inputClass="p-4 pr-12"
+          inputClass="p-4 pe-12"
           @input="slaSearchQuery = $event"
         />
         <Button
@@ -54,9 +54,9 @@
           description="Add one to get started."
           :icon="ShieldCheck"
         />
-        <div v-else class="-ml-2">
+        <div v-else class="-ms-2">
           <div
-            class="grid grid-cols-7 items-center gap-3 text-sm text-ink-gray-5 ml-2"
+            class="grid grid-cols-7 items-center gap-3 text-sm text-ink-gray-5 ms-2"
           >
             <div class="col-span-5">
               {{ __('Policy Name') }}
@@ -73,7 +73,7 @@
               class="grid grid-cols-7 items-center gap-4 cursor-pointer hover:bg-surface-sidebar rounded"
             >
               <div
-                class="w-full pl-2 col-span-5 flex items-center h-14 gap-2"
+                class="w-full ps-2 col-span-5 flex items-center h-14 gap-2"
                 @click="updateStep('view', sla, true)"
               >
                 <div class="text-base-medium text-ink-gray-7 truncate">
@@ -84,7 +84,7 @@
               <div class="col-span-1 text-ink-gray-8 text-sm">
                 {{ sla.apply_on == 'CRM Lead' ? 'Lead' : 'Deal' }}
               </div>
-              <div class="flex justify-between items-center w-full pr-2">
+              <div class="flex justify-between items-center w-full pe-2">
                 <div>
                   <Switch
                     size="sm"

--- a/frontend/src/components/Settings/Sla/SlaPolicyView.vue
+++ b/frontend/src/components/Settings/Sla/SlaPolicyView.vue
@@ -7,7 +7,7 @@
           icon-left="lucide-chevron-left"
           :label="slaData.sla_name || __('New SLA Policy')"
           size="md"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-ink-gray-7 text-lg-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer -ms-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-ink-gray-7 text-lg-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="goBack()"
         />
         <Badge

--- a/frontend/src/components/Settings/Sla/SlaPriorityList.vue
+++ b/frontend/src/components/Settings/Sla/SlaPriorityList.vue
@@ -12,7 +12,7 @@
         :key="column.key"
         class="text-ink-gray-5 overflow-hidden whitespace-nowrap text-ellipsis"
         :class="{
-          'ml-2':
+          'ms-2':
             column.key === 'priority' || column.key === 'first_response_time',
         }"
       >
@@ -48,10 +48,10 @@
               @change="(v) => (row[column.key] = v)"
             />
           </div>
-          <div v-else class="ml-2">
+          <div v-else class="ms-2">
             <select
               v-model="row[column.key]"
-              class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 pl-2 pr-5 bg-transparent -ml-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
+              class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 ps-2 pe-5 bg-transparent -ms-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
             >
               <option
                 v-for="option in priorityOptions"

--- a/frontend/src/components/Settings/Telephony/ExotelSettings.vue
+++ b/frontend/src/components/Settings/Telephony/ExotelSettings.vue
@@ -7,7 +7,7 @@
           icon-left="lucide-chevron-left"
           :label="__('Exotel Settings')"
           size="md"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer -ms-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="emit('updateStep', 'telephony-settings')"
         />
         <Badge

--- a/frontend/src/components/Settings/Telephony/TelephonySettings.vue
+++ b/frontend/src/components/Settings/Telephony/TelephonySettings.vue
@@ -32,7 +32,7 @@
     </div>
 
     <div v-if="telephonyAgent.doc" class="flex-1 flex flex-col overflow-y-auto">
-      <div class="flex items-center justify-between gap-8 py-3 pl-2 pr-1">
+      <div class="flex items-center justify-between gap-8 py-3 ps-2 pe-1">
         <div class="flex flex-col">
           <div class="text-p-base-medium text-ink-gray-7 truncate">
             {{ __('Default Medium') }}
@@ -67,7 +67,7 @@
       />
       <div
         v-if="isEnabled('twilio')"
-        class="flex items-center justify-between gap-8 py-3 pl-2 pr-1"
+        class="flex items-center justify-between gap-8 py-3 ps-2 pe-1"
       >
         <div class="flex flex-col">
           <div class="text-p-base-medium text-ink-gray-7 truncate">
@@ -98,7 +98,7 @@
       />
       <div
         v-if="isEnabled('exotel')"
-        class="flex items-center justify-between gap-8 py-3 pl-2 pr-1"
+        class="flex items-center justify-between gap-8 py-3 ps-2 pe-1"
       >
         <div class="flex flex-col">
           <div class="text-p-base-medium text-ink-gray-7 truncate">
@@ -125,7 +125,7 @@
       </div>
       <div
         v-if="isEnabled('exotel')"
-        class="flex items-center justify-between gap-8 py-3 pl-2 pr-1"
+        class="flex items-center justify-between gap-8 py-3 ps-2 pe-1"
       >
         <div class="flex flex-col">
           <div class="text-p-base-medium text-ink-gray-7 truncate">

--- a/frontend/src/components/Settings/Telephony/TwilioSettings.vue
+++ b/frontend/src/components/Settings/Telephony/TwilioSettings.vue
@@ -7,7 +7,7 @@
           icon-left="lucide-chevron-left"
           :label="__('Twilio Settings')"
           size="md"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pr-0 !max-w-96 !justify-start"
+          class="cursor-pointer -ms-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 text-2xl-semibold hover:opacity-70 !pe-0 !max-w-96 !justify-start"
           @click="emit('updateStep', 'telephony-settings')"
         />
         <Badge

--- a/frontend/src/components/Settings/ThemeSwitcher.vue
+++ b/frontend/src/components/Settings/ThemeSwitcher.vue
@@ -9,14 +9,14 @@
       "
       @click="theme = 'light'"
     >
-      <div class="pl-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]">
+      <div class="ps-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]">
         <div class="bg-white rounded-tl-sm">
           <div class="flex gap-[3px] py-[3px] px-1 border-b border-gray-100">
             <div class="size-1.5 bg-[#FF5F57] rounded-full"></div>
             <div class="size-1.5 bg-[#FEBC2D] rounded-full"></div>
             <div class="size-1.5 bg-[#28C840] rounded-full"></div>
           </div>
-          <div class="flex items-start justify-between gap-2 p-2.5 pr-0 pb-1">
+          <div class="flex items-start justify-between gap-2 p-2.5 pe-0 pb-1">
             <div
               class="flex items-center flex-1 gap-1 text-xs-semibold text-ink-gray-5"
             >
@@ -57,14 +57,14 @@
       "
       @click="theme = 'dark'"
     >
-      <div class="pl-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]">
+      <div class="ps-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]">
         <div class="bg-gray-900 rounded-tl-sm">
           <div class="flex gap-[3px] py-[3px] px-1 border-b border-gray-800">
             <div class="size-1.5 bg-[#FF5F57] rounded-full"></div>
             <div class="size-1.5 bg-[#FEBC2D] rounded-full"></div>
             <div class="size-1.5 bg-[#28C840] rounded-full"></div>
           </div>
-          <div class="flex items-start justify-between gap-2 p-2.5 pr-0 pb-1">
+          <div class="flex items-start justify-between gap-2 p-2.5 pe-0 pb-1">
             <div
               class="flex items-center flex-1 gap-1 text-xs-semibold text-ink-gray-5"
             >
@@ -109,7 +109,7 @@
     >
       <div class="flex">
         <div
-          class="flex flex-1 pl-5 pt-3.5 bg-surface-gray-2 rounded-tl-[10.5px]"
+          class="flex flex-1 ps-5 pt-3.5 bg-surface-gray-2 rounded-tl-[10.5px]"
         >
           <div class="bg-white rounded-tl-sm w-full">
             <div class="flex gap-[3px] py-[3px] px-1 border-b border-gray-100">
@@ -117,7 +117,7 @@
               <div class="size-1.5 bg-[#FEBC2D] rounded-full"></div>
               <div class="size-1.5 bg-[#28C840] rounded-full"></div>
             </div>
-            <div class="flex items-start justify-between gap-2 p-2.5 pr-0 pb-1">
+            <div class="flex items-start justify-between gap-2 p-2.5 pe-0 pb-1">
               <div
                 class="flex items-center flex-1 gap-1 text-xs-semibold text-ink-gray-5"
               >
@@ -133,7 +133,7 @@
           </div>
         </div>
         <div
-          class="flex flex-1 pl-5 pt-3.5 bg-surface-gray-3 rounded-tr-[10.5px]"
+          class="flex flex-1 ps-5 pt-3.5 bg-surface-gray-3 rounded-tr-[10.5px]"
         >
           <div class="bg-gray-900 rounded-tl-sm w-full">
             <div class="flex gap-[3px] py-[3px] px-1 border-b border-gray-800">
@@ -141,7 +141,7 @@
               <div class="size-1.5 bg-[#FEBC2D] rounded-full"></div>
               <div class="size-1.5 bg-[#28C840] rounded-full"></div>
             </div>
-            <div class="flex items-start justify-between gap-2 p-2.5 pb-3 pr-0">
+            <div class="flex items-start justify-between gap-2 p-2.5 pb-3 pe-0">
               <div
                 class="flex items-center flex-1 gap-1 text-xs-semibold text-ink-gray-5"
               >

--- a/frontend/src/components/Settings/Users.vue
+++ b/frontend/src/components/Settings/Users.vue
@@ -97,7 +97,7 @@
                 :label="user.full_name"
                 size="xl"
               />
-              <div class="flex flex-col ml-3">
+              <div class="flex flex-col ms-3">
                 <div class="flex items-center text-p-base text-ink-gray-8">
                   {{ user.full_name }}
                 </div>

--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -19,7 +19,7 @@
                 <Button
                   v-if="section.showEditButton"
                   variant="ghost"
-                  class="w-7 mr-2"
+                  class="w-7 me-2"
                   :icon="EditIcon"
                   @click="showSidePanelModal = true"
                 />
@@ -160,14 +160,14 @@
                         >
                           <template v-if="doc[field.fieldname]" #prefix>
                             <UserAvatar
-                              class="mr-1.5"
+                              class="me-1.5"
                               :user="doc[field.fieldname]"
                               size="sm"
                             />
                           </template>
                           <template #item-prefix="{ option }">
                             <UserAvatar
-                              class="mr-1.5"
+                              class="me-1.5"
                               :user="option.value"
                               size="sm"
                             />
@@ -302,7 +302,7 @@
                         <!-- Frappe stores Rating as a 0-1 fraction; Rating works in star units -->
                         <Rating
                           v-else-if="field.fieldtype === 'Rating'"
-                          class="pl-[10px]"
+                          class="ps-[10px]"
                           :step="0.5"
                           :modelValue="
                             (doc[field.fieldname] || 0) * ratingMax(field)
@@ -356,7 +356,7 @@
                           variant="ghost"
                           :fixed-menu="false"
                           :bubble-menu="true"
-                          editorClass="w-full !min-h-[38px] !h-[38px] ml-1"
+                          editorClass="w-full !min-h-[38px] !h-[38px] ms-1"
                           :value="doc[field.fieldname]"
                           :placeholder="field.placeholder"
                           :disabled="Boolean(field.read_only)"
@@ -372,7 +372,7 @@
                           @change.stop="fieldChange($event.target.value, field)"
                         />
                       </div>
-                      <div class="ml-1">
+                      <div class="ms-1">
                         <ArrowUpRightIcon
                           v-if="
                             field.fieldtype === 'Link' &&

--- a/frontend/src/components/Telephony/ExotelCallUI.vue
+++ b/frontend/src/components/Telephony/ExotelCallUI.vue
@@ -2,11 +2,11 @@
   <div>
     <div
       v-show="showSmallCallPopup"
-      class="ml-2 flex cursor-pointer select-none items-center justify-between gap-1 rounded-full bg-surface-gray-10 px-2 py-[7px] text-base text-ink-gray-2"
+      class="ms-2 flex cursor-pointer select-none items-center justify-between gap-1 rounded-full bg-surface-gray-10 px-2 py-[7px] text-base text-ink-gray-2"
       @click="toggleCallPopup"
     >
       <div
-        class="flex justify-center items-center size-5 rounded-full bg-surface-gray-9 shrink-0 mr-1"
+        class="flex justify-center items-center size-5 rounded-full bg-surface-gray-9 shrink-0 me-1"
       >
         <Avatar
           v-if="contact?.image"

--- a/frontend/src/components/Telephony/TaskPanel.vue
+++ b/frontend/src/components/Telephony/TaskPanel.vue
@@ -52,10 +52,10 @@
         @change="(option) => (task.assigned_to = option)"
       >
         <template #prefix>
-          <UserAvatar class="mr-2 !h-4 !w-4" :user="task.assigned_to" />
+          <UserAvatar class="me-2 !h-4 !w-4" :user="task.assigned_to" />
         </template>
         <template #item-prefix="{ option }">
-          <UserAvatar class="mr-2" :user="option.value" size="sm" />
+          <UserAvatar class="me-2" :user="option.value" size="sm" />
         </template>
         <template #item-label="{ option }">
           <Tooltip :text="option.value">

--- a/frontend/src/components/Telephony/TwilioCallUI.vue
+++ b/frontend/src/components/Telephony/TwilioCallUI.vue
@@ -108,7 +108,7 @@
   </div>
   <div
     v-show="showSmallCallWindow"
-    class="ml-2 flex cursor-pointer select-none items-center justify-between gap-3 rounded-lg bg-surface-gray-10 px-2 py-[7px] text-base text-ink-gray-2"
+    class="ms-2 flex cursor-pointer select-none items-center justify-between gap-3 rounded-lg bg-surface-gray-10 px-2 py-[7px] text-base text-ink-gray-2"
     v-bind="$attrs"
     @click="toggleCallWindow"
   >

--- a/frontend/src/components/UserDropdown.vue
+++ b/frontend/src/components/UserDropdown.vue
@@ -13,11 +13,11 @@
       >
         <BrandLogo v-model="brand" class="h-8 max-w-16 flex-shrink-0" />
         <div
-          class="flex flex-1 flex-col text-left duration-300 ease-in-out truncate"
+          class="flex flex-1 flex-col text-start duration-300 ease-in-out truncate"
           :class="
             isCollapsed
-              ? 'ml-0 w-0 overflow-hidden opacity-0'
-              : 'ml-2 w-auto opacity-100'
+              ? 'ms-0 w-0 overflow-hidden opacity-0'
+              : 'ms-2 w-auto opacity-100'
           "
         >
           <div class="text-base-medium leading-none text-ink-gray-9 truncate">
@@ -31,8 +31,8 @@
           class="duration-300 ease-in-out"
           :class="
             isCollapsed
-              ? 'ml-0 w-0 overflow-hidden opacity-0'
-              : 'ml-2 w-auto opacity-100'
+              ? 'ms-0 w-0 overflow-hidden opacity-0'
+              : 'ms-2 w-auto opacity-100'
           "
         >
           <span

--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -52,7 +52,7 @@
       </div>
       <div
         v-if="viewUpdated && route.query.view && (!view.public || isManager())"
-        class="flex flex-row-reverse items-center gap-2 border-r pr-2"
+        class="flex flex-row-reverse items-center gap-2 border-r pe-2"
       >
         <Button :label="__('Cancel')" @click="cancelChanges" />
         <Button :label="__('Save Changes')" @click="saveView" />
@@ -63,9 +63,9 @@
     v-else-if="customizeQuickFilter"
     class="flex items-center justify-between gap-2 p-5"
   >
-    <div class="flex flex-1 items-center overflow-hidden pl-1 gap-2">
+    <div class="flex flex-1 items-center overflow-hidden ps-1 gap-2">
       <FadedScrollableDiv
-        class="flex overflow-x-auto -ml-1"
+        class="flex overflow-x-auto -ms-1"
         orientation="horizontal"
       >
         <Draggable
@@ -102,7 +102,7 @@
         >
           <template #trigger="{ open, setOpen }">
             <Button
-              class="whitespace-nowrap mr-2"
+              class="whitespace-nowrap me-2"
               variant="ghost"
               :label="__('Add Filter')"
               iconLeft="plus"
@@ -119,7 +119,7 @@
         </Combobox>
       </div>
     </div>
-    <div class="-ml-2 h-[70%] border-l" />
+    <div class="-ms-2 h-[70%] border-l" />
     <div class="flex gap-1">
       <Button
         :label="__('Save')"
@@ -131,7 +131,7 @@
   </div>
   <div v-else class="flex items-center justify-between gap-2 px-5 py-4">
     <FadedScrollableDiv
-      class="flex flex-1 items-center overflow-x-auto -ml-1 h-9"
+      class="flex flex-1 items-center overflow-x-auto -ms-1 h-9"
       orientation="horizontal"
     >
       <div
@@ -145,11 +145,11 @@
         />
       </div>
     </FadedScrollableDiv>
-    <div class="-ml-2 h-[70%] border-l" />
+    <div class="-ms-2 h-[70%] border-l" />
     <div class="flex items-center gap-2">
       <div
         v-if="viewUpdated && route.query.view && (!view.public || isManager())"
-        class="flex items-center gap-2 border-r pr-2"
+        class="flex items-center gap-2 border-r pe-2"
       >
         <Button :label="__('Cancel')" @click="cancelChanges" />
         <Button :label="__('Save Changes')" @click="saveView" />

--- a/frontend/src/components/frappe-ui/Autocomplete.vue
+++ b/frontend/src/components/frappe-ui/Autocomplete.vue
@@ -14,7 +14,7 @@
         >
           <div class="w-full">
             <button
-              class="relative flex h-7 w-full items-center justify-between gap-2 rounded px-2 py-1 transition-colors pr-7"
+              class="relative flex h-7 w-full items-center justify-between gap-2 rounded px-2 py-1 transition-colors pe-7"
               :class="inputClasses"
               @click="() => !disabled && togglePopover()"
             >
@@ -29,7 +29,7 @@
               </div>
               <div
                 v-else
-                class="absolute text-ink-gray-4 text-left truncate w-full pr-7"
+                class="absolute text-ink-gray-4 text-start truncate w-full pe-7"
               >
                 {{ placeholder || '' }}
               </div>

--- a/frontend/src/pages/Calendar.vue
+++ b/frontend/src/pages/Calendar.vue
@@ -95,7 +95,7 @@
             <!-- View Buttons -->
             <FormControl
               type="select"
-              class="mr-1 w-24"
+              class="me-1 w-24"
               :modelValue="activeView"
               :options="[
                 { label: __('Day'), value: 'Day' },
@@ -119,10 +119,10 @@
               @change="(option) => updateUser(option)"
             >
               <template #prefix>
-                <UserAvatar class="mr-2 !h-4 !w-4" :user="currentUser" />
+                <UserAvatar class="me-2 !h-4 !w-4" :user="currentUser" />
               </template>
               <template #item-prefix="{ option }">
-                <UserAvatar class="mr-2" :user="option.value" size="sm" />
+                <UserAvatar class="me-2" :user="option.value" size="sm" />
               </template>
               <template #item-label="{ option }">
                 <Tooltip :text="option.value">

--- a/frontend/src/pages/Contact.vue
+++ b/frontend/src/pages/Contact.vue
@@ -3,7 +3,7 @@
     <template #left-header>
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
     </template>

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -51,7 +51,7 @@
         :button="{
           label: __(preset),
           class:
-            '!w-full justify-start [&>span]:mr-auto [&>svg]:text-ink-gray-5',
+            '!w-full justify-start [&>span]:me-auto [&>svg]:text-ink-gray-5',
           variant: 'outline',
           iconRight: 'chevron-down',
           iconLeft: 'calendar',
@@ -79,7 +79,7 @@
         "
       >
         <template #prefix>
-          <LucideCalendar class="size-4 text-ink-gray-5 mr-2" />
+          <LucideCalendar class="size-4 text-ink-gray-5 me-2" />
         </template>
       </DateRangePicker>
       <Link
@@ -99,13 +99,13 @@
         <template #prefix>
           <UserAvatar
             v-if="filters.user"
-            class="mr-2"
+            class="me-2"
             :user="filters.user"
             size="sm"
           />
         </template>
         <template #item-prefix="{ option }">
-          <UserAvatar class="mr-2" :user="option.value" size="sm" />
+          <UserAvatar class="me-2" :user="option.value" size="sm" />
         </template>
         <template #item-label="{ option }">
           <Tooltip :text="option.value">

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -3,7 +3,7 @@
     <template #left-header>
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
     </template>
@@ -152,7 +152,7 @@
           @afterFieldChange="reloadResources"
         >
           <template #actions="{ section }">
-            <div v-if="section.name == 'contacts_section'" class="pr-2">
+            <div v-if="section.name == 'contacts_section'" class="pe-2">
               <Link
                 value=""
                 doctype="Contact"
@@ -200,7 +200,7 @@
                   <CollapsibleSection :opened="contact.opened">
                     <template #header="{ opened, toggle }">
                       <div
-                        class="flex cursor-pointer items-center justify-between gap-2 pr-1 text-base leading-5 text-ink-gray-7"
+                        class="flex cursor-pointer items-center justify-between gap-2 pe-1 text-base leading-5 text-ink-gray-7"
                       >
                         <div
                           class="flex h-7 items-center gap-2 truncate"
@@ -216,7 +216,7 @@
                           </div>
                           <Badge
                             v-if="contact.is_primary"
-                            class="ml-2"
+                            class="ms-2"
                             variant="outline"
                             :label="__('Primary')"
                             theme="green"
@@ -254,7 +254,7 @@
                     <div class="flex flex-col gap-1.5 text-base">
                       <div
                         v-if="contact.email"
-                        class="flex items-center gap-3 pb-1.5 pl-1 pt-4 text-ink-gray-8"
+                        class="flex items-center gap-3 pb-1.5 ps-1 pt-4 text-ink-gray-8"
                       >
                         <Email2Icon class="h-4 w-4" />
                         {{ contact.email }}

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -3,7 +3,7 @@
     <template #left-header>
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
     </template>

--- a/frontend/src/pages/MobileContact.vue
+++ b/frontend/src/pages/MobileContact.vue
@@ -1,11 +1,11 @@
 <template>
   <LayoutHeader v-if="contact.doc">
     <header
-      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 pl-2"
+      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 ps-2"
     >
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
     </header>

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -1,11 +1,11 @@
 <template>
   <LayoutHeader>
     <header
-      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 pl-2"
+      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 ps-2"
     >
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
       <div class="absolute right-0">
@@ -79,7 +79,7 @@
               @afterFieldChange="reloadAssignees"
             >
               <template #actions="{ section }">
-                <div v-if="section.name == 'contacts_section'" class="pr-2">
+                <div v-if="section.name == 'contacts_section'" class="pe-2">
                   <Link
                     value=""
                     doctype="Contact"
@@ -132,7 +132,7 @@
                       <CollapsibleSection :opened="contact.opened">
                         <template #header="{ opened, toggle }">
                           <div
-                            class="flex cursor-pointer items-center justify-between gap-2 pr-1 text-base leading-5 text-ink-gray-7"
+                            class="flex cursor-pointer items-center justify-between gap-2 pe-1 text-base leading-5 text-ink-gray-7"
                           >
                             <div
                               class="flex h-7 items-center gap-2 truncate"
@@ -148,7 +148,7 @@
                               </div>
                               <Badge
                                 v-if="contact.is_primary"
-                                class="ml-2"
+                                class="ms-2"
                                 variant="outline"
                                 :label="__('Primary')"
                                 theme="green"
@@ -186,7 +186,7 @@
                         <div
                           class="flex flex-col gap-1.5 text-base text-ink-gray-8"
                         >
-                          <div class="flex items-center gap-3 pb-1.5 pl-1 pt-4">
+                          <div class="flex items-center gap-3 pb-1.5 ps-1 pt-4">
                             <Email2Icon class="h-4 w-4" />
                             {{ contact.email }}
                           </div>

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -1,11 +1,11 @@
 <template>
   <LayoutHeader>
     <header
-      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 pl-2"
+      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 ps-2"
     >
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
       <div class="absolute right-0">

--- a/frontend/src/pages/MobileOrganization.vue
+++ b/frontend/src/pages/MobileOrganization.vue
@@ -1,11 +1,11 @@
 <template>
   <LayoutHeader v-if="organization.doc">
     <header
-      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 pl-2"
+      class="relative flex h-10.5 items-center justify-between gap-2 py-2.5 ps-2"
     >
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
     </header>

--- a/frontend/src/pages/Organization.vue
+++ b/frontend/src/pages/Organization.vue
@@ -3,7 +3,7 @@
     <template #left-header>
       <Breadcrumbs :items="breadcrumbs">
         <template #prefix="{ item }">
-          <Icon v-if="item.icon" :icon="item.icon" class="mr-2 h-4" />
+          <Icon v-if="item.icon" :icon="item.icon" class="me-2 h-4" />
         </template>
       </Breadcrumbs>
     </template>

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -125,7 +125,7 @@
         <div>
           <Button
             v-if="getRow(itemName, 'reference_docname').label"
-            class="-ml-2"
+            class="-ms-2"
             variant="ghost"
             size="sm"
             :label="


### PR DESCRIPTION
## Problem

Hardcoded physical spacing/text-align classes (`ml-`/`mr-`, `pl-`/`pr-`, `text-left`/`text-right`) don't mirror when `dir="rtl"` is applied — margin/padding stays on the same physical side and text stays left/right-anchored regardless of direction.

## Fix

Safe subset only: `ml-/mr-` → `ms-/me-`, `pl-/pr-` → `ps-/pe-`, `text-left/right` → `text-start/end`. Behavior-preserving for LTR (these resolve to the same physical side when direction is `ltr`) and correct under `dir="rtl"`.

Deliberately does **not** touch `left-`/`right-` (positioning), `border-l/r` (side border width), or transforms (`translate-x` etc.) — those can sit right next to a converted class and interact with it in a way that needs a human to look, so a blind swap risks moving something to the wrong place.

## How this was done

Converted mechanically with a small script that has its own 15+-case self-test (variant prefixes, negatives, arbitrary values, fractions all covered; verified `px-`/`mx-`/`left-`/`right-`/`border-l-r`/`translate-x` are never touched), then spot-checked by hand. Zero remaining `ml-/mr-/pl-/pr-/text-left/text-right` instances after conversion.
