### PR TITLE
fix: prevent IntegrityError when syncing items without a standard rate

### DIFF
--- a/crm/integrations/erpnext/item.py
+++ b/crm/integrations/erpnext/item.py
@@ -39,6 +39,9 @@ def _catalogue_data(doc) -> dict:
 	rate = get_item_price_rate(doc.name, doc.get("stock_uom"))
 	if rate is not None:
 		data["standard_rate"] = rate
+	# standard_rate is a NOT NULL Currency column and frappe.db.set_value writes
+	# raw values (no flt coercion, unlike doc.insert), so never pass None through
+	data["standard_rate"] = frappe.utils.flt(data["standard_rate"])
 	return data
 
 

--- a/crm/integrations/erpnext/test_utils.py
+++ b/crm/integrations/erpnext/test_utils.py
@@ -70,6 +70,20 @@ class TestItemRateFallback(FrappeTestCase):
 			item.get_item_price_rate = original
 		self.assertEqual(data["standard_rate"], 50)
 
+	def test_none_rate_coerces_to_zero_when_no_item_price(self):
+		from crm.integrations.erpnext import item
+
+		doc = frappe._dict(
+			name="ITM-D", stock_uom="Nos", standard_rate=None, image=None, disabled=0, description="d"
+		)
+		original = item.get_item_price_rate
+		item.get_item_price_rate = lambda code, uom=None: None
+		try:
+			data = item._catalogue_data(doc)
+		finally:
+			item.get_item_price_rate = original
+		self.assertEqual(data["standard_rate"], 0)
+
 	@unittest.skipUnless(ERPNEXT_INSTALLED, "erpnext not installed")
 	def test_get_item_price_rate_uses_default_price_list_and_general_party(self):
 		from erpnext.stock import get_item_details


### PR DESCRIPTION
Closes #2721

When an Item has no Item Price and no `standard_rate`, `_catalogue_data()` keeps `standard_rate=None`. The insert path is safe (`doc.insert()` coerces float-like fields via `get_valid_dict`), but the update path writes the dict raw through `frappe.db.set_value`, so the moment any other catalogue field differs, `NULL` hits the NOT NULL currency column and MariaDB raises IntegrityError 1048 (the traceback in the issue).

Fix: coerce the rate with `frappe.utils.flt()` at the single data source, matching what the insert path already stores (`0.0`). `payload_differs()` already treats `None`/`0` as equal, so sync-trigger behavior is unchanged.

Adds a unit test alongside the existing `TestItemRateFallback` cases (runs without ERPNext installed, same as its siblings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
