### PR TITLE
Make website column clickable in Leads and Deals list views

### DIFF
--- a/frontend/src/components/ListViews/DealsListView.vue
+++ b/frontend/src/components/ListViews/DealsListView.vue
@@ -177,6 +177,14 @@
                 })
             "
           />
+          <button
+            v-else-if="column.key === 'website' && item?.url"
+            type="button"
+            class="w-full truncate bg-transparent p-0 text-left text-base cursor-pointer hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-4 focus-visible:ring-offset-1 rounded"
+            @click.stop.prevent="openWebsite(item.url)"
+          >
+            {{ getLabel(label, column) }}
+          </button>
           <div
             v-else-if="label"
             class="truncate text-base"
@@ -193,6 +201,14 @@
           >
             {{ getLabel(label, column) }}
           </div>
+        </template>
+        <template #suffix>
+          <span
+            v-if="column.key === 'website' && item?.url"
+            class="lucide-external-link h-3.5 w-3.5 shrink-0 cursor-pointer text-ink-gray-5"
+            aria-hidden="true"
+            @click.stop.prevent="openWebsite(item.url)"
+          />
         </template>
       </ListRowItem>
     </ListRows>
@@ -227,7 +243,7 @@ import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
 import RatingInput from '@/components/Controls/RatingInput.vue'
 import ListBulkActions from '@/components/ListBulkActions.vue'
 import ListRows from '@/components/ListViews/ListRows.vue'
-import { isTranslatable, formatDuration } from '@/utils'
+import { isTranslatable, formatDuration, openWebsite } from '@/utils'
 import {
   Avatar,
   ListView,

--- a/frontend/src/components/ListViews/DealsListView.vue
+++ b/frontend/src/components/ListViews/DealsListView.vue
@@ -177,14 +177,12 @@
                 })
             "
           />
-          <button
+          <WebsiteLink
             v-else-if="column.key === 'website' && item?.url"
-            type="button"
-            class="w-full truncate bg-transparent p-0 text-left text-base cursor-pointer hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-4 focus-visible:ring-offset-1 rounded"
-            @click.stop.prevent="openWebsite(item.url)"
-          >
-            {{ getLabel(label, column) }}
-          </button>
+            variant="label"
+            :url="item.url"
+            :label="getLabel(label, column)"
+          />
           <div
             v-else-if="label"
             class="truncate text-base"
@@ -203,11 +201,10 @@
           </div>
         </template>
         <template #suffix>
-          <span
+          <WebsiteLink
             v-if="column.key === 'website' && item?.url"
-            class="lucide-external-link h-3.5 w-3.5 shrink-0 cursor-pointer text-ink-gray-5"
-            aria-hidden="true"
-            @click.stop.prevent="openWebsite(item.url)"
+            variant="icon"
+            :url="item.url"
           />
         </template>
       </ListRowItem>
@@ -243,7 +240,8 @@ import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
 import RatingInput from '@/components/Controls/RatingInput.vue'
 import ListBulkActions from '@/components/ListBulkActions.vue'
 import ListRows from '@/components/ListViews/ListRows.vue'
-import { isTranslatable, formatDuration, openWebsite } from '@/utils'
+import WebsiteLink from '@/components/ListViews/WebsiteLink.vue'
+import { isTranslatable, formatDuration } from '@/utils'
 import {
   Avatar,
   ListView,

--- a/frontend/src/components/ListViews/LeadsListView.vue
+++ b/frontend/src/components/ListViews/LeadsListView.vue
@@ -181,14 +181,12 @@
                 })
             "
           />
-          <button
+          <WebsiteLink
             v-else-if="column.key === 'website' && item?.url"
-            type="button"
-            class="w-full truncate bg-transparent p-0 text-left text-base cursor-pointer hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-4 focus-visible:ring-offset-1 rounded"
-            @click.stop.prevent="openWebsite(item.url)"
-          >
-            {{ getLabel(label, column) }}
-          </button>
+            variant="label"
+            :url="item.url"
+            :label="getLabel(label, column)"
+          />
           <div
             v-else-if="label"
             class="truncate text-base"
@@ -207,11 +205,10 @@
           </div>
         </template>
         <template #suffix>
-          <span
+          <WebsiteLink
             v-if="column.key === 'website' && item?.url"
