### PR TITLE
fix: update broken demo API endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     </picture>
 </div>
 
-[Live Demo](https://frappecrm-demo.frappe.cloud/api/method/crm.api.live_demo.login) - [Website](https://frappe.io/crm) - [Documentation](https://docs.frappe.io/crm)
+[Live Demo](https://frappecrm-demo.frappe.cloud/#login) - [Website](https://frappe.io/crm) - [Documentation](https://docs.frappe.io/crm)
 
 </div>
 


### PR DESCRIPTION
## Description

Fix the broken Frappe CRM demo API endpoint referenced in the README.

The README currently points to the old demo login endpoint, which is no longer accessible:

`https://frappecrm-demo.frappe.cloud/api/method/crm.api.live_demo.login`

The Frappe CRM demo site itself is still available at:

`https://frappecrm-demo.frappe.cloud/`

This updates the README to reference the current demo endpoint.

## Changes

* Updated the outdated Frappe CRM demo endpoint in `README.md`.
* Kept the change limited to the documentation.

## Issue

Closes #2702

## Testing

* Verified that the updated demo URL is accessible.
* Confirmed that the README no longer references the broken endpoint.
