### PR TITLE
fix: propagate no_of_employees to organization on lead/deal conversion

### DIFF
--- a/crm/fcrm/doctype/crm_deal/crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.py
@@ -425,6 +425,7 @@ def create_organization(doc):
 			"territory": doc.get("territory"),
 			"industry": doc.get("industry"),
 			"annual_revenue": doc.get("annual_revenue"),
+			"no_of_employees": doc.get("no_of_employees"),
 		}
 	)
 	organization.insert(ignore_permissions=True)

--- a/crm/fcrm/doctype/crm_deal/test_crm_deal.py
+++ b/crm/fcrm/doctype/crm_deal/test_crm_deal.py
@@ -335,6 +335,21 @@ class TestCRMDeal(IntegrationTestCase):
 		deal = frappe.get_doc("CRM Deal", deal_name)
 		self.assertEqual(deal.organization, org.name)
 
+	def test_create_deal_api_propagates_no_of_employees(self):
+		"""Test that no_of_employees is copied onto the organization create_deal creates"""
+		deal_name = create_deal(
+			{
+				"organization_name": "Employees Test Org",
+				"no_of_employees": "51-200",
+				"first_name": "Employees",
+				"email": "employeestest@example.com",
+			}
+		)
+
+		deal = frappe.get_doc("CRM Deal", deal_name)
+		org = frappe.get_doc("CRM Organization", deal.organization)
+		self.assertEqual(org.no_of_employees, "51-200")
+
 	def test_create_deal_with_existing_contact(self):
 		"""Test create_deal with existing contact"""
 		# Create contact first

--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -268,6 +268,7 @@ class CRMLead(Document):
 				"territory": self.territory,
 				"industry": self.industry,
 				"annual_revenue": self.annual_revenue,
+				"no_of_employees": self.no_of_employees,
 			}
 		)
 		organization.insert(ignore_permissions=True)

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -512,6 +512,22 @@ class TestCRMLead(IntegrationTestCase):
 		self.assertEqual(deal.annual_revenue, 750000)
 		self.assertEqual(deal.job_title, "CEO")
 
+	def test_no_of_employees_propagated_to_organization_on_conversion(self):
+		"""Test that no_of_employees on lead is copied to the organization created on conversion"""
+		lead = create_lead(
+			first_name="Employees",
+			last_name="Test",
+			email="employeestest@example.com",
+			organization="Employees Test Inc",
+			no_of_employees="201-500",
+		)
+
+		deal_name = lead.convert_to_deal()
+		deal = frappe.get_doc("CRM Deal", deal_name)
+
+		org = frappe.get_doc("CRM Organization", deal.organization)
+		self.assertEqual(org.no_of_employees, "201-500")
+
 	def test_custom_fields_copied_to_deal_by_label(self):
 		"""Custom Lead fields map to matching custom Deal fields."""
 		create_lead_deal_custom_fields()

--- a/frontend/src/components/Modals/OrganizationModal.vue
+++ b/frontend/src/components/Modals/OrganizationModal.vue
@@ -204,7 +204,9 @@ const tabs = createResource({
 })
 
 onMounted(() => {
-  organization.doc.no_of_employees = '1-10'
+  if (!props.data?.no_of_employees) {
+    organization.doc.no_of_employees = '1-10'
+  }
   Object.assign(organization.doc, props.data)
 })
 


### PR DESCRIPTION
The employee count entered on a Lead or Deal was getting lost when it was converted into an Organization — it either wasn't copied at all, or got silently reset to the default 1-10. This fix passes no_of_employees through in both conversion paths so the value carries over correctly.

closes : #2744 