### PR TITLE
feat: link to the desk workspace from the apps screen

### DIFF
--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -19,6 +19,7 @@ add_to_apps_screen = [
 		"title": "CRM",
 		"route": "/crm",
 		"has_permission": "crm.api.check_app_permission",
+		"desk_route": "/desk/frappe-crm",
 	}
 ]
 


### PR DESCRIPTION
Desk-ification of CRM is on the way but until then users need a way to go to desk 

<img width="148" height="158" alt="Screenshot 2026-08-29 at 12 43 38 AM" src="https://github.com/user-attachments/assets/401a1727-4f74-4c6e-9dfe-93469ba0f4b1" />

Depends on https://github.com/frappe/frappe/pull/42244
