### PR TITLE
fix: preserve scroll position in grouped list view

### DIFF
--- a/frontend/src/components/ListViews/ListRows.vue
+++ b/frontend/src/components/ListViews/ListRows.vue
@@ -1,5 +1,9 @@
 <template>
-  <div v-if="showGroupedRows" class="mx-3 mt-2 h-full overflow-y-auto sm:mx-5">
+  <div
+    v-if="showGroupedRows"
+    ref="groupedScrollContainer"
+    class="mx-3 mt-2 h-full overflow-y-auto sm:mx-5"
+  >
     <div v-for="group in reactivieRows" :key="group.group">
       <ListGroupHeader :group="group">
         <div
@@ -27,12 +31,7 @@
       </ListGroupRows>
     </div>
   </div>
-  <ListRows
-    v-else
-    ref="scrollContainer"
-    class="mx-3 sm:mx-5"
-    @scroll="handleScroll"
-  >
+  <ListRows v-else ref="scrollContainer" class="mx-3 sm:mx-5">
     <ListRow
       v-for="row in reactivieRows"
       :key="row.name"
@@ -47,7 +46,7 @@
 <script setup>
 import { useStorage } from '@vueuse/core'
 import { ListRows, ListRow, ListGroupHeader, ListGroupRows } from 'frappe-ui'
-import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 
 const props = defineProps({
   rows: { type: Array, required: true },
@@ -69,23 +68,39 @@ let showGroupedRows = computed(() => {
 
 const scrollPosition = useStorage(`scrollPosition${props.doctype}`, 0)
 const scrollContainer = ref(null)
+const groupedScrollContainer = ref(null)
 
-const handleScroll = () => {
-  if (scrollContainer.value) {
-    scrollPosition.value = scrollContainer.value.$el.scrollTop
-  }
+const handleScroll = (e) => {
+  scrollPosition.value = e.target.scrollTop
 }
 
-onBeforeUnmount(() => {
-  if (scrollContainer.value) {
-    scrollContainer.value.$el.removeEventListener('scroll', handleScroll)
-  }
-})
+// Grouping can toggle at runtime (props.rows reshaping) without remounting
+// this component, so track whichever container is currently in the DOM
+// rather than only wiring the listener up once on mount.
+let activeScrollEl = null
 
-onMounted(() => {
-  if (scrollContainer.value) {
-    scrollContainer.value.$el.addEventListener('scroll', handleScroll)
-    scrollContainer.value.$el.scrollTop = scrollPosition.value
+watch(
+  [scrollContainer, groupedScrollContainer],
+  () => {
+    const el =
+      scrollContainer.value?.$el || groupedScrollContainer.value || null
+    if (el === activeScrollEl) return
+
+    if (activeScrollEl) {
+      activeScrollEl.removeEventListener('scroll', handleScroll)
+    }
+    activeScrollEl = el
+    if (activeScrollEl) {
+      activeScrollEl.addEventListener('scroll', handleScroll)
+      activeScrollEl.scrollTop = scrollPosition.value
+    }
+  },
+  { immediate: true, flush: 'post' },
+)
+
+onBeforeUnmount(() => {
+  if (activeScrollEl) {
+    activeScrollEl.removeEventListener('scroll', handleScroll)
   }
 })
 </script>


### PR DESCRIPTION
Fixes scroll position not being preserved when using the "Group By" list view. Currently, if you scroll down a grouped list, open a record, and go back, the list jumps back to the top instead of staying where you were — this already works correctly in the normal flat list view, just not the grouped one. This fix makes it work the same way in both.

Related to #401.

