### PR TITLE
fix: manual backport of visited records dimming (#2693, #2767)

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -355,6 +355,9 @@ def get_data(
 		if group_by_field and group_by_field not in rows:
 			rows.append(group_by_field)
 
+		if meta.track_seen and "_seen" not in rows:
+			rows.append("_seen")
+
 		data = (
 			frappe.get_list(
 				doctype,
@@ -602,6 +605,13 @@ def remove_assignments(doctype: str, name: str, assignees: str | list, ignore_pe
 			status="Cancelled",
 			ignore_permissions=ignore_permissions,
 		)
+
+
+@frappe.whitelist()
+def add_seen(doctype: str, name: str):
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("read")
+	doc.add_seen()
 
 
 @frappe.whitelist()

--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -525,5 +525,6 @@
  "sort_order": "DESC",
  "states": [],
  "title_field": "organization",
- "track_changes": 1
+ "track_changes": 1,
+ "track_seen": 1
 }

--- a/crm/fcrm/doctype/crm_lead/crm_lead.json
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.json
@@ -477,5 +477,6 @@
  "sort_order": "DESC",
  "states": [],
  "title_field": "lead_name",
- "track_changes": 1
+ "track_changes": 1,
+ "track_seen": 1
 }

--- a/crm/patches.txt
+++ b/crm/patches.txt
@@ -29,3 +29,4 @@ crm.patches.v1_0.create_custom_fields_for_product_item_sync
 crm.patches.v1_0.add_forecasting_section_in_quick_entry
 crm.patches.v1_0.set_persona_captured_for_existing_sites
 crm.patches.v1_0.reorder_address_quick_entry_layout
+crm.patches.v1_0.set_seen_for_existing_deals_and_leads

--- a/crm/patches/v1_0/set_seen_for_existing_deals_and_leads.py
+++ b/crm/patches/v1_0/set_seen_for_existing_deals_and_leads.py
@@ -1,0 +1,46 @@
+import json
+
+import frappe
+from frappe.query_builder import DocType
+
+from crm.api.session import CRM_ALLOWED_ROLES
+
+DOCTYPES = ("CRM Deal", "CRM Lead")
+
+
+def execute():
+	"""Backfill `_seen` for CRM Deals/Leads that predate track_seen being enabled.
+
+	Without this, every record created before track_seen was turned on would
+	show up as unvisited (bold) to everyone, since there's no real view
+	history to reconstruct. Default them to already seen by every enabled
+	CRM user instead, so only records created or updated from now on show
+	as unvisited.
+	"""
+	users = get_crm_users()
+	if not users:
+		return
+
+	seen = json.dumps(users)
+
+	for doctype in DOCTYPES:
+		table = DocType(doctype)
+		frappe.qb.update(table).set(table._seen, seen).where(
+			table._seen.isnull() | table._seen.isin(["", "[]"])
+		).run()
+
+
+def get_crm_users():
+	users_with_crm_role = frappe.get_all(
+		"Has Role",
+		filters={"parenttype": "User", "role": ["in", CRM_ALLOWED_ROLES]},
+		pluck="parent",
+		distinct=True,
+	)
+	users_with_crm_role.append("Administrator")
+
+	return frappe.get_all(
+		"User",
+		filters={"name": ["in", users_with_crm_role], "enabled": 1},
+		pluck="name",
+	)

--- a/frontend/src/components/ListViews/DealsListView.vue
+++ b/frontend/src/components/ListViews/DealsListView.vue
@@ -53,6 +53,9 @@
             <MultipleAvatar
               :avatars="item"
               size="sm"
+              :label-class="
+                isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+              "
               @click="
                 (event) =>
                   emit('applyFilter', {
@@ -102,6 +105,9 @@
               ].includes(column.key)
             "
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {
@@ -156,7 +162,15 @@
             >
               <HeartIcon
                 class="h-4 w-4"
-                :class="isLiked(item) ? 'fill-red-500 text-red-500' : ''"
+                :class="
+                  isLiked(item)
+                    ? isVisited
+                      ? 'fill-red-400 text-red-400'
+                      : 'fill-red-500 text-red-500'
+                    : isVisited
+                      ? 'text-ink-gray-6'
+                      : 'text-ink-gray-9'
+                "
               />
             </Button>
           </div>

--- a/frontend/src/components/ListViews/DealsListView.vue
+++ b/frontend/src/components/ListViews/DealsListView.vue
@@ -40,7 +40,7 @@
       </ListHeaderItem>
     </ListHeader>
     <ListRows
-      v-slot="{ idx, column, item, row }"
+      v-slot="{ idx, column, item, row, isVisited }"
       :rows="rows"
       doctype="CRM Deal"
     >
@@ -180,6 +180,9 @@
           <div
             v-else-if="label"
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {

--- a/frontend/src/components/ListViews/LeadsListView.vue
+++ b/frontend/src/components/ListViews/LeadsListView.vue
@@ -53,6 +53,9 @@
             <MultipleAvatar
               :avatars="item"
               size="sm"
+              :label-class="
+                isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+              "
               @click="
                 (event) =>
                   emit('applyFilter', {
@@ -102,6 +105,9 @@
               ].includes(column.key)
             "
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {
@@ -130,7 +136,15 @@
             >
               <HeartIcon
                 class="h-4 w-4"
-                :class="isLiked(item) ? 'fill-red-500 text-red-500' : ''"
+                :class="
+                  isLiked(item)
+                    ? isVisited
+                      ? 'fill-red-400 text-red-400'
+                      : 'fill-red-500 text-red-500'
+                    : isVisited
+                      ? 'text-ink-gray-6'
+                      : 'text-ink-gray-9'
+                "
               />
             </Button>
           </div>

--- a/frontend/src/components/ListViews/LeadsListView.vue
+++ b/frontend/src/components/ListViews/LeadsListView.vue
@@ -40,7 +40,7 @@
       </ListHeaderItem>
     </ListHeader>
     <ListRows
-      v-slot="{ idx, column, item, row }"
+      v-slot="{ idx, column, item, row, isVisited }"
       :rows="rows"
       doctype="CRM Lead"
     >
@@ -184,6 +184,9 @@
           <div
             v-else-if="label"
             class="truncate text-base"
+            :class="
+              isVisited ? 'text-ink-gray-6' : 'font-medium text-ink-gray-9'
+            "
             @click="
               (event) =>
                 emit('applyFilter', {

--- a/frontend/src/components/ListViews/ListRows.vue
+++ b/frontend/src/components/ListViews/ListRows.vue
@@ -26,7 +26,9 @@
           v-slot="{ idx, column, item }"
           :row="row"
         >
-          <slot v-bind="{ idx, column, item, row }" />
+          <slot
+            v-bind="{ idx, column, item, row, isVisited: isVisited(row._seen) }"
+          />
         </ListRow>
       </ListGroupRows>
     </div>
@@ -38,7 +40,9 @@
       v-slot="{ idx, column, item }"
       :row="row"
     >
-      <slot v-bind="{ idx, column, item, row }" />
+      <slot
+        v-bind="{ idx, column, item, row, isVisited: isVisited(row._seen) }"
+      />
     </ListRow>
   </ListRows>
 </template>
@@ -47,6 +51,7 @@
 import { useStorage } from '@vueuse/core'
 import { ListRows, ListRow, ListGroupHeader, ListGroupRows } from 'frappe-ui'
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 
 const props = defineProps({
   rows: { type: Array, required: true },
@@ -69,6 +74,8 @@ let showGroupedRows = computed(() => {
 const scrollPosition = useStorage(`scrollPosition${props.doctype}`, 0)
 const scrollContainer = ref(null)
 const groupedScrollContainer = ref(null)
+
+const { isVisited } = useVisitedRecords(props.doctype)
 
 const handleScroll = (e) => {
   scrollPosition.value = e.target.scrollTop

--- a/frontend/src/components/MultipleAvatar.vue
+++ b/frontend/src/components/MultipleAvatar.vue
@@ -14,7 +14,7 @@
           :label="avatars[0].label"
           :size="size"
         />
-        <div class="truncate">{{ avatars[0].label }}</div>
+        <div class="truncate" :class="labelClass">{{ avatars[0].label }}</div>
       </div>
     </Tooltip>
     <Tooltip
@@ -41,6 +41,7 @@ import { computed } from 'vue'
 const props = defineProps({
   avatars: { type: Array, default: () => [] },
   size: { type: String, default: 'md' },
+  labelClass: { type: String, default: '' },
 })
 const reverseAvatars = computed(() => [...props.avatars].reverse())
 </script>

--- a/frontend/src/composables/useVisitedRecords.js
+++ b/frontend/src/composables/useVisitedRecords.js
@@ -1,0 +1,19 @@
+import { call } from 'frappe-ui'
+import { sessionStore } from '@/stores/session'
+
+export function useVisitedRecords(doctype) {
+  const { user } = sessionStore()
+
+  function isVisited(seen) {
+    if (!seen) return false
+    let seenBy = typeof seen === 'string' ? JSON.parse(seen) : seen
+    return seenBy.includes(user)
+  }
+
+  function markVisited(name) {
+    if (!name) return
+    call('crm.api.doc.add_seen', { doctype, name })
+  }
+
+  return { isVisited, markVisited }
+}

--- a/frontend/src/composables/useVisitedRecords.ts
+++ b/frontend/src/composables/useVisitedRecords.ts
@@ -1,16 +1,16 @@
 import { call } from 'frappe-ui'
 import { sessionStore } from '@/stores/session'
 
-export function useVisitedRecords(doctype) {
+export function useVisitedRecords(doctype: string) {
   const { user } = sessionStore()
 
-  function isVisited(seen) {
+  function isVisited(seen?: string | string[] | null) {
     if (!seen) return false
-    let seenBy = typeof seen === 'string' ? JSON.parse(seen) : seen
+    const seenBy = typeof seen === 'string' ? JSON.parse(seen) : seen
     return seenBy.includes(user)
   }
 
-  function markVisited(name) {
+  function markVisited(name?: string) {
     if (!name) return
     call('crm.api.doc.add_seen', { doctype, name })
   }

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -406,6 +406,7 @@ import {
 import { useRoute, useRouter } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
 import { useUnsavedChangesWarning } from '@/composables/useUnsavedChangesWarning'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 
 const { on } = useBroadcast()
 const { brand } = getSettings()
@@ -497,11 +498,14 @@ watch(
 
 const organization = computed(() => organizationDocument.value?.doc || {})
 
+const { markVisited } = useVisitedRecords('CRM Deal')
+
 onMounted(async () => {
   $socket.on('crm_customer_created', () => {
     toast.success(__('Customer Created Successfully'))
   })
   if (document.doc) await triggerOnRender()
+  markVisited(props.dealId)
 })
 
 onBeforeUnmount(() => {

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -291,6 +291,7 @@ import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
 import { useUnsavedChangesWarning } from '@/composables/useUnsavedChangesWarning'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 
 const { brand } = getSettings()
 const { $dialog, $socket, makeCall } = globalStore()
@@ -328,8 +329,11 @@ const doc = computed(() => document.doc || {})
 
 useUnsavedChangesWarning(() => document.isDirty)
 
+const { markVisited } = useVisitedRecords('CRM Lead')
+
 onMounted(async () => {
   if (document.doc) await triggerOnRender()
+  markVisited(props.leadId)
 })
 
 watch(error, (err) => {

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -304,6 +304,7 @@ import { isMobileView } from '@/composables/settings'
 import { whatsappEnabled } from '@/composables/whatsapp'
 import { callEnabled } from '@/composables/telephony'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 import {
   createResource,
   Dropdown,
@@ -344,8 +345,11 @@ const {
 
 const doc = computed(() => document.doc || {})
 
+const { markVisited } = useVisitedRecords('CRM Deal')
+
 onMounted(async () => {
   if (document.doc) await triggerOnRender()
+  markVisited(props.dealId)
 })
 
 watch(error, (err) => {

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -154,6 +154,7 @@ import { useDocument } from '@/data/document'
 import { isMobileView } from '@/composables/settings'
 import { whatsappEnabled } from '@/composables/whatsapp'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
+import { useVisitedRecords } from '@/composables/useVisitedRecords'
 import {
   createResource,
   Dropdown,
@@ -194,8 +195,11 @@ const {
 
 const doc = computed(() => document.doc || {})
 
+const { markVisited } = useVisitedRecords('CRM Lead')
+
 onMounted(async () => {
   if (document.doc) await triggerOnRender()
+  markVisited(props.leadId)
 })
 
 watch(error, (err) => {


### PR DESCRIPTION
Manual backport of #2693 and #2767 to `main-hotfix`

#2693 carried the `backport main-hotfix` label but no backport PR was ever opened for it. Mergify backports by cherry-picking the PR commits and #2693 has a merge commit in it (`4e4cf94`, merging `upstream/develop` into the feature branch) which a plain cherry-pick cannot replay, so the backport never happened and nobody noticed

Only the follow up #2767 got backported, as #2768. That one fails `bench migrate` on the upgrade job with

```
pymysql.err.OperationalError: (1054, "Unknown column '_seen' in 'WHERE'")
```

because the patch it adds writes to `_seen`, and `_seen` only exists when the doctype has `track_seen` enabled, which is part of #2693. The frontend half of #2768 is dead too, `isVisited` is referenced in the list views but `ListRows.vue` on `main-hotfix` never provides it

Both PRs are cherry-picked here as their `develop` merge commits, so `main-hotfix` gets the whole feature in the right order. #2768 can be closed

### Checks
- `track_seen: 1` on CRM Deal and CRM Lead, patch sits under `[post_model_sync]` so the column exists before the patch runs
- `isVisited` provided by `ListRows.vue` and consumed by both list views
- `ruff check crm/` clean, prettier and eslint clean on the changed frontend files, `yarn build` succeeds
