### PR TITLE
fix: skip Facebook lead form fields with no values

### DIFF
--- a/crm/lead_syncing/doctype/lead_sync_source/facebook.py
+++ b/crm/lead_syncing/doctype/lead_sync_source/facebook.py
@@ -35,12 +35,18 @@ class FacebookSyncSource:
 	def sync(self):
 		leads = self.fetch_leads()
 		for lead in leads:
-			self.sync_single_lead(lead)
+			try:
+				self.sync_single_lead(lead)
+			except Exception:
+				frappe.log_error(
+		            title="Facebook Lead Sync Failed",
+		            message=f"Lead ID: {lead.get('id')}\n\n{frappe.get_traceback()}",
+		        )
 		self.update_last_synced_at()
 
 	def sync_single_lead(self, lead, raise_exception=False):
 		question_to_field_map = self.get_form_questions_mapping()
-		lead_data = {item["name"]: item["values"][0] for item in lead["field_data"]}
+		lead_data = {item["name"]: item["values"][0] for item in lead["field_data"]	if item.get("values")}
 		crm_lead_data = {
 			question_to_field_map.get(k): v for k, v in lead_data.items() if k in question_to_field_map
 		}


### PR DESCRIPTION
## Problem

`FacebookSyncSource.sync_single_lead` assumes every entry in a lead's
`field_data` has a `values` key:

```python
lead_data = {item["name"]: item["values"][0] for item in lead["field_data"]}
```

The Graph API omits `values` entirely when a field is left blank, so the
comprehension raises `KeyError: 'values'`.

Actual payload from a production sync:

```json
{
  "id": "2454422221636016",
  "created_time": "2026-08-15T01:58:16+0000",
  "field_data": [
    {"name": "full_name", "values": ["Rojina Gautam"]},
    {"name": "phone", "values": ["+977..."]},
    {"name": "inbox_url"}
  ]
}
```

The preceding lead in the same batch had `inbox_url` populated, so this
varies per lead rather than per form.

## Impact

`sync()` iterates leads and calls `sync_single_lead` without catching
exceptions, so a single lead with a blank field aborts the whole batch —
every lead after it in that run is never created and is silently lost.

## Fix

Skip entries without values. `.get("values")` covers both the missing key
and an empty list. No data is lost: blank fields have nothing to map, and
unmapped names are discarded by `question_to_field_map` anyway.

## Testing

Verified against a live Meta lead form where one lead had a blank
`inbox_url`. Before: `KeyError` and the batch aborted. After: the lead
syncs with its remaining fields and the batch completes.