-            class="lucide-external-link h-3.5 w-3.5 shrink-0 cursor-pointer text-ink-gray-5"
-            aria-hidden="true"
-            @click.stop.prevent="openWebsite(item.url)"
+            variant="icon"
+            :url="item.url"
           />
         </template>
       </ListRowItem>
@@ -247,7 +244,8 @@ import RatingInput from '@/components/Controls/RatingInput.vue'
 import MultipleAvatar from '@/components/MultipleAvatar.vue'
 import ListBulkActions from '@/components/ListBulkActions.vue'
 import ListRows from '@/components/ListViews/ListRows.vue'
-import { isTranslatable, formatDuration, openWebsite } from '@/utils'
+import WebsiteLink from '@/components/ListViews/WebsiteLink.vue'
+import { isTranslatable, formatDuration } from '@/utils'
 import {
   Avatar,
   ListView,

--- a/frontend/src/components/ListViews/LeadsListView.vue
+++ b/frontend/src/components/ListViews/LeadsListView.vue
@@ -181,6 +181,14 @@
                 })
             "
           />
+          <button
+            v-else-if="column.key === 'website' && item?.url"
+            type="button"
+            class="w-full truncate bg-transparent p-0 text-left text-base cursor-pointer hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-4 focus-visible:ring-offset-1 rounded"
+            @click.stop.prevent="openWebsite(item.url)"
+          >
+            {{ getLabel(label, column) }}
+          </button>
           <div
             v-else-if="label"
             class="truncate text-base"
@@ -197,6 +205,14 @@
           >
             {{ getLabel(label, column) }}
           </div>
+        </template>
+        <template #suffix>
+          <span
+            v-if="column.key === 'website' && item?.url"
+            class="lucide-external-link h-3.5 w-3.5 shrink-0 cursor-pointer text-ink-gray-5"
+            aria-hidden="true"
+            @click.stop.prevent="openWebsite(item.url)"
+          />
         </template>
       </ListRowItem>
     </ListRows>
@@ -231,7 +247,7 @@ import RatingInput from '@/components/Controls/RatingInput.vue'
 import MultipleAvatar from '@/components/MultipleAvatar.vue'
 import ListBulkActions from '@/components/ListBulkActions.vue'
 import ListRows from '@/components/ListViews/ListRows.vue'
-import { isTranslatable, formatDuration } from '@/utils'
+import { isTranslatable, formatDuration, openWebsite } from '@/utils'
 import {
   Avatar,
   ListView,

--- a/frontend/src/components/ListViews/WebsiteLink.vue
+++ b/frontend/src/components/ListViews/WebsiteLink.vue
@@ -1,0 +1,30 @@
+<template>
+  <button
+    v-if="variant === 'label'"
+    type="button"
+    class="w-full truncate bg-transparent p-0 text-left text-base cursor-pointer hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-4 focus-visible:ring-offset-1 rounded"
+    @click.stop.prevent="openWebsite(url)"
+  >
+    {{ label }}
+  </button>
+  <span
+    v-else
+    class="lucide-external-link h-3.5 w-3.5 shrink-0 cursor-pointer text-ink-gray-5"
+    aria-hidden="true"
+    @click.stop.prevent="openWebsite(url)"
+  />
+</template>
+
+<script setup>
+import { openWebsite } from '@/utils'
+
+defineProps({
+  url: { type: String, required: true },
+  label: { type: String, default: '' },
+  variant: {
+    type: String,
+    default: 'label',
+    validator: (value) => ['label', 'icon'].includes(value),
+  },
+})
+</script>

--- a/frontend/src/pages/Deals.vue
+++ b/frontend/src/pages/Deals.vue
@@ -420,7 +420,7 @@ function parseRows(rows, columns = []) {
           logo: getOrganization(deal.organization)?.organization_logo,
         }
       } else if (row === 'website') {
-        _rows[row] = website(deal.website)
+        _rows[row] = { label: website(deal.website), url: deal.website }
       } else if (row == 'status') {
         _rows[row] = {
           label: deal.status,

--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -454,7 +454,7 @@ function parseRows(rows, columns = []) {
       } else if (row == 'organization') {
         _rows[row] = lead.organization
       } else if (row === 'website') {
-        _rows[row] = website(lead.website)
+        _rows[row] = { label: website(lead.website), url: lead.website }
       } else if (row == 'status') {
         _rows[row] = {
           label: lead.status,


### PR DESCRIPTION
closes : #2750 

Makes the website field in Leads and Deals list views clickable — it now opens the URL in a new tab instead of showing as plain text.