### PR TITLE
fix: typos in user-facing messages, comments and a parameter name

### DIFF
--- a/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
+++ b/crm/fcrm/doctype/fcrm_settings/fcrm_settings.py
@@ -199,7 +199,7 @@ def sync_table(key, hook):
 	new_standard_items = {}
 
 	# add new items
-	count = 0  # maintain count because list may come from seperate apps
+	count = 0  # maintain count because list may come from separate apps
 	for item in frappe.get_hooks(hook):
 		if item.get("name1") not in existing_items:
 			crm_settings.append(key, item, count)

--- a/crm/integrations/exotel/handler.py
+++ b/crm/integrations/exotel/handler.py
@@ -79,7 +79,7 @@ def handle_request(**kwargs):
 @frappe.whitelist()
 def make_a_call(to_number: str, from_number: str | None = None, caller_id: str | None = None):
 	if not is_integration_enabled():
-		frappe.throw(_("Please setup Exotel intergration"), title=_("Integration Not Enabled"))
+		frappe.throw(_("Please setup Exotel integration"), title=_("Integration Not Enabled"))
 
 	endpoint = get_exotel_endpoint("Calls/connect.json?details=true")
 

--- a/crm/integrations/twilio/twilio_handler.py
+++ b/crm/integrations/twilio/twilio_handler.py
@@ -54,7 +54,7 @@ class Twilio:
 
 	@classmethod
 	def safe_identity(cls, identity: str):
-		"""Create a safe identity by replacing unsupported special charaters `@` with (at)).
+		"""Create a safe identity by replacing unsupported special characters `@` with (at)).
 		Twilio Client JS fails to make a call connection if identity has special characters like @, [, / etc)
 		https://www.twilio.com/docs/voice/client/errors (#31105)
 		"""

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -492,10 +492,10 @@ export function convertSize(size) {
   return `${size?.toFixed(2)} ${units[unitIndex]}`
 }
 
-export function isImage(extention) {
-  if (!extention) return false
+export function isImage(extension) {
+  if (!extension) return false
   return ['png', 'jpg', 'jpeg', 'gif', 'svg', 'bmp', 'webp'].includes(
-    extention.toLowerCase(),
+    extension.toLowerCase(),
   )
 }
 


### PR DESCRIPTION
Fixes a handful of typos:

- `intergration` → `integration` in the Exotel "Integration Not Enabled" error (user-visible)
- `charaters` → `characters` in a Twilio docstring
- `seperate` → `separate` in a comment
- renames the local parameter `extention` → `extension` in `isImage()` (`frontend/src/utils/index.js`); grepped the repo to confirm there are no other usages — no behavior change

Verified with `node --check` on the edited JS module and `python -m py_compile` on the edited Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
