### PR TITLE
fix: bulk edit reports failures and supports lost reason

### DIFF
--- a/frontend/src/components/Modals/EditValueModal.vue
+++ b/frontend/src/components/Modals/EditValueModal.vue
@@ -149,10 +149,7 @@ const isLostStatus = computed(() => {
   return false
 })
 
-console.log('asim isLostStatus', isLostStatus.value)
-
 function onCreateLostReason(value, close) {
-  console.log('asim onCreateLostReason', value, close)
   createDocument('CRM Lost Reason', { lost_reason: value }, close, (doc) => {
     lostReason.value = doc.name
     lostReasonLinkRef.value?.reload('', true)

--- a/frontend/src/components/Modals/EditValueModal.vue
+++ b/frontend/src/components/Modals/EditValueModal.vue
@@ -22,6 +22,35 @@
           @change="(v) => updateValue(v)"
         />
       </div>
+      <template v-if="isLostStatus">
+        <div class="mt-4">
+          <div class="mb-1.5 text-sm text-ink-gray-5">
+            {{ __('Lost Reason') }}
+            <span class="text-ink-red-5">*</span>
+          </div>
+          <Link
+            ref="lostReasonLinkRef"
+            class="form-control flex-1 truncate"
+            :value="lostReason"
+            doctype="CRM Lost Reason"
+            :onCreate="onCreateLostReason"
+            @change="(v) => (lostReason = v)"
+          />
+        </div>
+        <div class="mt-4">
+          <div class="mb-1.5 text-sm text-ink-gray-5">
+            {{ __('Lost Notes') }}
+            <span v-if="lostReason == 'Other'" class="text-ink-red-5">*</span>
+          </div>
+          <FormControl
+            class="form-control flex-1 truncate"
+            type="textarea"
+            :value="lostNotes"
+            @change="(e) => (lostNotes = e.target.value)"
+          />
+        </div>
+      </template>
+      <ErrorMessage v-if="error" class="mt-4" :message="error" />
     </template>
     <template #actions>
       <Button
@@ -37,12 +66,16 @@
 
 <script setup>
 import Link from '@/components/Controls/Link.vue'
+import { statusesStore } from '@/stores/statuses'
+import { createDocument } from '@/composables/document'
 import { useTelemetry } from 'frappe-ui/frappe'
 import {
   Combobox,
   FormControl,
+  ErrorMessage,
   call,
   createResource,
+  toast,
   TextEditor,
   DatePicker,
 } from 'frappe-ui'
@@ -97,12 +130,56 @@ const field = ref({
 
 const newValue = ref('')
 const loading = ref(false)
+const error = ref('')
+
+const { getLeadStatus, getDealStatus } = statusesStore()
+
+const lostReason = ref('')
+const lostNotes = ref('')
+const lostReasonLinkRef = ref(null)
+
+const isLostStatus = computed(() => {
+  if (field.value.fieldname !== 'status' || !newValue.value) return false
+  if (props.doctype === 'CRM Lead') {
+    return getLeadStatus(newValue.value)?.type === 'Lost'
+  }
+  if (props.doctype === 'CRM Deal') {
+    return getDealStatus(newValue.value)?.type === 'Lost'
+  }
+  return false
+})
+
+console.log('asim isLostStatus', isLostStatus.value)
+
+function onCreateLostReason(value, close) {
+  console.log('asim onCreateLostReason', value, close)
+  createDocument('CRM Lost Reason', { lost_reason: value }, close, (doc) => {
+    lostReason.value = doc.name
+    lostReasonLinkRef.value?.reload('', true)
+  })
+}
 
 function updateValues() {
+  error.value = ''
   let fieldVal = newValue.value
   if (field.value.fieldtype == 'Check') {
     fieldVal = fieldVal == 'Yes' ? 1 : 0
   }
+
+  let data = { [field.value.fieldname]: fieldVal || null }
+  if (isLostStatus.value) {
+    if (!lostReason.value) {
+      error.value = __('Lost Reason is required')
+      return
+    }
+    if (lostReason.value === 'Other' && !lostNotes.value) {
+      error.value = __('Lost Notes are required when Lost Reason is "Other"')
+      return
+    }
+    data.lost_reason = lostReason.value
+    data.lost_notes = lostNotes.value
+  }
+
   loading.value = true
   call(
     'frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs',
@@ -110,11 +187,20 @@ function updateValues() {
       doctype: props.doctype,
       docnames: Array.from(props.selectedValues),
       action: 'update',
-      data: {
-        [field.value.fieldname]: fieldVal || null,
-      },
+      data,
     },
-  ).then(() => {
+  ).then((failed) => {
+    loading.value = false
+    // Response is the list of docnames that failed to save, or null when the
+    // operation was enqueued (>= 20 records).
+    if (Array.isArray(failed) && failed.length) {
+      error.value = __('Failed to update {0} record(s): {1}', [
+        failed.length,
+        failed.join(', '),
+      ])
+      emit('reload')
+      return
+    }
     field.value = {
       label: '',
       fieldtype: '',
@@ -122,15 +208,26 @@ function updateValues() {
       options: '',
     }
     newValue.value = ''
-    loading.value = false
+    lostReason.value = ''
+    lostNotes.value = ''
     show.value = false
     capture('bulk_update', { doctype: props.doctype })
     emit('reload')
+    if (!Array.isArray(failed)) {
+      toast.info(
+        __(
+          'Bulk operation is enqueued in background. Failures, if any, are recorded in Error Log.',
+        ),
+      )
+    }
   })
 }
 
 function changeField(f) {
   newValue.value = ''
+  lostReason.value = ''
+  lostNotes.value = ''
+  error.value = ''
   if (!f) return
   field.value = f
 }


### PR DESCRIPTION
## Why

Bulk Edit silently reported success even when every record failed to save. The dialog closed, the list reloaded, and a success telemetry event fired - while zero records were updated (see #2723). The server-side bulk endpoint returns the list of failed docnames with HTTP 200, but `EditValueModal` never inspected the response.

The common trigger: setting Status to a Lost-type status (e.g. `Junk`) fails `validate_lost_reason` in `crm_lead.py` / `crm_deal.py`, because Bulk Edit only sends the one field and the status requires a lost reason.

## What changed

Frontend-only fix in `EditValueModal.vue`:

- **Lost Reason support**: when the field is Status and the chosen value is a Lost-type status (CRM Lead / CRM Deal, detected via `statusesStore`), the dialog shows Lost Reason (Link -> CRM Lost Reason, with quick-create) and Lost Notes inputs - same UX and client-side validation as the individual `LostReasonModal` (reason required; notes required when reason is "Other"). The payload becomes `{ status, lost_reason, lost_notes }`, which `_bulk_action` merges via `doc.update(data)`, so backend validation passes with no backend change.
- **Failure reporting**: the response is now inspected. A non-empty array (failed docnames) keeps the dialog open with an inline `ErrorMessage` listing the failed records, skips success telemetry, and still reloads the list so records that did save are reflected.
- **Enqueued path** (>= 20 records, server returns `None`): dialog closes with an info toast noting failures are recorded in Error Log.

## Known limitations (Frappe framework, out of scope here)

- Above the enqueue threshold the endpoint returns `None`, so per-doc failure reporting is impossible client-side - it would need a realtime event or persisted result in Frappe.
- frappe-ui drops `_server_messages` on success responses unless a `serverMessagesHandler` is configured, so failure *reasons* (not just docnames) can't be surfaced without a Frappe-side change. For now reasons remain in Error Log.

## Testing

- 150 unit tests pass (`yarn test:run`), prettier/eslint clean, production build succeeds.
- Verified end-to-end against a live site: bulk Status=Junk without a reason returns both docnames as failed; with `{ status, lost_reason, lost_notes }` both leads save successfully.

Closes #2723
