### PR TITLE
fix: dim assignee, timestamp and favourite columns for visited rows

### DIFF
--- a/crm/patches.txt
+++ b/crm/patches.txt
@@ -30,3 +30,4 @@ crm.patches.v1_0.add_forecasting_section_in_quick_entry
 crm.patches.v1_0.set_persona_captured_for_existing_sites
 crm.patches.v1_0.add_enrichment_fields_to_layouts
 crm.patches.v1_0.reorder_address_quick_entry_layout
+crm.patches.v1_0.set_seen_for_existing_deals_and_leads

--- a/crm/patches/v1_0/set_seen_for_existing_deals_and_leads.py
+++ b/crm/patches/v1_0/set_seen_for_existing_deals_and_leads.py
@@ -1,0 +1,46 @@
+import json
+
+import frappe
+from frappe.query_builder import DocType
+
+from crm.api.session import CRM_ALLOWED_ROLES
+
+DOCTYPES = ("CRM Deal", "CRM Lead")
+
+
+def execute():
+	"""Backfill `_seen` for CRM Deals/Leads that predate track_seen being enabled.
+
+	Without this, every record created before track_seen was turned on would
+	show up as unvisited (bold) to everyone, since there's no real view
+	history to reconstruct. Default them to already seen by every enabled
+	CRM user instead, so only records created or updated from now on show
+	as unvisited.
+	"""
+	users = get_crm_users()
+	if not users:
+		return
+
+	seen = json.dumps(users)
+
+	for doctype in DOCTYPES:
+		table = DocType(doctype)
+		frappe.qb.update(table).set(table._seen, seen).where(
+			table._seen.isnull() | table._seen.isin(["", "[]"])
+		).run()
+
+
+def get_crm_users():
+	users_with_crm_role = frappe.get_all(
+		"Has Role",
+		filters={"parenttype": "User", "role": ["in", CRM_ALLOWED_ROLES]},
+		pluck="parent",
+		distinct=True,
+	)
+	users_with_crm_role.append("Administrator")
+
+	return frappe.get_all(
+		"User",
+		filters={"name": ["in", users_with_crm_role], "enabled": 1},
+		pluck="name",
+	)

--- a/frontend/src/components/ListViews/DealsListView.vue
+++ b/frontend/src/components/ListViews/DealsListView.vue
@@ -53,6 +53,9 @@
             <MultipleAvatar
               :avatars="item"
               size="sm"
+              :label-class="
+                isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+              "
               @click="
                 (event) =>
                   emit('applyFilter', {
@@ -102,6 +105,9 @@
               ].includes(column.key)
             "
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {
@@ -156,7 +162,15 @@
             >
               <HeartIcon
                 class="h-4 w-4"
-                :class="isLiked(item) ? 'fill-red-500 text-red-500' : ''"
+                :class="
+                  isLiked(item)
+                    ? isVisited
+                      ? 'fill-red-400 text-red-400'
+                      : 'fill-red-500 text-red-500'
+                    : isVisited
+                      ? 'text-ink-gray-6'
+                      : 'text-ink-gray-9'
+                "
               />
             </Button>
           </div>

--- a/frontend/src/components/ListViews/LeadsListView.vue
+++ b/frontend/src/components/ListViews/LeadsListView.vue
@@ -53,6 +53,9 @@
             <MultipleAvatar
               :avatars="item"
               size="sm"
+              :label-class="
+                isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+              "
               @click="
                 (event) =>
                   emit('applyFilter', {
@@ -102,6 +105,9 @@
               ].includes(column.key)
             "
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {
@@ -130,7 +136,15 @@
             >
               <HeartIcon
                 class="h-4 w-4"
-                :class="isLiked(item) ? 'fill-red-500 text-red-500' : ''"
+                :class="
+                  isLiked(item)
+                    ? isVisited
+                      ? 'fill-red-400 text-red-400'
+                      : 'fill-red-500 text-red-500'
+                    : isVisited
+                      ? 'text-ink-gray-6'
+                      : 'text-ink-gray-9'
+                "
               />
             </Button>
           </div>

--- a/frontend/src/components/MultipleAvatar.vue
+++ b/frontend/src/components/MultipleAvatar.vue
@@ -14,7 +14,7 @@
           :label="avatars[0].label"
           :size="size"
         />
-        <div class="truncate">{{ avatars[0].label }}</div>
+        <div class="truncate" :class="labelClass">{{ avatars[0].label }}</div>
       </div>
     </Tooltip>
     <Tooltip
@@ -41,6 +41,7 @@ import { computed } from 'vue'
 const props = defineProps({
   avatars: { type: Array, default: () => [] },
   size: { type: String, default: 'md' },
+  labelClass: { type: String, default: '' },
 })
 const reverseAvatars = computed(() => [...props.avatars].reverse())
 </script>


### PR DESCRIPTION
## Summary
Follow-up to #2693. @ps173 pointed out that the visited-row dimming didn't carry to every column, and that a new `track_seen` field needs a data patch for existing customer records.

- The `isVisited` dim styling was only wired into the generic text fallback branch in `DealsListView.vue`/`LeadsListView.vue`, so the assignee avatar's name, the timestamp columns (modified/creation/first_response_time/first_responded_on/response_by) and the favourite heart icon stayed bold even after a row was opened. Applied the same `isVisited`-based classes to all three.
- Added a `labelClass` prop to `MultipleAvatar` so the single-assignee name label can pick up the dim/bold styling from the parent.
- Added patch `set_seen_for_existing_deals_and_leads` to backfill `_seen` (as `[owner]`) for CRM Deals/Leads that predate `track_seen` being enabled, so existing records don't all show up as unvisited.

## Test plan
- [x] `yarn build` (frontend) succeeds
- [x] `eslint` on changed Vue files passes clean
- [x] pre-commit hooks (ruff, prettier, eslint, check-python-ast) pass on commit
- [x] Manually verify in the list view: open a deal/lead, confirm assignee name, timestamp column and favourite icon all dim on return to the list
- [x] Run `bench migrate` on a site with existing deals/leads and confirm `_seen` gets backfilled