### PR TITLE
fix: validate form field mappings on save

### DIFF
--- a/crm/api/form.py
+++ b/crm/api/form.py
@@ -72,6 +72,8 @@ DENIED_FIELDNAMES = (
 	"facebook_lead_id",
 )
 
+LAYOUT_BREAKS = ("Section Break", "Column Break")
+
 # Starting layout of a brand-new form, per target doctype: labelled sections,
 # each a list of columns, each column a list of fieldnames. A sensible
 # contact-capture starting point the author can then edit.
@@ -392,6 +394,41 @@ def _assert_hidden_defaults_set(hidden: list[dict]):
 		frappe.throw(_("Set a default value before publishing for: {0}").format(", ".join(missing)))
 
 
+def _validated_visible_fields(document_type: str, fields: list[dict]) -> list[dict]:
+	"""Re-apply the catalog the picker filters by: `accept()` lets a public visitor
+	write anything listed in `web_form_fields`."""
+	meta = frappe.get_meta(document_type)
+	catalog = {f["fieldname"]: f for f in _mappable_fields(document_type)}
+	rows = []
+	for f in fields:
+		fieldname = f.get("fieldname")
+		if f.get("fieldtype") in LAYOUT_BREAKS:
+			# a break carries no data, but `accept()` still writes any row naming a field
+			if meta.has_field(fieldname):
+				frappe.throw(_("{0} can't be used as a layout break").format(fieldname))
+			rows.append(f)
+			continue
+		allowed = catalog.get(fieldname)
+		if not allowed:
+			frappe.throw(_("{0} can't be collected by a form").format(fieldname or _("Unnamed field")))
+		rows.append({**f, "fieldtype": allowed["fieldtype"], "options": allowed["options"]})
+	return rows
+
+
+def _validated_hidden_fields(document_type: str, hidden: list[dict]) -> list[dict]:
+	"""Same gate for the hidden section: `_apply_hidden_defaults` writes these onto
+	every submission."""
+	catalog = {h["fieldname"]: h for h in _seed_hidden_fields(document_type)}
+	rows = []
+	for h in hidden:
+		fieldname = h.get("fieldname")
+		allowed = catalog.get(fieldname)
+		if not allowed:
+			frappe.throw(_("{0} can't be set as a hidden field").format(fieldname or _("Unnamed field")))
+		rows.append({**h, "fieldtype": allowed["fieldtype"], "options": allowed["options"]})
+	return rows
+
+
 @frappe.whitelist()
 def save_form(name: str | None, form: dict | str) -> dict:
 	"""Create/update a native Web Form scoped to CRM doctypes."""
@@ -434,6 +471,7 @@ def save_form(name: str | None, form: dict | str) -> dict:
 	# only rewrite the layout when fields were actually sent — an update that omits
 	# `fields` (e.g. a settings-only save) must not wipe the existing layout
 	if fields is not None:
+		fields = _validated_visible_fields(form["document_type"], fields)
 		doc.set("web_form_fields", [])
 		for i, f in enumerate(fields):
 			doc.append(
@@ -463,7 +501,7 @@ def save_form(name: str | None, form: dict | str) -> dict:
 		hidden = _seed_hidden_fields(form["document_type"])
 	if isinstance(hidden, str):
 		hidden = json.loads(hidden or "[]")
-	hidden = hidden or []
+	hidden = _validated_hidden_fields(form["document_type"], hidden or [])
 	if doc.crm_published:
 		_assert_hidden_defaults_set(hidden)
 	doc.crm_hidden_defaults = json.dumps(hidden) if hidden else ""

--- a/crm/tests/test_form_api.py
+++ b/crm/tests/test_form_api.py
@@ -230,6 +230,65 @@ class TestFormAPI(IntegrationTestCase):
 
 		self.assertEqual(len(F.get_form_config(name)["fields"]), before)
 
+	# ---- field allowlist ----
+
+	def test_save_form_rejects_denied_field(self):
+		"""A payload can't map an internal field the picker excludes."""
+		name = make_form("denied-field")
+		with self.assertRaises(frappe.ValidationError):
+			F.save_form(
+				name=name,
+				form={
+					"title": "D",
+					"route": "denied-field",
+					"document_type": "CRM Lead",
+					"fields": [{"fieldname": "converted", "fieldtype": "Check"}],
+					"hidden_fields": [],
+				},
+			)
+
+	def test_save_form_rejects_layout_break_shadowing_a_field(self):
+		"""A break skips the catalog check, so it must not name a real field."""
+		name = make_form("break-shadow")
+		with self.assertRaises(frappe.ValidationError):
+			F.save_form(
+				name=name,
+				form={
+					"title": "B",
+					"route": "break-shadow",
+					"document_type": "CRM Lead",
+					"fields": [{"fieldname": "converted", "fieldtype": "Section Break"}],
+					"hidden_fields": [],
+				},
+			)
+
+	def test_save_form_rejects_unknown_hidden_field(self):
+		"""Only the system-managed mandatory fields may be hidden fields."""
+		name = make_form("hidden-denied")
+		with self.assertRaises(frappe.ValidationError):
+			F.save_form(
+				name=name,
+				form={
+					"title": "H",
+					"route": "hidden-denied",
+					"document_type": "CRM Lead",
+					"fields": [{"fieldname": "first_name", "fieldtype": "Data"}],
+					"hidden_fields": [{"fieldname": "converted", "fieldtype": "Check", "default": "1"}],
+				},
+			)
+
+	def test_save_form_takes_fieldtype_from_catalog(self):
+		"""fieldtype and options come from the doctype, not the payload."""
+		name = make_form(
+			"spoof-type",
+			fields=[{"fieldname": "first_name", "fieldtype": "Attach", "options": "User"}],
+			hidden_fields=[],
+		)
+		stored = frappe.get_doc("Web Form", name).web_form_fields[0]
+		self.assertEqual(stored.fieldname, "first_name")
+		self.assertEqual(stored.fieldtype, "Data")
+		self.assertFalse(stored.options)
+
 	# ---- draft dry-run ----
 
 	def test_test_submit_validates_but_creates_nothing(self):


### PR DESCRIPTION
Follow up to the review on #2715

`save_form` wrote the field list the builder sent straight into `web_form_fields` and `crm_hidden_defaults`. The catalog in `_mappable_fields` decides which fields a form may collect, but it was only applied in the picker, so the payload was trusted to have gone through it. `web_form_fields` is the list the framework's `accept()` walks when it assigns a submission onto the record, so it decides what a public visitor can write.

The catalog is now re-applied on save

- visible rows must name a mappable field
- layout breaks must not shadow a real field, since `accept()` assigns every row it finds
- hidden rows must name one of the system managed mandatory fields from `_seed_hidden_fields`
- fieldtype and options come from the doctype instead of the request, so a permitted field cannot be re-typed or pointed at another doctype

No frontend change needed, the builder already only offers catalog fields

Tests: 22 pass in `crm.tests.test_form_api`, 4 new
