### PR TITLE
fix: use system time format for WhatsApp message timestamps

### DIFF
--- a/frontend/src/components/Activities/WhatsAppArea.vue
+++ b/frontend/src/components/Activities/WhatsAppArea.vue
@@ -140,7 +140,7 @@
           <div class="-mb-1 flex shrink-0 items-end gap-1 text-ink-gray-5">
             <Tooltip :text="formatDate(whatsapp.creation, 'ddd, MMM D, YYYY')">
               <div class="text-2xs">
-                {{ formatDate(whatsapp.creation, 'hh:mm a') }}
+                {{ formatDate(whatsapp.creation, '', false, true) }}
               </div>
             </Tooltip>
             <div v-if="whatsapp.type == 'Outgoing'">


### PR DESCRIPTION
Closes #2695

WhatsApp message bubbles hardcode `hh:mm a`, so sites configured with a 24-hour time format still see 12-hour timestamps. List views already render Datetime cells through `getFormat()` / `window.sysdefaults.time_format` (e.g. `Leads.vue`), making the WhatsApp area the odd one out. This switches the bubble to the same mechanism, so the timestamp follows System Settings.

Note: `TaskArea.vue` / `TasksListView.vue` have the same hardcoding; left out to keep this scoped to the reported issue — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
