### PR TITLE
fix: wrap hardcoded user-facing strings in __() for translation

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -733,49 +733,57 @@ const top = computed(() => {
 })
 
 const emptyText = computed(() => {
-  let text = 'No Activities Found'
+  let text = __('No Activities Found')
   if (title.value == 'Emails') {
-    text = 'No Emails Found'
+    text = __('No Emails Found')
   } else if (title.value == 'Comments') {
-    text = 'No Comments Found'
+    text = __('No Comments Found')
   } else if (title.value == 'Data') {
-    text = 'No Data Fields Added Yet'
+    text = __('No Data Fields Added Yet')
   } else if (title.value == 'Calls') {
-    text = 'No Call History'
+    text = __('No Call History')
   } else if (title.value == 'Notes') {
-    text = 'No Notes Found'
+    text = __('No Notes Found')
   } else if (title.value == 'Tasks') {
-    text = 'No Tasks Found'
+    text = __('No Tasks Found')
   } else if (title.value == 'Attachments') {
-    text = 'No Attachments Found'
+    text = __('No Attachments Found')
   } else if (title.value == 'WhatsApp') {
-    text = 'No WhatsApp Messages Found'
+    text = __('No WhatsApp Messages Found')
   }
   return text
 })
 
 const emptyTextDescription = computed(() => {
-  let description =
-    'There are no activities to display here. Go ahead and make some changes.'
+  let description = __(
+    'There are no activities to display here. Go ahead and make some changes.',
+  )
   if (title.value == 'Emails') {
-    description =
-      'No emails found in your inbox. New messages will appear here soon.'
+    description = __(
+      'No emails found in your inbox. New messages will appear here soon.',
+    )
   } else if (title.value == 'Comments') {
-    description = 'Be the first to add one.'
+    description = __('Be the first to add one.')
   } else if (title.value == 'Data') {
-    description = 'No data fields have been added yet.'
+    description = __('No data fields have been added yet.')
   } else if (title.value == 'Calls') {
-    description = 'No recent calls to display. Log a call or call someone now!'
+    description = __(
+      'No recent calls to display. Log a call or call someone now!',
+    )
   } else if (title.value == 'Notes') {
-    description = 'Nothing here for now. Add a note to keep track of things.'
+    description = __(
+      'Nothing here for now. Add a note to keep track of things.',
+    )
   } else if (title.value == 'Tasks') {
-    description =
-      'Nothing to do at the moment. Start organizing by adding one here.'
+    description = __(
+      'Nothing to do at the moment. Start organizing by adding one here.',
+    )
   } else if (title.value == 'Attachments') {
-    description =
-      'No files have been attached yet. Upload files to see them here.'
+    description = __(
+      'No files have been attached yet. Upload files to see them here.',
+    )
   } else if (title.value == 'WhatsApp') {
-    description = 'Start a conversation now!'
+    description = __('Start a conversation now!')
   }
   return description
 })

--- a/frontend/src/components/Controls/TableMultiselectInput.vue
+++ b/frontend/src/components/Controls/TableMultiselectInput.vue
@@ -90,8 +90,9 @@ const getLinkField = () => {
       ['Link', 'User'].includes(df.fieldtype),
     )
     if (!linkField.value) {
-      error.value =
-        'Table MultiSelect requires a Table with atleast one Link field'
+      error.value = __(
+        'Table MultiSelect requires a Table with at least one Link field',
+      )
     }
   }
   return linkField.value
