### PR TITLE
fix: show filter date fields in the system date format

### DIFF
--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -173,6 +173,7 @@ import {
 } from 'frappe-ui'
 import { h, computed, onMounted } from 'vue'
 import { isMobileView } from '@/composables/settings'
+import { getFormat } from '@/utils'
 
 const typeCheck = ['Check']
 const typeLink = ['Link', 'Dynamic Link']
@@ -451,7 +452,11 @@ function getValueControl(f) {
   } else if (typeNumber.includes(fieldtype)) {
     return h(FormControl, { type: 'number' })
   } else if (typeDate.includes(fieldtype) && operator == 'between') {
-    return h(DateRangePicker, { value: f.value, iconLeft: '' })
+    return h(DateRangePicker, {
+      value: f.value,
+      iconLeft: '',
+      format: getFormat('', '', true, false, false),
+    })
   } else if (typeDuration.includes(fieldtype)) {
     return h(DurationInput, { value: f.value })
   } else if (typeRating.includes(fieldtype)) {
@@ -464,6 +469,10 @@ function getValueControl(f) {
     return h(fieldtype == 'Date' ? DatePicker : DateTimePicker, {
       value: f.value,
       iconLeft: '',
+      format:
+        fieldtype == 'Date'
+          ? getFormat('', '', true, false, false)
+          : getFormat('', '', true, true, false),
     })
   } else {
     return h(FormControl, { type: 'text' })

--- a/frontend/src/components/QuickFilterField.vue
+++ b/frontend/src/components/QuickFilterField.vue
@@ -28,6 +28,11 @@
     class="border-none"
     :value="filter.value"
     :placeholder="filter.label"
+    :format="
+      filter.fieldtype === 'Date'
+        ? getFormat('', '', true, false, false)
+        : getFormat('', '', true, true, false)
+    "
     @change="(v) => updateFilter(filter, v)"
   />
   <FormControl
@@ -41,6 +46,7 @@
 <script setup>
 import Link from '@/components/Controls/Link.vue'
 import { FormControl, DatePicker, DateTimePicker } from 'frappe-ui'
+import { getFormat } from '@/utils'
 import { useDebounceFn } from '@vueuse/core'
 import { reactive, watch } from 'vue'
 


### PR DESCRIPTION
The date and date-range filter inputs showed raw ISO dates instead of the format configured in System Settings; this passes the system date format to those pickers so filters display dates the same way the rest of the CRM does, while the stored/queried value stays unchanged.

closes: https://github.com/frappe/crm/issues/2757