### PR TITLE
chore: auto generate POT files for main-hotfix

### DIFF
--- a/.github/helper/update_pot_file.sh
+++ b/.github/helper/update_pot_file.sh
@@ -5,7 +5,7 @@ cd ~ || exit
 echo "Setting Up Bench..."
 
 pip install frappe-bench
-bench -v init frappe-bench --skip-assets --skip-redis-config-generation --python "$(which python)" --frappe-branch "${BASE_BRANCH}"
+bench -v init frappe-bench --skip-assets --skip-redis-config-generation --python "$(which python)" --frappe-branch develop
 cd ./frappe-bench || exit
 
 echo "Get FCRM..."

--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["develop"]
+        branch: ["develop", "main-hotfix"]
     permissions:
       contents: write
 


### PR DESCRIPTION
permanently fixes the conflict resolution problem, and won't have to backport POT updates