@@ -101,7 +102,7 @@ const addValue = (value) => {
   error.value = null
 
   if (values.value.some((row) => row[linkField.value.fieldname] === value)) {
-    error.value = 'Value already exists'
+    error.value = __('Value already exists')
     return
   }
 

--- a/frontend/src/components/EventNotificationPopup.vue
+++ b/frontend/src/components/EventNotificationPopup.vue
@@ -20,7 +20,7 @@
                   class="font-medium text-ink-gray-8 mb-1 cursor-pointer"
                   @click="openEvent(alert)"
                 >
-                  {{ alert.notification.subject || 'Event Notification' }}
+                  {{ alert.notification.subject || __('Event Notification') }}
                 </div>
                 <div class="text-ink-gray-6">
                   {{ formatEventTime(alert.notification) }}

--- a/frontend/src/components/FilesUploader/FilesUploader.vue
+++ b/frontend/src/components/FilesUploader/FilesUploader.vue
@@ -190,7 +190,7 @@ function attachFile(file, i) {
   })
   uploader.value.on('error', (error) => {
     file.uploading = false
-    file.errorMessage = error || 'Error Uploading File'
+    file.errorMessage = error || __('Error Uploading File')
   })
   uploader.value.on('finish', () => {
     file.uploading = false
@@ -211,7 +211,7 @@ function attachFile(file, i) {
     })
     .catch((error) => {
       file.uploading = false
-      let errorMessage = 'Error Uploading File'
+      let errorMessage = __('Error Uploading File')
       if (error?._server_messages) {
         errorMessage = JSON.parse(JSON.parse(error._server_messages)[0]).message
       } else if (error?.exc) {

--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -411,11 +411,11 @@ function getValueControl(f) {
       trigger: 'button',
       options: [
         {
-          label: 'Set',
+          label: __('Set'),
           value: 'set',
         },
         {
-          label: 'Not Set',
+          label: __('Not Set'),
           value: 'not set',
         },
       ],

--- a/frontend/src/components/Modals/DoctypeModal.vue
+++ b/frontend/src/components/Modals/DoctypeModal.vue
@@ -122,7 +122,7 @@ const _create = createResource({
       error.value = __('Mandatory field error: {0}', [fieldName])
       return
     }
-    error.value = err.messages?.[0] || 'Could not create document'
+    error.value = err.messages?.[0] || __('Could not create document')
   },
 })
 
@@ -144,7 +144,7 @@ function update() {
       show.value = false
     },
     onError: (err) => {
-      error.value = err.messages?.[0] || 'Could not update document'
+      error.value = err.messages?.[0] || __('Could not update document')
     },
   })
 }

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -454,10 +454,10 @@ watch(error, (err) => {
   if (err) {
     errorTitle.value = __(
       err.exc_type == 'DoesNotExistError'
-        ? 'Document Not Found'
-        : 'Error Occurred',
+        ? __('Document Not Found')
+        : __('Error Occurred'),
     )
-    errorMessage.value = __(err.messages?.[0] || 'An Error Occurred')
+    errorMessage.value = __(err.messages?.[0] || __('An Error Occurred'))
   } else {
     errorTitle.value = ''
     errorMessage.value = ''

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -343,10 +343,10 @@ watch(error, (err) => {
   if (err) {
     errorTitle.value = __(
       err.exc_type == 'DoesNotExistError'
-        ? 'Document not found'
-        : 'Error occurred',
+        ? __('Document not found')
+        : __('Error occurred'),
     )
-    errorMessage.value = __(err.messages?.[0] || 'An error occurred')
+    errorMessage.value = __(err.messages?.[0] || __('An error occurred'))
   } else {
     errorTitle.value = ''
     errorMessage.value = ''

--- a/frontend/src/utils/fieldTransforms.js
+++ b/frontend/src/utils/fieldTransforms.js
@@ -108,7 +108,10 @@ export function applyStateFieldOptions(
     const hasRegionalStateData =
       stateOptionsByCountry && Object.keys(stateOptionsByCountry).length > 0
     if (hasRegionalStateData && !doc?.country) {
-      return { ...field, placeholder: 'Select Country to see state options' }
+      return {
+        ...field,
+        placeholder: __('Select Country to see state options'),
+      }
     }
     return field
   }


### PR DESCRIPTION
A pass over the frontend for user-visible strings that never reach translators because they aren't wrapped in `__()` (the extractor only picks up literal first arguments):

- error banners on the Deal/Lead pages (wrapped the inner literals, same pattern as `MobileDeal.vue`)
- `DoctypeModal` create/update fallback errors (the modal even calls `__(error)` at display time, but these msgids were never extracted)
- Table MultiSelect validation messages (also corrects `atleast` → `at least`)
- file-upload errors, empty-state titles/descriptions for all Activities tabs, event-notification fallback title, address-state placeholder, and the `Set` / `Not Set` filter labels

~34 strings across 9 files; pure `__()` wraps plus prettier reflow, no behavior change. Deliberately avoids the files touched by #2432 (complementary — those fix display-time translation, these make the literals extractable). Did not regenerate `main.pot` since that lands via the scheduled chore PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
