### PR TITLE
fix: prevent 'Document not found' error flash on lead delete

### DIFF
--- a/frontend/src/components/DeleteLinkedDocModal.vue
+++ b/frontend/src/components/DeleteLinkedDocModal.vue
@@ -131,9 +131,10 @@
 </template>
 
 <script setup>
-import { createResource, call } from 'frappe-ui'
+import { createResource, call, toast } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import { computed, ref } from 'vue'
+import { markDocumentAsDeleted } from '@/data/document'
 
 const show = defineModel({ type: Boolean })
 const router = useRouter()
@@ -253,6 +254,9 @@ const deleteDoc = async () => {
     doctype: props.doctype,
     name: props.docname,
   })
+  markDocumentAsDeleted(props.doctype, props.docname)
+  toast.success(__('{0} deleted successfully', [props.doctype]))
+  show.value = false
   router.push({ name: props.name })
   props?.reload?.()
 }

--- a/frontend/src/components/DeleteLinkedDocModal.vue
+++ b/frontend/src/components/DeleteLinkedDocModal.vue
@@ -134,7 +134,11 @@
 import { createResource, call, toast } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import { computed, ref } from 'vue'
-import { markDocumentAsDeleted, unmarkDocumentAsDeleted } from '@/data/document'
+import {
+  markDocumentAsDeleted,
+  unmarkDocumentAsDeleted,
+  expireDeletionMarker,
+} from '@/data/document'
 
 const show = defineModel({ type: Boolean })
 const router = useRouter()
@@ -263,6 +267,7 @@ const deleteDoc = async () => {
     unmarkDocumentAsDeleted(props.doctype, props.docname)
     throw err
   }
+  expireDeletionMarker(props.doctype, props.docname)
   toast.success(__('{0} deleted successfully', [props.doctype]))
   show.value = false
   router.push({ name: props.name })

