### PR TITLE
fix: prevent document not found error on delete

### DIFF
--- a/frontend/src/components/DeleteLinkedDocModal.vue
+++ b/frontend/src/components/DeleteLinkedDocModal.vue
@@ -131,9 +131,10 @@
 </template>
 
 <script setup>
-import { createResource, call } from 'frappe-ui'
+import { createResource, call, toast } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import { computed, ref } from 'vue'
+import { deletedDocuments } from '@/data/document'
 
 const show = defineModel({ type: Boolean })
 const router = useRouter()
@@ -249,11 +250,22 @@ const removeDocLinks = () => {
 }
 
 const deleteDoc = async () => {
-  await call('frappe.client.delete', {
-    doctype: props.doctype,
-    name: props.docname,
-  })
-  router.push({ name: props.name })
-  props?.reload?.()
+  const key = `${props.doctype}:${props.docname}`
+  deletedDocuments.add(key)
+  try {
+    await call('frappe.client.delete', {
+      doctype: props.doctype,
+      name: props.docname,
+    })
+    toast.success(__('Document deleted successfully'))
+    router.push({ name: props.name })
+    props?.reload?.()
+    setTimeout(() => {
+      deletedDocuments.delete(key)
+    }, 2000)
+  } catch (err) {
+    deletedDocuments.delete(key)
+    throw err
+  }
 }
 </script>

--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -9,6 +9,8 @@ import { createDocumentResource, createResource, toast } from 'frappe-ui'
 import { ref, reactive, getCurrentInstance } from 'vue'
 
 const documentsCache = {}
+export const deletedDocuments = new Set()
+
 const controllersCache = {}
 const assigneesCache = {}
 const permissionsCache = {}
@@ -36,9 +38,15 @@ export function useDocument(doctype, docname, resourceOverrides = {}) {
           name: docname,
           onSuccess: async () => await setupFormScript(),
           onError: (err) => {
-            error.value = err
             if (err.exc_type === 'DoesNotExistError') {
+              const key = `${doctype}:${docname}`
+              if (deletedDocuments.has(key)) {
+                return
+              }
+              error.value = err
               toast.error(__(err.messages[0] || 'Document does not exist'))
+            } else {
+              error.value = err
             }
             if (err.exc_type === 'PermissionError') {
               toast.error(


### PR DESCRIPTION
closes: #2718

## Problem

Deleting a Lead or Deal succeeds, but a "Document not found" error briefly appears before navigating to the list view.

## Fix

Mark the document as intentionally deleted before the delete request. If the document resource receives the expected `DoesNotExistError` during the deletion flow, the error is ignored instead of being displayed to the user.

The deletion marker is cleared when the delete fails and expires after a short period to prevent it from affecting unrelated errors.

## Testing

* Created a test Lead
* Deleted the Lead successfully
* Verified the "Document deleted successfully" message
* Verified navigation to the Leads list
* Verified the deleted Lead was removed
* Verified the "Document not found" error was not displayed
