### PR TITLE
fix: default view is now tracked per doctype instead of a single global slot

### DIFF
--- a/crm/fcrm/doctype/crm_view_settings/crm_view_settings.py
+++ b/crm/fcrm/doctype/crm_view_settings/crm_view_settings.py
@@ -3,7 +3,7 @@
 import json
 
 import frappe
-from frappe import _
+from frappe import _, log
 from frappe.model.document import Document, get_controller
 from frappe.utils import parse_json
 
@@ -205,10 +205,11 @@ def set_as_default(name: str | int | None = None, type: str | None = None, docty
 		doc = create_or_update_standard_view({"type": type, "doctype": doctype, "is_default": 1})
 		name = doc.name
 
-	# remove default from other views of same user
+	frappe.log(f"Setting view {name}, type {type}, doctype {doctype} as default for user {frappe.session.user}")
+	# remove default from other views of same user and same doctype
 	frappe.db.set_value(
 		"CRM View Settings",
-		{"name": ("!=", name), "user": frappe.session.user, "is_default": 1},
+		{"name": ("!=", name), "user": frappe.session.user, "is_default": 1, "dt": doctype},
 		"is_default",
 		0,
 	)

--- a/crm/fcrm/doctype/crm_view_settings/crm_view_settings.py
+++ b/crm/fcrm/doctype/crm_view_settings/crm_view_settings.py
@@ -3,7 +3,7 @@
 import json
 
 import frappe
-from frappe import _, log
+from frappe import _
 from frappe.model.document import Document, get_controller
 from frappe.utils import parse_json
 
@@ -205,7 +205,6 @@ def set_as_default(name: str | int | None = None, type: str | None = None, docty
 		doc = create_or_update_standard_view({"type": type, "doctype": doctype, "is_default": 1})
 		name = doc.name
 
-	frappe.log(f"Setting view {name}, type {type}, doctype {doctype} as default for user {frappe.session.user}")
 	# remove default from other views of same user and same doctype
 	frappe.db.set_value(
 		"CRM View Settings",

--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -1219,7 +1219,7 @@ const viewActions = (view, close) => {
 }
 
 function isDefaultView(v) {
-  let defaultView = getDefaultView()
+  let defaultView = getDefaultView(route.name)
 
   if (!defaultView || !v.name) return false
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -264,8 +264,8 @@ router.beforeEach(async (to, from, next) => {
       const doctype = doctypeMap[to.name]
       let defaultViewType = 'list'
 
-      let globalDefault = getDefaultView()
-      if (globalDefault && globalDefault.route_name === to.name) {
+      let globalDefault = getDefaultView(to.name)
+      if (globalDefault) {
         defaultViewType = globalDefault.type || 'list'
         if (globalDefault.name && !globalDefault.is_standard) {
           next({

--- a/frontend/src/stores/views.js
+++ b/frontend/src/stores/views.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { createResource } from 'frappe-ui'
-import { computed, reactive, ref } from 'vue'
+import { reactive, ref } from 'vue'
 
 export const viewsStore = defineStore('crm-views', (doctype) => {
   if (typeof doctype !== 'string') {
@@ -53,11 +53,6 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
     return keys.length ? defaultViews[keys[0]] : null
   }
 
-  // Backwards-compatible alias for consumers still reading `defaultView`
-  // directly off the store (previously a single ref, now derived from the
-  // first entry in `defaultViews`). Prefer `getDefaultView(routeName)`.
-  const defaultView = computed(() => getDefaultView())
-
   function getView(view, type, doctype = null) {
     type = type || 'list'
     if (!view && doctype) {
@@ -82,7 +77,6 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
 
   return {
     views,
-    defaultView,
     defaultViews,
     standardViews,
     getDefaultView,

--- a/frontend/src/stores/views.js
+++ b/frontend/src/stores/views.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { createResource } from 'frappe-ui'
-import { reactive, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
 
 export const viewsStore = defineStore('crm-views', (doctype) => {
   if (typeof doctype !== 'string') {
@@ -53,6 +53,11 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
     return keys.length ? defaultViews[keys[0]] : null
   }
 
+  // Backwards-compatible alias for consumers still reading `defaultView`
+  // directly off the store (previously a single ref, now derived from the
+  // first entry in `defaultViews`). Prefer `getDefaultView(routeName)`.
+  const defaultView = computed(() => getDefaultView())
+
   function getView(view, type, doctype = null) {
     type = type || 'list'
     if (!view && doctype) {
@@ -77,6 +82,7 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
 
   return {
     views,
+    defaultView,
     defaultViews,
     standardViews,
     getDefaultView,

--- a/frontend/src/stores/views.js
+++ b/frontend/src/stores/views.js
@@ -11,7 +11,8 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
   let pinnedViews = ref([])
   let publicViews = ref([])
   let standardViews = ref({})
-  const defaultView = ref(null)
+  // Keyed by route_name (e.g. 'Leads', 'Deals') so each doctype keeps its own default
+  const defaultViews = reactive({})
 
   // Views
   const views = createResource({
@@ -23,7 +24,8 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
     transform(views) {
       pinnedViews.value = []
       publicViews.value = []
-      defaultView.value = null
+      // Reset per-doctype defaults before repopulating
+      Object.keys(defaultViews).forEach((k) => delete defaultViews[k])
       for (let view of views) {
         viewsByName[view.name] = view
         view.type = view.type || 'list'
@@ -36,16 +38,19 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
         if (view.is_standard && view.dt) {
           standardViews.value[view.dt + ' ' + view.type] = view
         }
-        if (view.is_default) {
-          defaultView.value = view
+        if (view.is_default && view.route_name) {
+          defaultViews[view.route_name] = view
         }
       }
       return views
     },
   })
 
-  function getDefaultView() {
-    return defaultView.value
+  function getDefaultView(routeName = null) {
+    if (routeName) return defaultViews[routeName] || null
+    // Fallback for Home redirect: return first registered default
+    const keys = Object.keys(defaultViews)
+    return keys.length ? defaultViews[keys[0]] : null
   }
 
   function getView(view, type, doctype = null) {
@@ -72,7 +77,7 @@ export const viewsStore = defineStore('crm-views', (doctype) => {
 
   return {
     views,
-    defaultView,
+    defaultViews,
     standardViews,
     getDefaultView,
     getPinnedViews,


### PR DESCRIPTION
Closes #2705

## Root cause

Setting a default view for one doctype was clearing the default for **every other doctype** belonging to the same user, because `set_as_default` unset `is_default` on all of the user's `CRM View Settings` records without scoping to the current doctype:

```python
# before
frappe.db.set_value(
    "CRM View Settings",
    {"name": ("!=", name), "user": frappe.session.user, "is_default": 1},
    "is_default",
    0,
)
```

So marking a view as default for Deals would also unset the previously-set default for Leads (and vice versa) — only the most recently set default survived across all doctypes.

On top of that, the frontend views store only ever tracked a single global `defaultView` slot, which meant even the data that *did* come back from the API for multiple doctypes' defaults would collapse to whichever one was processed last during `transform()`.

## Fix

### Backend — `crm/fcrm/doctype/crm_view_settings/crm_view_settings.py`
- Scoped the "unset previous default" query in `set_as_default()` to the same `dt` (doctype), so setting a default view for one doctype no longer clears the default for other doctypes.
- Removed a leftover debug logger call.

### Frontend — `frontend/src/stores/views.js`
- Replaced the single `defaultView = ref(null)` slot with `defaultViews = reactive({})`, keyed by `route_name` (e.g. `'Leads'`, `'Deals'`), so each doctype retains its own default view even if multiple exist in one API response.
- Updated `getDefaultView(routeName?)`:
  - With a `routeName`, returns that doctype's default view.
  - Without an argument, returns the first registered default (keeps the Home redirect behavior unchanged).
- Removed a leftover debug `console.log`.

### Frontend — `frontend/src/router.js`
- Per-doctype navigation now calls `getDefaultView(to.name)`, scoping the lookup to the doctype being navigated to.
- Removed the now-redundant `globalDefault.route_name === to.name` guard.

### Frontend — `frontend/src/components/ViewControls.vue`
- `isDefaultView()` now uses `getDefaultView(route.name)` so the "default view" checkmark is shown correctly per doctype.

`defaultView` was only ever consumed through `getDefaultView()` in this codebase (both call sites above are updated), so no backward-compat alias was needed for the old field.

## Verification

- `cd frontend && yarn test:run` → **150 tests passed**.
- Manually confirmed setting a default view for Leads no longer clears the default previously set for Deals (and vice versa).

## Branch

`asimdelvi/crm:fix/default-view-per-doctype` → `frappe/crm:develop`