--- a/frontend/src/components/DeleteLinkedDocModal.vue
+++ b/frontend/src/components/DeleteLinkedDocModal.vue
@@ -146,6 +146,7 @@ const props = defineProps({
   name: { type: String, required: true },
   doctype: { type: String, required: true },
   docname: { type: String, required: true },
+  title: { type: String, default: null },
   reload: { type: Function, default: null },
 })
 const viewControls = ref({
@@ -268,7 +269,10 @@ const deleteDoc = async () => {
     throw err
   }
   expireDeletionMarker(props.doctype, props.docname)
-  toast.success(__('{0} deleted successfully', [props.doctype]))
+  const label = props.title
+    ? `${props.docname} (${props.title})`
+    : props.docname
+  toast.success(__('{0} deleted successfully', [label]))
   show.value = false
   router.push({ name: props.name })
   props?.reload?.()

--- a/frontend/src/components/DeleteLinkedDocModal.vue
+++ b/frontend/src/components/DeleteLinkedDocModal.vue
@@ -134,7 +134,7 @@
 import { createResource, call, toast } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import { computed, ref } from 'vue'
-import { markDocumentAsDeleted } from '@/data/document'
+import { markDocumentAsDeleted, unmarkDocumentAsDeleted } from '@/data/document'
 
 const show = defineModel({ type: Boolean })
 const router = useRouter()
@@ -250,11 +250,19 @@ const removeDocLinks = () => {
 }
 
 const deleteDoc = async () => {
-  await call('frappe.client.delete', {
-    doctype: props.doctype,
-    name: props.docname,
-  })
+  // Mark before the request starts: the backend's delete_doc fires a
+  // realtime doc_update event that can reach the still-mounted document
+  // resource before this awaited call resolves on the frontend.
   markDocumentAsDeleted(props.doctype, props.docname)
+  try {
+    await call('frappe.client.delete', {
+      doctype: props.doctype,
+      name: props.docname,
+    })
+  } catch (err) {
+    unmarkDocumentAsDeleted(props.doctype, props.docname)
+    throw err
+  }
   toast.success(__('{0} deleted successfully', [props.doctype]))
   show.value = false
   router.push({ name: props.name })

--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -28,6 +28,12 @@ export function markDocumentAsDeleted(doctype, docname) {
   setTimeout(() => intentionallyDeletedDocs.delete(key), 10000)
 }
 
+// Called if the delete request itself fails, so a legitimate later
+// DoesNotExistError for this doc isn't silently swallowed.
+export function unmarkDocumentAsDeleted(doctype, docname) {
+  intentionallyDeletedDocs.delete(`${doctype}:${docname}`)
+}
+
 export function useDocument(doctype, docname, resourceOverrides = {}) {
   if (typeof docname === 'number') docname = String(docname)
   const { setupScript, scripts } = getScript(doctype)

--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -13,6 +13,21 @@ const controllersCache = {}
 const assigneesCache = {}
 const permissionsCache = {}
 
+// Deleting a doc triggers a realtime `doc_update` event (sent by the
+// framework as part of `delete_doc`), which makes the still-mounted document
+// resource refetch and hit a DoesNotExistError right as we're navigating
+// away. Docs marked here have that one expected error swallowed instead of
+// surfaced as an error page.
+const intentionallyDeletedDocs = new Set()
+
+export function markDocumentAsDeleted(doctype, docname) {
+  const key = `${doctype}:${docname}`
+  intentionallyDeletedDocs.add(key)
+  // self-expire in case the realtime event never arrives, so a reused
+  // docname doesn't have a later, unrelated error silently swallowed
+  setTimeout(() => intentionallyDeletedDocs.delete(key), 10000)
+}
+
 export function useDocument(doctype, docname, resourceOverrides = {}) {
   if (typeof docname === 'number') docname = String(docname)
   const { setupScript, scripts } = getScript(doctype)
@@ -36,6 +51,14 @@ export function useDocument(doctype, docname, resourceOverrides = {}) {
           name: docname,
           onSuccess: async () => await setupFormScript(),
           onError: (err) => {
+            const deletionKey = `${doctype}:${docname}`
+            if (
+              err.exc_type === 'DoesNotExistError' &&
+              intentionallyDeletedDocs.has(deletionKey)
+            ) {
+              intentionallyDeletedDocs.delete(deletionKey)
+              return
+            }
             error.value = err
             if (err.exc_type === 'DoesNotExistError') {
               toast.error(__(err.messages[0] || 'Document does not exist'))

--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -21,10 +21,15 @@ const permissionsCache = {}
 const intentionallyDeletedDocs = new Set()
 
 export function markDocumentAsDeleted(doctype, docname) {
+  intentionallyDeletedDocs.add(`${doctype}:${docname}`)
+}
+
+// Called once the delete request has completed, so a reused docname
+// doesn't have a later, unrelated error silently swallowed. Kept separate
+// from markDocumentAsDeleted so the marker survives the full (possibly
+// slow) delete request instead of a fixed window starting before it.
+export function expireDeletionMarker(doctype, docname) {
   const key = `${doctype}:${docname}`
-  intentionallyDeletedDocs.add(key)
-  // self-expire in case the realtime event never arrives, so a reused
-  // docname doesn't have a later, unrelated error silently swallowed
   setTimeout(() => intentionallyDeletedDocs.delete(key), 10000)
 }
 

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -331,6 +331,7 @@
     v-model="showDeleteLinkedDocModal"
     :doctype="'CRM Deal'"
     :docname="dealId"
+    :title="doc.organization"
     name="Deals"
   />
   <LostReasonModal

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -229,6 +229,7 @@
     v-model="showDeleteLinkedDocModal"
     :doctype="'CRM Lead'"
     :docname="leadId"
+    :title="doc.lead_name"
     name="Leads"
   />
   <LostReasonModal

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -254,6 +254,7 @@
     v-model="showDeleteLinkedDocModal"
     :doctype="'CRM Deal'"
     :docname="dealId"
+    :title="doc.organization"
     name="Deals"
   />
   <LostReasonModal

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -113,6 +113,7 @@
     v-model="showDeleteLinkedDocModal"
     :doctype="'CRM Lead'"
     :docname="leadId"
+    :title="doc.lead_name"
     name="Leads"
   />
   <LostReasonModal


### PR DESCRIPTION
closes: #2718
## Problem

Deleting a Lead /deal(or any document via `DeleteLinkedDocModal`) succeeds, but
a "Document not found" error flashes on screen before the app navigates
away to the list view. The delete actually works — the error is just
misleading noise.

## Fix
Mark the doc as "intentionally deleted" before sending the delete request,
so that expected error gets silently ignored instead of shown to the user.
The marker is cleared once the delete finishes (or immediately if the
delete itself fails), so it doesn't accidentally hide unrelated errors later.

