### PR TITLE
Fix:deal contact organization filter

### DIFF
--- a/frontend/src/components/Controls/Grid.vue
+++ b/frontend/src/components/Controls/Grid.vue
@@ -150,6 +150,7 @@
                             : row[field.options]
                         "
                         :filters="field.filters"
+                        :grouping="field.grouping"
                         :disabled="Boolean(field.disabled)"
                         :onCreate="
                           (value, close) => field.create(v, field, row, close)
@@ -500,7 +501,10 @@ import {
 import { flt } from '@/utils/numberFormat.js'
 import { usersStore } from '@/stores/users'
 import { getMeta } from '@/stores/meta'
-import { parseLinkFilters } from '@/utils/fieldTransforms'
+import {
+  parseLinkFilters,
+  applyContactOrganizationGrouping,
+} from '@/utils/fieldTransforms'
 import { isFetchedFromLink } from '@/utils/fetchFrom'
 import { createDocument } from '@/composables/document'
 import {
@@ -644,6 +648,12 @@ function getFieldObj(field) {
       ...(parseLinkFilters(field.link_filters) || {}),
     })
   }
+
+  field = applyContactOrganizationGrouping(
+    field,
+    parentDoc.value,
+    props.parentDoctype,
+  )
 
   const fieldObjWithFilters = {
     ...field,

--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -6,7 +6,7 @@
     <Autocomplete
       ref="autocomplete"
       v-model="value"
-      :options="options.data"
+      :options="autocompleteOptions"
       :size="attrs.size || 'sm'"
       :variant="attrs.variant"
       :placeholder="attrs.placeholder"
@@ -78,6 +78,13 @@ const props = defineProps({
   filters: { type: [Array, Object, String], default: () => [] },
   modelValue: { type: String, default: '' },
   hideMe: { type: Boolean, default: false },
+  /**
+   * Split the dropdown into two labelled groups instead of filtering options
+   * out: the ones matching `grouping.filters` first, everything else below.
+   * `{ filters: { company_name: 'Frappe' }, label: '...', otherLabel: '...' }`
+   * Only supported alongside object (or empty) `filters`.
+   */
+  grouping: { type: Object, default: null },
 })
 
 const emit = defineEmits(['update:modelValue', 'change'])
@@ -122,12 +129,40 @@ watchDebounced(
 )
 
 watchDebounced(
-  () => props.filters,
+  () => [props.filters, props.grouping],
   () => {
     reload('', true)
   },
   { debounce: 300, immediate: true },
 )
+
+// `filters` is only mergeable with `grouping.filters` when it is a plain
+// object; an array or a JSON string is left alone and grouping is skipped.
+function objectFilters() {
+  const filters = props.filters
+  if (Array.isArray(filters)) return filters.length ? null : {}
+  if (typeof filters === 'string') return null
+  return filters || {}
+}
+
+const isGrouped = computed(() =>
+  Boolean(
+    props.grouping?.filters &&
+      props.grouping?.label &&
+      props.grouping?.otherLabel &&
+      objectFilters(),
+  ),
+)
+
+function toOptions(data) {
+  return data.map((option) => {
+    return {
+      label: option.label || option.value,
+      value: option.value,
+      description: stripHtml(option.description),
+    }
+  })
+}
 
 const options = createResource({
   url: 'frappe.desk.search.search_link',
@@ -139,14 +174,8 @@ const options = createResource({
     filters: props.filters,
   },
   transform: (data) => {
-    let allData = data.map((option) => {
-      return {
-        label: option.label || option.value,
-        value: option.value,
-        description: stripHtml(option.description),
-      }
-    })
-    if (!props.hideMe && props.doctype == 'User') {
+    let allData = toOptions(data)
+    if (!isGrouped.value && !props.hideMe && props.doctype == 'User') {
       allData.unshift({
         label: '@me',
         value: '@me',
@@ -154,6 +183,27 @@ const options = createResource({
     }
     return allData
   },
+})
+
+// Holds the `grouping.filters` matches; `options` then holds everything else.
+const groupedOptions = createResource({
+  url: 'frappe.desk.search.search_link',
+  cache: ['grouped', props.doctype, text.value, props.hideMe, props.filters],
+  method: 'POST',
+  params: {
+    txt: text.value,
+    doctype: props.doctype,
+    filters: props.filters,
+  },
+  transform: toOptions,
+})
+
+const autocompleteOptions = computed(() => {
+  if (!isGrouped.value) return options.data
+  return [
+    { group: props.grouping.label, items: groupedOptions.data || [] },
+    { group: props.grouping.otherLabel, items: options.data || [] },
+  ].filter((group) => group.items.length)
 })
 
 function stripHtml(html) {
@@ -175,14 +225,49 @@ function reload(val, force = false) {
   )
     return
 
+  if (!isGrouped.value) {
+    options.update({
+      params: {
+        txt: val,
+        doctype: props.doctype,
+        filters: props.filters,
+      },
+    })
+    options.reload()
+    return
+  }
+
+  const baseFilters = objectFilters()
+  const groupFilters = props.grouping.filters
+
   options.update({
     params: {
       txt: val,
       doctype: props.doctype,
-      filters: props.filters,
+      // `!=` is null-safe in frappe (it wraps the column in ifnull), so
+      // records with the field unset land in this group rather than nowhere.
+      filters: { ...baseFilters, ...negateFilters(groupFilters) },
     },
   })
   options.reload()
+
+  groupedOptions.update({
+    params: {
+      txt: val,
+      doctype: props.doctype,
+      filters: { ...baseFilters, ...groupFilters },
+    },
+  })
+  groupedOptions.reload()
+}
+
+function negateFilters(filters) {
+  return Object.fromEntries(
+    Object.entries(filters).map(([fieldname, value]) => [
+      fieldname,
+      ['!=', value],
+    ]),
+  )
 }
 
 function clearValue(close) {

--- a/frontend/src/components/FieldLayout/Field.vue
+++ b/frontend/src/components/FieldLayout/Field.vue
@@ -101,6 +101,7 @@
           field.fieldtype == 'Link' ? field.options : data[field.options]
         "
         :filters="field.filters"
+        :grouping="field.grouping"
         :placeholder="getPlaceholder(field)"
         :disabled="Boolean(field.disabled)"
         :onCreate="field.create"
@@ -354,6 +355,7 @@ import { getMeta } from '@/stores/meta'
 import {
   parseLinkFilters,
   applyStateFieldOptions,
+  applyContactOrganizationGrouping,
 } from '@/utils/fieldTransforms'
 import { isFetchedFromLink } from '@/utils/fetchFrom'
 import { usersStore } from '@/stores/users'
@@ -531,6 +533,8 @@ const field = computed(() => {
       }
     }
   }
+
+  field = applyContactOrganizationGrouping(field, data.value, doctype)
 
   const read_only_via_depends_on = evaluateDependsOnValue(
     field.read_only_depends_on,

--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -192,6 +192,7 @@
                               : doc[field.options]
                           "
                           :filters="field.filters"
+                          :grouping="field.grouping"
                           :placeholder="field.placeholder"
                           :onCreate="field.create"
                           @change="(v) => fieldChange(v, field)"
@@ -434,7 +435,10 @@ import Link from '@/components/Controls/Link.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import SidePanelModal from '@/components/Modals/SidePanelModal.vue'
 import { getMeta } from '@/stores/meta'
-import { parseLinkFilters } from '@/utils/fieldTransforms'
+import {
+  parseLinkFilters,
+  applyContactOrganizationGrouping,
+} from '@/utils/fieldTransforms'
 import { usersStore } from '@/stores/users'
 import { isMobileView } from '@/composables/settings'
 import {
@@ -535,6 +539,8 @@ function parsedField(field) {
       ...(parseLinkFilters(field.link_filters) || {}),
     })
   }
+
+  field = applyContactOrganizationGrouping(field, doc.value, props.doctype)
 
   const read_only_via_depends_on = evaluateDependsOnValue(
     field.read_only_depends_on,

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -156,6 +156,15 @@
               <Link
                 value=""
                 doctype="Contact"
+                :grouping="
+                  doc.organization
+                    ? {
+                        filters: { company_name: doc.organization },
+                        label: __('Contacts at {0}', [doc.organization]),
+                        otherLabel: __('Other contacts'),
+                      }
+                    : null
+                "
                 :onCreate="
                   (value, close) => {
                     _contact = {

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -83,6 +83,15 @@
                   <Link
                     value=""
                     doctype="Contact"
+                    :grouping="
+                      doc.organization
+                        ? {
+                            filters: { company_name: doc.organization },
+                            label: __('Contacts at {0}', [doc.organization]),
+                            otherLabel: __('Other contacts'),
+                          }
+                        : null
+                    "
                     :onCreate="
                       (value, close) => {
                         _contact = {

--- a/frontend/src/pages/MobileOrganization.vue
+++ b/frontend/src/pages/MobileOrganization.vue
@@ -129,6 +129,32 @@
           :columns="columns"
           :options="{ selectable: false, showTooltip: false }"
         />
+        <div v-if="tab.label === 'Contacts'" class="flex justify-end px-3 pt-3">
+          <Link
+            value=""
+            doctype="Contact"
+            :filters="{ company_name: ['!=', props.organizationId] }"
+            :onCreate="
+              (value, close) => {
+                _contact = {
+                  first_name: value,
+                  company_name: props.organizationId,
+                }
+                showContactModal = true
+                close()
+              }
+            "
+            @change="(contact) => addContact(contact)"
+          >
+            <template #target="{ togglePopover }">
+              <Button
+                :label="__('Add Contact')"
+                iconLeft="plus"
+                @click="togglePopover()"
+              />
+            </template>
+          </Link>
+        </div>
         <ContactsListView
           v-if="tab.label === 'Contacts' && rows.length"
           class="mt-4"
@@ -148,6 +174,12 @@
       </template>
     </Tabs>
   </div>
+  <ContactModal
+    v-if="showContactModal"
+    v-model="showContactModal"
+    :contact="_contact"
+    :options="{ redirect: false, afterInsert: () => contacts.reload() }"
+  />
 </template>
 
 <script setup>
@@ -156,6 +188,8 @@ import Icon from '@/components/Icon.vue'
 import LayoutHeader from '@/components/LayoutHeader.vue'
 import DealsListView from '@/components/ListViews/DealsListView.vue'
 import ContactsListView from '@/components/ListViews/ContactsListView.vue'
+import ContactModal from '@/components/Modals/ContactModal.vue'
+import Link from '@/components/Controls/Link.vue'
 import DetailsIcon from '@/components/Icons/DetailsIcon.vue'
 import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
@@ -333,6 +367,8 @@ function getParsedSections(_sections) {
 }
 
 const tabIndex = ref(0)
+const showContactModal = ref(false)
+const _contact = ref({})
 const tabs = [
   {
     name: 'Details',
@@ -396,6 +432,21 @@ const contacts = createListResource({
   pageLength: 20,
   auto: true,
 })
+
+// Links an existing contact to this organization; `Contact.company_name` is
+// the only tie between the two, and until now it could only be set from the
+// contact's own page.
+async function addContact(contact) {
+  if (!contact) return
+  await call('frappe.client.set_value', {
+    doctype: 'Contact',
+    name: contact,
+    fieldname: 'company_name',
+    value: props.organizationId,
+  })
+  contacts.reload()
+  toast.success(__('Contact added to {0}', [props.organizationId]))
+}
 
 const rows = computed(() => {
   let list = !tabIndex.value ? deals : contacts

--- a/frontend/src/pages/Organization.vue
+++ b/frontend/src/pages/Organization.vue
@@ -154,15 +154,47 @@
           :columns="columns"
           :options="{ selectable: false, showTooltip: false }"
         />
-        <ContactsListView
-          v-if="tab.label === 'Contacts' && rows.length"
-          class="mt-4"
-          :rows="rows"
-          :columns="columns"
-          :options="{ selectable: false, showTooltip: false }"
-        />
+        <div
+          v-else-if="tab.label === 'Contacts'"
+          class="flex flex-1 flex-col overflow-hidden"
+        >
+          <div class="flex justify-end px-5">
+            <Link
+              value=""
+              doctype="Contact"
+              :filters="{ company_name: ['!=', props.organizationId] }"
+              :onCreate="
+                (value, close) => {
+                  _contact = {
+                    first_name: value,
+                    company_name: props.organizationId,
+                  }
+                  showContactModal = true
+                  close()
+                }
+              "
+              @change="(contact) => addContact(contact)"
+            >
+              <template #target="{ togglePopover }">
+                <Button
+                  :label="__('Add Contact')"
+                  iconLeft="plus"
+                  @click="togglePopover()"
+                />
+              </template>
+            </Link>
+          </div>
+          <ContactsListView
+            v-if="rows.length"
+            class="mt-4"
+            :rows="rows"
+            :columns="columns"
+            :options="{ selectable: false, showTooltip: false }"
+          />
+          <EmptyState v-else :icon="tab.icon" :name="__(tab.label)" />
+        </div>
         <EmptyState
-          v-if="!rows.length"
+          v-if="tab.label === 'Deals' && !rows.length"
           :icon="tab.icon"
           :name="__(tab.label)"
         />
@@ -181,6 +213,12 @@
     :docname="props.organizationId"
     name="Organizations"
   />
+  <ContactModal
+    v-if="showContactModal"
+    v-model="showContactModal"
+    :contact="_contact"
+    :options="{ redirect: false, afterInsert: () => contacts.reload() }"
+  />
 </template>
 
 <script setup>
@@ -196,6 +234,8 @@ import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import DealsIcon from '@/components/Icons/DealsIcon.vue'
 import ContactsIcon from '@/components/Icons/ContactsIcon.vue'
 import DeleteLinkedDocModal from '@/components/DeleteLinkedDocModal.vue'
+import ContactModal from '@/components/Modals/ContactModal.vue'
+import Link from '@/components/Controls/Link.vue'
 import CustomActions from '@/components/CustomActions.vue'
 import EnrichFromWebsite from '@/components/EnrichFromWebsite.vue'
 import { useDocument } from '@/data/document'
@@ -246,6 +286,8 @@ const errorTitle = ref('')
 const errorMessage = ref('')
 
 const showDeleteLinkedDocModal = ref(false)
+const showContactModal = ref(false)
+const _contact = ref({})
 
 const {
   document: organization,
@@ -438,6 +480,21 @@ const contacts = createListResource({
   pageLength: 20,
   auto: true,
 })
+
+// Links an existing contact to this organization; `Contact.company_name` is
+// the only tie between the two, and until now it could only be set from the
+// contact's own page.
+async function addContact(contact) {
+  if (!contact) return
+  await call('frappe.client.set_value', {
+    doctype: 'Contact',
+    name: contact,
+    fieldname: 'company_name',
+    value: props.organizationId,
+  })
+  contacts.reload()
+  toast.success(__('Contact added to {0}', [props.organizationId]))
+}
 
 const rows = computed(() => {
   let list = !tabIndex.value ? deals : contacts

--- a/frontend/src/utils/fieldTransforms.js
+++ b/frontend/src/utils/fieldTransforms.js
@@ -125,6 +125,45 @@ export function applyStateFieldOptions(
 }
 
 /**
+ * Group the Deal's `contact` Link field by the selected Organization: contacts
+ * of that organization are listed first under their own label, every other
+ * contact under a second one.
+ *
+ * Contact doesn't have a direct "deal" relationship - the tie is via
+ * `Contact.company_name`, which is set to the Deal's organization when a
+ * contact is created from a Deal (see crm_deal.py::create_contact).
+ *
+ * Grouping rather than filtering keeps contacts that aren't linked to the
+ * organization yet reachable, since a Deal's contact isn't always one of them.
+ *
+ * @param {object} field - processed field object
+ * @param {object} doc - the document data (reads doc.organization)
+ * @param {string} doctype - the field's doctype; only 'CRM Deal' is affected
+ * @returns {object} the field, unchanged unless it is CRM Deal's `contact` field
+ */
+export function applyContactOrganizationGrouping(field, doc, doctype) {
+  if (
+    !field ||
+    doctype !== 'CRM Deal' ||
+    field.fieldname !== 'contact' ||
+    field.fieldtype !== 'Link' ||
+    field.options !== 'Contact' ||
+    !doc?.organization
+  ) {
+    return field
+  }
+
+  return {
+    ...field,
+    grouping: {
+      filters: { company_name: doc.organization },
+      label: __('Contacts at {0}', [doc.organization]),
+      otherLabel: __('Other contacts'),
+    },
+  }
+}
+
+/**
  * Find mandatory fields that are missing values in the doc.
  * Respects script overrides for reqd and hidden.
  *

--- a/frontend/tests/unit/applyContactOrganizationGrouping.test.js
+++ b/frontend/tests/unit/applyContactOrganizationGrouping.test.js
@@ -1,0 +1,102 @@
+import { applyContactOrganizationGrouping } from '@/utils/fieldTransforms'
+
+const contactField = {
+  fieldname: 'contact',
+  fieldtype: 'Link',
+  options: 'Contact',
+  label: 'Contact',
+}
+
+describe('applyContactOrganizationGrouping', () => {
+  it('groups the contact field by the deal organization', () => {
+    const result = applyContactOrganizationGrouping(
+      contactField,
+      { organization: 'Frappe' },
+      'CRM Deal',
+    )
+    expect(result.grouping).toEqual({
+      filters: { company_name: 'Frappe' },
+      label: 'Contacts at Frappe',
+      otherLabel: 'Other contacts',
+    })
+  })
+
+  it('leaves link_filters alone so no contact is filtered out', () => {
+    const fieldWithFilters = {
+      ...contactField,
+      link_filters: JSON.stringify({ status: 'Passive' }),
+    }
+    const result = applyContactOrganizationGrouping(
+      fieldWithFilters,
+      { organization: 'Frappe' },
+      'CRM Deal',
+    )
+    expect(result.link_filters).toBe(fieldWithFilters.link_filters)
+  })
+
+  it('does not group when no organization is selected', () => {
+    const result = applyContactOrganizationGrouping(
+      contactField,
+      { organization: '' },
+      'CRM Deal',
+    )
+    expect(result).toBe(contactField)
+  })
+
+  it('does not group when the doc is missing', () => {
+    const result = applyContactOrganizationGrouping(
+      contactField,
+      null,
+      'CRM Deal',
+    )
+    expect(result).toBe(contactField)
+  })
+
+  it('does not mutate the input field', () => {
+    applyContactOrganizationGrouping(
+      contactField,
+      { organization: 'Frappe' },
+      'CRM Deal',
+    )
+    expect(contactField.grouping).toBeUndefined()
+  })
+
+  it('only applies to the CRM Deal doctype', () => {
+    const result = applyContactOrganizationGrouping(
+      contactField,
+      { organization: 'Frappe' },
+      'CRM Lead',
+    )
+    expect(result).toBe(contactField)
+  })
+
+  it('only applies to the contact fieldname', () => {
+    const otherField = { ...contactField, fieldname: 'primary_contact' }
+    const result = applyContactOrganizationGrouping(
+      otherField,
+      { organization: 'Frappe' },
+      'CRM Deal',
+    )
+    expect(result).toBe(otherField)
+  })
+
+  it('only applies to a Link field with options Contact', () => {
+    const wrongOptions = { ...contactField, options: 'User' }
+    const result = applyContactOrganizationGrouping(
+      wrongOptions,
+      { organization: 'Frappe' },
+      'CRM Deal',
+    )
+    expect(result).toBe(wrongOptions)
+  })
+
+  it('handles a nullish field safely', () => {
+    expect(
+      applyContactOrganizationGrouping(
+        null,
+        { organization: 'Frappe' },
+        'CRM Deal',
+      ),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #1203

### Problem

In a Deal, the Contact dropdown listed every contact in the system, ignoring the
Deal's Organization.

The obvious fix is to filter the dropdown by organization. But a contact is tied
to an organization through Contact.company_name, and until now that field could
only be set from the contact's own page — there was no way to do it from the
organization. So filtering alone would leave most users with an empty dropdown
and no way out.

This PR fixes the missing link first, then makes the dropdown helpful without
hiding anything.

### Changes

**1. Add contacts from the Organization page**

The Contacts tab on an organization was read-only. It now has an **Add Contact**
button that either:
- links an existing contact to the organization, or
- opens the contact modal with the organization already filled in ("Create New")

Added on both desktop and mobile.

**2. Group the Deal's contact dropdown instead of filtering it**

The dropdown now splits into two labelled groups — the organization's contacts
first, everyone else below — so the org's contacts are easy to find but no
contact is ever hidden. A deal's contact isn't always someone already linked to
the organization, so removing them from the list would be wrong.

This is done with a new optional `grouping` prop on the `Link` control, which
reuses the grouped-options support already present in `Autocomplete`.
