### PR TITLE
fix: keep deal activities visible when the lead is not readable

### DIFF
--- a/crm/api/activities.py
+++ b/crm/api/activities.py
@@ -50,8 +50,11 @@ def get_deal_activities(name: str):
 	creation_text = _("created this deal")
 
 	if lead:
-		activities, calls, notes, tasks, attachments = get_lead_activities(lead)
 		creation_text = _("converted the lead to this deal")
+		# a user can have access to the deal but not the lead it came from, so
+		# skip the lead's history instead of failing the whole timeline
+		if frappe.has_permission("CRM Lead", "read", lead):
+			activities, calls, notes, tasks, attachments = get_lead_activities(lead)
 
 	activities.append(
 		{

--- a/crm/permissions/test_org_hierarchy.py
+++ b/crm/permissions/test_org_hierarchy.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils.nestedset import rebuild_tree
 
+from crm.api.activities import get_activities
 from crm.permissions.org_hierarchy import (
 	get_lead_permission_query_conditions,
 	has_deal_permission,
@@ -120,6 +121,30 @@ class TestOrgHierarchy(IntegrationTestCase):
 	def test_peer_cannot_read_sibling_deal(self):
 		deal = make_deal("rep2@hier.test")
 		self.assertFalse(has_deal_permission(deal, "read", "rep1@hier.test"))
+
+	# ------------------------------------------------------------------
+	# Deal activities
+	# ------------------------------------------------------------------
+
+	def test_deal_activities_skip_lead_the_user_cannot_read(self):
+		lead = make_lead("rep2@hier.test")
+		deal = make_deal("rep1@hier.test")
+		frappe.db.set_value("CRM Deal", deal.name, "lead", lead.name)
+
+		frappe.set_user("rep1@hier.test")
+		try:
+			activities, calls, notes, tasks, attachments = get_activities(deal.name)
+		finally:
+			frappe.set_user("Administrator")
+
+		# the deal's own timeline loads instead of the lead check failing the call
+		self.assertTrue(any(a["activity_type"] == "creation" for a in activities))
+
+		# the lead's history stays hidden
+		self.assertEqual(calls, [])
+		self.assertEqual(notes, [])
+		self.assertEqual(tasks, [])
+		self.assertEqual(attachments, [])
 
 	# ------------------------------------------------------------------
 	# Permission query conditions

--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -549,6 +549,9 @@ const all_activities = createResource({
     return { versions, calls, notes, tasks, attachments }
   },
   onSuccess: () => nextTick(() => scroll()),
+  onError: (error) => {
+    toast.error(error.messages?.[0] || __('Failed to load activities'))
+  },
 })
 
 const showWhatsappTemplates = ref(false)


### PR DESCRIPTION
A deal converted from a lead builds its timeline through `get_lead_activities`, which throws if the user cannot read that lead

So a user with access to the deal but not to the lead it came from gets an empty Activity and Comments tab

Skip the lead's history when it is not readable instead of failing the whole call, and show the error in the UI so a failed load no longer looks like an empty timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)