### PR TITLE
fix: send users without a password to the set password page

### DIFF
--- a/crm/api/user.py
+++ b/crm/api/user.py
@@ -46,6 +46,68 @@ def change_password(old_password: str, new_password: str):
 	return _("Password Updated Successfully")
 
 
+def needs_password_setup() -> bool:
+	"""Whether the session user has no password of their own and must set one.
+
+	True for users provisioned without a password — the Frappe Cloud site owner,
+	users created by a script — who are logged into a session they never
+	authenticated for and so have no way back in once it expires.
+
+	Users who sign in through SSO are excluded: having no password is the
+	correct state for them, not something to fix.
+	"""
+	user = frappe.session.user
+
+	# Checked first: it is the discriminating one, and it short-circuits the
+	# other queries for everyone who already has a password — which is almost
+	# everyone, on every CRM page load.
+	if has_password(user):
+		return False
+
+	if frappe.get_system_settings("disable_user_pass_login"):
+		return False
+
+	# Every user carries a `frappe` provider row (Frappe issues one on insert
+	# so the site can act as an identity provider), so only other providers
+	# mean the user actually signs in through SSO.
+	if frappe.db.exists(
+		"User Social Login",
+		{
+			"parenttype": "User",
+			"parent": user,
+			"provider": ["!=", "frappe"],
+			"userid": ["is", "set"],
+		},
+	):
+		return False
+
+	return True
+
+
+def has_password(user: str) -> bool:
+	"""Whether a password is stored for the user.
+
+	User passwords are hashed rows in `__Auth` with `encrypted = 0`, so
+	`get_decrypted_password` (which only looks at encrypted rows) cannot answer
+	this — hence the direct query.
+	"""
+	Auth = frappe.qb.Table("__Auth")
+
+	return bool(
+		(
+			frappe.qb.from_(Auth)
+			.select(Auth.name)
+			.where(
+				(Auth.doctype == "User")
+				& (Auth.name == user)
+				& (Auth.fieldname == "password")
+				& (Auth.encrypted == 0)
+			)
+			.limit(1)
+		).run()
+	)
+
+
 @frappe.whitelist()
 def add_existing_users(users: str | list, role: str = "Sales User"):
 	"""

--- a/crm/tests/test_password_setup.py
+++ b/crm/tests/test_password_setup.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import sha256_hash
+from frappe.utils.password import update_password
+
+from crm.api.user import has_password, needs_password_setup
+from crm.www.crm import get_context, redirect_to_set_password
+
+STRONG_PASSWORD = "Qx7#mLp2vT9!"
+
+
+def make_user(email, roles=None):
+	"""A user created the way Frappe Cloud and scripts create one: no password."""
+	user = frappe.get_doc(
+		doctype="User",
+		user_type="System User",
+		email=email,
+		first_name=email.split("@")[0].title(),
+		send_welcome_email=0,
+	).insert(ignore_permissions=True)
+
+	if roles:
+		user.append_roles(*roles)
+		user.save(ignore_permissions=True)
+
+	return user
+
+
+class TestPasswordSetup(IntegrationTestCase):
+	def setUp(self):
+		self.user = make_user("no-password@example.com", roles=["System Manager"])
+		frappe.set_user(self.user.name)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.local.flags.redirect_location = None
+		frappe.db.rollback()
+
+	def make_sso_user(self):
+		frappe.set_user("Administrator")
+		self.user.append("social_logins", {"provider": "google", "userid": "1234567890"})
+		self.user.save(ignore_permissions=True)
+		frappe.set_user(self.user.name)
+
+	# ---- needs_password_setup ----
+
+	def test_needs_setup_for_user_without_password(self):
+		self.assertTrue(needs_password_setup())
+
+	def test_does_not_need_setup_once_password_exists(self):
+		update_password(user=self.user.name, pwd=STRONG_PASSWORD)
+
+		self.assertTrue(has_password(self.user.name))
+		self.assertFalse(needs_password_setup())
+
+	def test_does_not_need_setup_for_sso_user(self):
+		"""No password is the correct state for someone who signs in via SSO."""
+		self.make_sso_user()
+
+		self.assertFalse(needs_password_setup())
+
+	def test_does_not_need_setup_when_password_login_is_disabled(self):
+		with self.change_settings("System Settings", disable_user_pass_login=1):
+			self.assertFalse(needs_password_setup())
+
+	# ---- redirect ----
+
+	def test_redirects_to_set_password_page_with_a_working_key(self):
+		with patch.object(frappe.db.__class__, "commit") as commit:
+			with self.assertRaises(frappe.Redirect) as raised:
+				redirect_to_set_password()
+
+			# the reset key is written on a GET, which is rolled back otherwise
+			self.assertTrue(commit.called)
+
+		# a 301 would be cached by the browser and outlive the key it points at
+		self.assertEqual(raised.exception.http_status_code, 302)
+
+		link = frappe.local.flags.redirect_location
+		self.assertIn("/update-password?key=", link)
+
+		key = link.split("key=")[1]
+		self.assertEqual(frappe.db.get_value("User", self.user.name, "reset_password_key"), sha256_hash(key))
+
+	def test_no_redirect_for_user_who_has_a_password(self):
+		update_password(user=self.user.name, pwd=STRONG_PASSWORD)
+
+		redirect_to_set_password()
+
+		self.assertIsNone(frappe.local.flags.redirect_location)
+
+	def test_no_redirect_for_sso_user(self):
+		self.make_sso_user()
+
+		redirect_to_set_password()
+
+		self.assertIsNone(frappe.local.flags.redirect_location)
+
+	def test_crm_page_load_redirects_a_user_without_a_password(self):
+		"""The redirect is wired into the page the user actually opens."""
+		with patch.object(frappe.db.__class__, "commit"):
+			with self.assertRaises(frappe.Redirect):
+				get_context()
+
+		self.assertIn("/update-password?key=", frappe.local.flags.redirect_location)

--- a/crm/tests/test_password_setup.py
+++ b/crm/tests/test_password_setup.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-from unittest.mock import patch
-
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import sha256_hash
@@ -39,6 +37,7 @@ class TestPasswordSetup(IntegrationTestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		frappe.local.flags.redirect_location = None
+		frappe.local.flags.commit = False
 		frappe.db.rollback()
 
 	def make_sso_user(self):
@@ -71,15 +70,14 @@ class TestPasswordSetup(IntegrationTestCase):
 	# ---- redirect ----
 
 	def test_redirects_to_set_password_page_with_a_working_key(self):
-		with patch.object(frappe.db.__class__, "commit") as commit:
-			with self.assertRaises(frappe.Redirect) as raised:
-				redirect_to_set_password()
-
-			# the reset key is written on a GET, which is rolled back otherwise
-			self.assertTrue(commit.called)
+		with self.assertRaises(frappe.Redirect) as raised:
+			redirect_to_set_password()
 
 		# a 301 would be cached by the browser and outlive the key it points at
 		self.assertEqual(raised.exception.http_status_code, 302)
+
+		# the reset key is written on a GET, which is rolled back otherwise
+		self.assertTrue(frappe.local.flags.commit)
 
 		link = frappe.local.flags.redirect_location
 		self.assertIn("/update-password?key=", link)
@@ -103,8 +101,7 @@ class TestPasswordSetup(IntegrationTestCase):
 
 	def test_crm_page_load_redirects_a_user_without_a_password(self):
 		"""The redirect is wired into the page the user actually opens."""
-		with patch.object(frappe.db.__class__, "commit"):
-			with self.assertRaises(frappe.Redirect):
-				get_context()
+		with self.assertRaises(frappe.Redirect):
+			get_context()
 
 		self.assertIn("/update-password?key=", frappe.local.flags.redirect_location)

--- a/crm/tests/test_password_setup.py
+++ b/crm/tests/test_password_setup.py
@@ -38,6 +38,7 @@ class TestPasswordSetup(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		frappe.local.flags.redirect_location = None
 		frappe.local.flags.commit = False
+		frappe.local.system_settings = None
 		frappe.db.rollback()
 
 	def make_sso_user(self):
@@ -64,8 +65,12 @@ class TestPasswordSetup(IntegrationTestCase):
 		self.assertFalse(needs_password_setup())
 
 	def test_does_not_need_setup_when_password_login_is_disabled(self):
-		with self.change_settings("System Settings", disable_user_pass_login=1):
-			self.assertFalse(needs_password_setup())
+		# not change_settings: it saves the doc, and validating System Settings
+		# fails on a bare site that has no language or time zone set
+		frappe.db.set_single_value("System Settings", "disable_user_pass_login", 1)
+		frappe.local.system_settings = None
+
+		self.assertFalse(needs_password_setup())
 
 	# ---- redirect ----
 

--- a/crm/www/crm.py
+++ b/crm/www/crm.py
@@ -43,8 +43,8 @@ def redirect_to_set_password():
 	user = frappe.get_doc("User", frappe.session.user)
 	link = user._reset_password()
 
-	# GET requests are rolled back, which would take the reset key with them.
-	frappe.db.commit()  # nosemgrep
+	# this is a GET request, which is rolled back unless a commit is requested
+	frappe.local.flags.commit = True
 
 	frappe.local.flags.redirect_location = link
 

--- a/crm/www/crm.py
+++ b/crm/www/crm.py
@@ -17,12 +17,43 @@ def get_context():
 	if not check_app_permission():
 		frappe.throw(_("You do not have permission to access Frappe CRM"), frappe.PermissionError)
 
+	redirect_to_set_password()
+
 	frappe.db.commit()
 	context = frappe._dict()
 	context.boot = get_boot()
 	if frappe.session.user != "Guest":
 		capture("active_site", "crm")
 	return context
+
+
+def redirect_to_set_password():
+	"""Send users who have no password of their own to the set password page.
+
+	The Frappe Cloud site owner arrives on a session handed over by the
+	dashboard and never sets a password, so they cannot get back in once it
+	expires. Invited users are already routed here by `accept_invitation`; this
+	covers everyone else, on the same page.
+	"""
+	from crm.api.user import needs_password_setup
+
+	if not needs_password_setup():
+		return
+
+	user = frappe.get_doc("User", frappe.session.user)
+	link = user._reset_password()
+
+	# GET requests are rolled back, which would take the reset key with them.
+	frappe.db.commit()  # nosemgrep
+
+	frappe.local.flags.redirect_location = link
+
+	# 302, not the 301 default: v16+ lets the browser cache a permanent redirect,
+	# which would keep sending the user to a spent key long after they set a
+	# password. Set on the instance — v15's `Redirect` takes no constructor arg.
+	redirect = frappe.Redirect()
+	redirect.http_status_code = 302
+	raise redirect
 
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)


### PR DESCRIPTION
Follow-up to #2611.

## Problem

#2611 routes newly invited users to the framework set password page, but the whole fix hangs off one entry point: `crm.api.accept_invitation` → `CRMInvitation.accept()` → redirect to `/update-password?key=…`.

The first user on a Frappe Cloud site never touches `CRM Invitation`. Press provisions that User during site creation and the person arrives via a session handed over by the FC dashboard, so they have no password row in `__Auth` at all. Same end state as #2609 — once that session is gone they can only get back in through the dashboard or Forgot Password — reached by a completely different path.

## Fix

`crm/www/crm.py::get_context` redirects anyone who has no password of their own to the same `/update-password?key=…` page invited users already land on. No new APIs, no frontend changes.

The signal is not "is this the first user" or "did this come from FC" — CRM cannot reliably detect either. It is simply *does this user have a password*, which also covers users created by a script or added from the desk without a welcome mail. It is self-limiting: anyone who already went through #2611's flow has a password and is never prompted twice.

Two things worth calling out, both found while writing this:

- Passwords are hashed rows in `__Auth` with `encrypted = 0`, so `get_decrypted_password` (which filters to encrypted rows) can never see them. The check queries `__Auth` directly.
- The SSO exclusion cannot just be "has a `User Social Login` row" — Frappe issues every user a `provider = "frappe"` row on insert so the site can act as an identity provider. Without excluding it, *every* user looks like an SSO user and the redirect would never fire. Only non-`frappe` providers count.

I also borrowed a guard from frappe core's own invitation flow: skip entirely when `disable_user_pass_login` is set. On an SSO-only site, sending someone to set a credential they cannot use would be a lockout, not a fix.

I did not use core's `not user.last_password_reset_date` signal, even though it is cheaper. It is only written by the whitelisted `update_password` endpoint, so a user given a password at creation or from the desk never has it and would be bounced despite having a working password.

## Redirect status code

The redirect is a **302**, and this is version-dependent in a way that is easy to get wrong:

- **v15** — `serve.py` ignores the exception's status code and `RedirectPage.render()` hardcodes 301, but sends `Cache-Control: no-store, no-cache, must-revalidate`.
- **v16+** — the status code is honoured, and the `Cache-Control` header is gone.

So on v16+ the 301 default would let the browser cache a permanent redirect to a key that is spent the moment it is used: after setting a password, opening `/crm` would be served from the redirect cache straight back to "this link has either been used before or is invalid", with no way out short of clearing browser data. The code sets `http_status_code` on the exception instance rather than passing it to the constructor, because v15's `Redirect` takes no constructor argument.

## Commit on a GET

`_reset_password()` writes the key, and `sync_database()` rolls back GET requests, which would take the key with it and make every link dead on arrival. The `frappe.db.commit()` is deliberate and is the last statement before the raise, so no partial state follows it. Frappe core does the identical thing with the identical comment in `core/api/user_invitation.py`.

## Not addressed

- `get_context_for_dev()` returns `get_boot()` and never runs the redirect, so with the vite dev server on :8080 this never fires locally. Not a production issue, but it means the flow is invisible in the normal dev loop.
- `_reset_password()` is a private frappe method. Frappe core calls it from `core/api/user_invitation.py` so it is de-facto stable, but there is no compat guarantee.
- Every page load regenerates the key until one is set, so two open tabs mean the older tab's link is already dead. Reloading fixes it, and there is no cross-user vector since the key is only ever minted for `frappe.session.user`.

## Testing

```
bench --site crm.localhost run-tests --module crm.tests.test_password_setup
Ran 8 tests in 1.657s
OK

bench --site crm.localhost run-tests --module crm.fcrm.doctype.crm_invitation.test_crm_invitation
Ran 13 tests in 0.411s
OK
```

Eight tests covering all four detection branches, the key round-trip (the key in the URL hashes to the stored `reset_password_key`), the status code, both no-redirect paths, and one through `get_context()` so the wiring is covered and not just the helper.

**Not verified in a browser.** It needs a logged-in passwordless user on a running site, which the dev-server gap above makes awkward. The server side is covered by tests, but the actual `Location` header and the cache behaviour are reasoned about, not observed — worth a manual pass before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
