### PR TITLE
feat: dim visited deals/leads in list view using frappe's _seen field

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -355,6 +355,9 @@ def get_data(
 		if group_by_field and group_by_field not in rows:
 			rows.append(group_by_field)
 
+		if meta.track_seen and "_seen" not in rows:
+			rows.append("_seen")
+
 		data = (
 			frappe.get_list(
 				doctype,
@@ -603,6 +606,13 @@ def remove_assignments(doctype: str, name: str, assignees: str | list, ignore_pe
 			status="Cancelled",
 			ignore_permissions=ignore_permissions,
 		)
+
+
+@frappe.whitelist()
+def add_seen(doctype: str, name: str):
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("read")
+	doc.add_seen()
 
 
 @frappe.whitelist()

--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -570,5 +570,6 @@
  "sort_order": "DESC",
  "states": [],
  "title_field": "organization",
- "track_changes": 1
+ "track_changes": 1,
+ "track_seen": 1
 }

--- a/crm/fcrm/doctype/crm_lead/crm_lead.json
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -520,5 +520,6 @@
  "sort_order": "DESC",
  "states": [],
  "title_field": "lead_name",
- "track_changes": 1
+ "track_changes": 1,
+ "track_seen": 1
 }

--- a/frontend/src/components/ListViews/DealsListView.vue
+++ b/frontend/src/components/ListViews/DealsListView.vue
@@ -40,7 +40,7 @@
       </ListHeaderItem>
     </ListHeader>
     <ListRows
-      v-slot="{ idx, column, item, row }"
+      v-slot="{ idx, column, item, row, isVisited }"
       :rows="rows"
       doctype="CRM Deal"
     >
@@ -180,6 +180,9 @@
           <div
             v-else-if="label"
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {

--- a/frontend/src/components/ListViews/LeadsListView.vue
+++ b/frontend/src/components/ListViews/LeadsListView.vue
@@ -40,7 +40,7 @@
       </ListHeaderItem>
     </ListHeader>
     <ListRows
-      v-slot="{ idx, column, item, row }"
+      v-slot="{ idx, column, item, row, isVisited }"
       :rows="rows"
       doctype="CRM Lead"
     >
@@ -184,6 +184,9 @@
           <div
             v-else-if="label"
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {

--- a/frontend/src/components/ListViews/ListRows.vue
+++ b/frontend/src/components/ListViews/ListRows.vue
@@ -22,7 +22,9 @@
           v-slot="{ idx, column, item }"
           :row="row"
         >
-          <slot v-bind="{ idx, column, item, row }" />
+          <slot
+            v-bind="{ idx, column, item, row, isVisited: isVisited(row._seen) }"
+          />
         </ListRow>
       </ListGroupRows>
     </div>
@@ -39,7 +41,9 @@
       v-slot="{ idx, column, item }"
       :row="row"
     >
-      <slot v-bind="{ idx, column, item, row }" />
+      <slot
+        v-bind="{ idx, column, item, row, isVisited: isVisited(row._seen) }"
+      />
     </ListRow>
   </ListRows>
 </template>
@@ -48,6 +52,7 @@
 import { useStorage } from '@vueuse/core'
 import { ListRows, ListRow, ListGroupHeader, ListGroupRows } from 'frappe-ui'
 import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 
 const props = defineProps({
   rows: { type: Array, required: true },
@@ -69,6 +74,8 @@ let showGroupedRows = computed(() => {
 
 const scrollPosition = useStorage(`scrollPosition${props.doctype}`, 0)
 const scrollContainer = ref(null)
+
+const { isVisited } = useVisitedRecords(props.doctype)
 
 const handleScroll = () => {
   if (scrollContainer.value) {

--- a/frontend/src/composables/useVisitedRecords.js
+++ b/frontend/src/composables/useVisitedRecords.js
@@ -1,0 +1,19 @@
+import { call } from 'frappe-ui'
+import { sessionStore } from '@/stores/session'
+
+export function useVisitedRecords(doctype) {
+  const { user } = sessionStore()
+
+  function isVisited(seen) {
+    if (!seen) return false
+    let seenBy = typeof seen === 'string' ? JSON.parse(seen) : seen
+    return seenBy.includes(user)
+  }
+
+  function markVisited(name) {
+    if (!name) return
+    call('crm.api.doc.add_seen', { doctype, name })
+  }
+
+  return { isVisited, markVisited }
+}

--- a/frontend/src/composables/useVisitedRecords.ts
+++ b/frontend/src/composables/useVisitedRecords.ts
@@ -1,16 +1,16 @@
 import { call } from 'frappe-ui'
 import { sessionStore } from '@/stores/session'
 
-export function useVisitedRecords(doctype) {
+export function useVisitedRecords(doctype: string) {
   const { user } = sessionStore()
 
-  function isVisited(seen) {
+  function isVisited(seen?: string | string[] | null) {
     if (!seen) return false
-    let seenBy = typeof seen === 'string' ? JSON.parse(seen) : seen
+    const seenBy = typeof seen === 'string' ? JSON.parse(seen) : seen
     return seenBy.includes(user)
   }
 
-  function markVisited(name) {
+  function markVisited(name?: string) {
     if (!name) return
     call('crm.api.doc.add_seen', { doctype, name })
   }

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -413,6 +413,7 @@ import {
 import { useRoute, useRouter } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
 import { useUnsavedChangesWarning } from '@/composables/useUnsavedChangesWarning'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 
 const { on } = useBroadcast()
 const { brand } = getSettings()
@@ -504,11 +505,14 @@ watch(
 
 const organization = computed(() => organizationDocument.value?.doc || {})
 
+const { markVisited } = useVisitedRecords('CRM Deal')
+
 onMounted(async () => {
   $socket.on('crm_customer_created', () => {
     toast.success(__('Customer Created Successfully'))
   })
   if (document.doc) await triggerOnRender()
+  markVisited(props.dealId)
 })
 
 onBeforeUnmount(() => {

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -298,6 +298,7 @@ import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
 import { useUnsavedChangesWarning } from '@/composables/useUnsavedChangesWarning'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 
 const { brand } = getSettings()
 const { $dialog, $socket, makeCall } = globalStore()
@@ -335,8 +336,11 @@ const doc = computed(() => document.doc || {})
 
 useUnsavedChangesWarning(() => document.isDirty)
 
+const { markVisited } = useVisitedRecords('CRM Lead')
+
 onMounted(async () => {
   if (document.doc) await triggerOnRender()
+  markVisited(props.leadId)
 })
 
 watch(error, (err) => {

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -303,6 +303,7 @@ import { isMobileView } from '@/composables/settings'
 import { whatsappEnabled } from '@/composables/whatsapp'
 import { callEnabled } from '@/composables/telephony'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 import {
   createResource,
   Dropdown,
@@ -343,8 +344,11 @@ const {
 
 const doc = computed(() => document.doc || {})
 
+const { markVisited } = useVisitedRecords('CRM Deal')
+
 onMounted(async () => {
   if (document.doc) await triggerOnRender()
+  markVisited(props.dealId)
 })
 
 watch(error, (err) => {

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -153,6 +153,7 @@ import { useDocument } from '@/data/document'
 import { isMobileView } from '@/composables/settings'
 import { whatsappEnabled } from '@/composables/whatsapp'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 import {
   createResource,
   Dropdown,
@@ -193,8 +194,11 @@ const {
 
 const doc = computed(() => document.doc || {})
 
+const { markVisited } = useVisitedRecords('CRM Lead')
+
 onMounted(async () => {
   if (document.doc) await triggerOnRender()
+  markVisited(props.leadId)
 })
 
 watch(error, (err) => {


### PR DESCRIPTION
issue : #401 
Dims deal/lead rows in the list view once the current user has opened them, using Frappe's built-in `_seen` tracking (the same mechanism desk's own list view uses to bold/unbold rows) instead of a client-side store.

