### PR TITLE
fix: pin primary contact to top of Deal contacts list

### DIFF
--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -7,6 +7,7 @@ def get_deal_contacts(name: str):
 		"CRM Contacts",
 		filters={"parenttype": "CRM Deal", "parent": name},
 		fields=["contact", "is_primary"],
+		order_by="is_primary desc, idx asc",
 		distinct=True,
 	)
 	deal_contacts = []

--- a/crm/fcrm/doctype/crm_deal/test_crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/test_crm_deal.py
@@ -6,6 +6,7 @@ from frappe.desk.form.assign_to import add as assign_add
 from frappe.desk.form.assign_to import remove as assign_remove
 from frappe.tests import IntegrationTestCase
 
+from crm.fcrm.doctype.crm_deal.api import get_deal_contacts
 from crm.fcrm.doctype.crm_deal.crm_deal import (
 	add_contact,
 	create_deal,
@@ -261,6 +262,25 @@ class TestCRMDeal(IntegrationTestCase):
 				self.assertEqual(c.is_primary, 1)
 			else:
 				self.assertEqual(c.is_primary, 0)
+
+	def test_get_deal_contacts_orders_primary_first(self):
+		"""Test that get_deal_contacts pins the primary contact to the top
+		regardless of the order contacts were added in"""
+		contact1 = create_test_contact(first_name="Alpha", email="alpha@example.com")
+		contact2 = create_test_contact(first_name="Beta", email="beta@example.com")
+		contact3 = create_test_contact(first_name="Gamma", email="gamma@example.com")
+
+		deal = create_test_deal(organization="Contact Order Org")
+		deal.append("contacts", {"contact": contact1.name})
+		deal.append("contacts", {"contact": contact2.name})
+		deal.append("contacts", {"contact": contact3.name, "is_primary": 1})
+		deal.save()
+
+		contacts = get_deal_contacts(deal.name)
+
+		self.assertEqual(contacts[0]["name"], contact3.name)
+		self.assertEqual(contacts[0]["is_primary"], 1)
+		self.assertEqual([c["name"] for c in contacts[1:]], [contact1.name, contact2.name])
 
 	def test_create_deal_api(self):
 		"""Test create_deal API function"""


### PR DESCRIPTION
Order CRM Contacts by is_primary before idx so the primary contact is always first, instead of keeping its original insertion position.

Fixes #2698