### PR TITLE
fix:  kanban three-dot click -In Task Page 

### DIFF
--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -146,9 +146,12 @@
           class="flex items-center gap-2"
           :options="actions(itemName)"
           variant="ghost"
-          @click.stop.prevent
         >
-          <Button icon="lucide-more-horizontal" variant="ghost" />
+          <Button
+            icon="lucide-more-horizontal"
+            variant="ghost"
+            @click.stop.prevent
+          />
         </Dropdown>
       </div>
     </template>
@@ -182,6 +185,14 @@
     name="Tasks"
     :icon="Email2Icon"
   />
+  <DeleteLinkedDocModal
+    v-if="showDeleteTaskModal"
+    v-model="showDeleteTaskModal"
+    name="Tasks"
+    doctype="CRM Task"
+    :docname="taskToDelete"
+    :reload="() => tasks.value.reload()"
+  />
 </template>
 
 <script setup>
@@ -196,13 +207,14 @@ import ViewControls from '@/components/ViewControls.vue'
 import TasksListView from '@/components/ListViews/TasksListView.vue'
 import EmptyState from '@/components/ListViews/EmptyState.vue'
 import KanbanView from '@/components/Kanban/KanbanView.vue'
+import DeleteLinkedDocModal from '@/components/DeleteLinkedDocModal.vue'
 import { useDoctypeModal } from '@/composables/doctypeModal'
 import { getMeta } from '@/stores/meta'
 import { usersStore } from '@/stores/users'
 import { formatDate, sanitizeHTML } from '@/utils'
 import { timestampCell } from '@/composables/useTimelinePreferences'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import { Tooltip, Avatar, Dropdown, call } from 'frappe-ui'
+import { Tooltip, Avatar, Dropdown } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -222,6 +234,9 @@ const loadMore = ref(1)
 const triggerResize = ref(1)
 const updatedPageCount = ref(20)
 const viewControls = ref(null)
+
+const showDeleteTaskModal = ref(false)
+const taskToDelete = ref(null)
 
 function getRow(name, field) {
   function getValue(value) {
@@ -361,21 +376,19 @@ function createTask(column) {
 function actions(name) {
   return [
     {
+      label: __('Edit'),
+      icon: 'edit-2',
+      onClick: () => showTask(name),
+    },
+    {
       label: __('Delete'),
       icon: 'trash-2',
       onClick: () => {
-        deleteTask(name)
-        tasks.value.reload()
+        taskToDelete.value = name
+        showDeleteTaskModal.value = true
       },
     },
   ]
-}
-
-async function deleteTask(name) {
-  await call('frappe.client.delete', {
-    doctype: 'CRM Task',
-    name,
-  })
 }
 
 function redirect(doctype, docname) {

--- a/frontend/src/pages/Tasks.vue
+++ b/frontend/src/pages/Tasks.vue
@@ -191,7 +191,7 @@
     name="Tasks"
     doctype="CRM Task"
     :docname="taskToDelete"
-    :reload="() => tasks.value.reload()"
+    :reload="() => tasks.reload()"
   />
 </template>
 


### PR DESCRIPTION
Fixes the Kanban Task card's three-dot (⋯) menu:

Clicking it used to open the task's edit modal and the dropdown at the same time — now it just opens the dropdown.
Delete no longer removes the task instantly; it asks for confirmation first, same as the List view.
Added an explicit Edit option to the menu, so Edit and Delete are both there instead of Edit only working by clicking the card itself.
closes : #2707 