### PR TITLE
feat(desk-v2): put Territories back in the Organizations panel

### DIFF
--- a/crm/sidebar/doctype_crm_organization/doctype_crm_organization.json
+++ b/crm/sidebar/doctype_crm_organization/doctype_crm_organization.json
@@ -7,7 +7,7 @@
  "items": [],
  "link_doctype": "DocType",
  "link_to": "CRM Organization",
- "modified": "2026-09-02 18:53:12.409196",
+ "modified": "2026-09-03 12:10:44.512038",
  "modified_by": "Administrator",
  "name": "doctype_crm_organization",
  "navigation_items": [
@@ -45,6 +45,19 @@
    "label": "Industries",
    "link_doctype": "DocType",
    "link_to": "CRM Industry",
+   "parent_key": "organizations-configure",
+   "switches_app": 0
+  },
+  {
+   "added": 0,
+   "collapsible": 0,
+   "hidden": 0,
+   "item_type": "DocType",
+   "keep_closed": 0,
+   "key": "territories",
+   "label": "Territories",
+   "link_doctype": "DocType",
+   "link_to": "CRM Territory",
    "parent_key": "organizations-configure",
    "switches_app": 0
   }

--- a/crm/tests/test_navigation.py
+++ b/crm/tests/test_navigation.py
@@ -26,7 +26,12 @@ SIDEBARS = {
 	"doctype_crm_lead": ("leads", "leads-configure", "lead-statuses", "lead-sources", "lost-reasons"),
 	"doctype_crm_deal": ("deals", "deals-configure", "deal-statuses", "products", "territories"),
 	"doctype_contact": ("contacts", "call-logs"),
-	"doctype_crm_organization": ("organizations", "organizations-configure", "industries"),
+	"doctype_crm_organization": (
+		"organizations",
+		"organizations-configure",
+		"industries",
+		"territories",
+	),
 }
 
 # The two rail items that open no sidebar. Charter point 1 makes independent a first-class
@@ -106,36 +111,34 @@ class TestCRMNavigation(IntegrationTestCase):
 				if row.item_type == "DocType":
 					self.assertTrue(frappe.db.exists("DocType", row.link_to), f"{address}/{row.key}")
 
-	def test_no_destination_sits_in_two_of_crm_s_sidebars(self):
-		"""A CRM convention for now, NOT a rule about navigation. See the note below.
+	def test_crm_territory_is_listed_in_both_the_panels_it_belongs_to(self):
+		"""The replacement for the guard that said the opposite. See the note.
 
-		Putting one destination in two panels is ordinary and legitimate -- ERPNext has 101 rows
-		linking outside their own module. But today an address resolves to exactly one panel: it
-		is matched against every destination the payload can be standing on, the deepest cover
-		wins, and equal covers tie-break on rail order, top to bottom. So `CRM Territory` under
-		both Deals and Organizations meant clicking it in the Organizations panel moved the
-		reader to Deals, with nothing warning either the author or the reader.
+		CRM used to ship each destination exactly once, because an address resolved to exactly
+		one panel: the deepest cover won and equal covers tie-broke on rail order, so clicking
+		Territories in the Organizations panel moved the reader to Deals. `CRM Territory` was
+		removed from Organizations rather than the behaviour being fixed, and a test guarded
+		that removal.
 
-		CRM therefore ships each destination once while that is the behaviour. This test is the
-		guard on that choice, and it should be deleted -- not weakened -- once one address in two
-		panels resolves to the panel the reader is in.
+		The reader now keeps the panel they are in, so a destination may be listed in as many
+		panels as it belongs in. This asserts the restored row rather than merely allowing it,
+		so the thinning is not quietly redone by someone reading the old convention.
 
-		Read off the shipped rows: a destination the reader cannot open is gone from the resolved
-		payload, so a duplicate could hide behind a permission rather than be reported.
+		Read off the shipped rows: a destination the reader cannot open is gone from the
+		resolved payload, so the row could hide behind a permission rather than be reported.
 		"""
-		seen: dict[tuple[str, str], str] = {}
+		panels = set()
 
 		for container, address in every_container():
 			# The rail is not one of the panels this is about, and it carries `DocType` rows of
-			# its own -- Tasks and Notes -- which would otherwise be counted as destinations.
+			# its own -- Tasks and Notes.
 			if container != "Sidebar":
 				continue
 			for row in shipped(container, address):
-				if row.item_type != "DocType":
-					continue
-				destination = (row.link_doctype, row.link_to)
-				self.assertNotIn(destination, seen, f"{row.link_to} is also in {seen.get(destination)}")
-				seen[destination] = address
+				if (row.link_doctype, row.link_to) == ("DocType", "CRM Territory"):
+					panels.add(address)
+
+		self.assertEqual(panels, {"doctype_crm_deal", "doctype_crm_organization"})
 
 	def test_keys_are_unique_within_each_container(self):
 		"""Every site and user edit is filed against a key, so two rows sharing one collide."""


### PR DESCRIPTION
`CRM Territory` belongs under both Deals and Organizations, and was authored under both when CRM's rail was first walked. Clicking Territories in the Organizations panel moved the reader to Deals, because an address resolved to exactly one panel and equal covers tie-broke on rail order. The row was removed from Organizations rather than the behaviour being fixed, and CRM has shipped each destination exactly once since — 15 rows over four panels, marked in the code as the workaround it was.

The reader now keeps the panel they are in and the tab remembers it across a reload ([frappe#42432](https://github.com/frappe/frappe/issues/42432), shipped as [frappe#42476](https://github.com/frappe/frappe/pull/42476)), so a destination may be listed in as many panels as it belongs in. This spends that.

## What changed

- The `territories` row is back in `doctype_crm_organization`, under its `Configure` section, identical to its twin under Deals. Keys are unique per container, so both panels carry `territories` and neither collides.
- The fixture's `modified` stamp is bumped with the row. An unchanged stamp means `migrate` skips the import and keeps the old child rows without saying so.
- `test_no_destination_sits_in_two_of_crm_s_sidebars` is deleted rather than weakened, as its own docstring asked. Its replacement asserts `CRM Territory` is in both panels, so the thinning is not quietly redone by someone reading the old convention.

## Walked on a real site

| From | Click Territories | After reload |
|---|---|---|
| Organizations | panel stays **Organizations** | **Organizations** |
| Deals | panel stays **Deals** | **Deals** |

A cold paste of `/apps/crm/crm-territory` into a fresh tab picks **Deals** on rail order. That is the intended behaviour, not a gap: CRM's panels are keyed on doctypes, every CRM doctype is in one module, and there is no module fallback to help.

14/14 in `crm.tests.test_navigation` green.

## Scope

Nothing else was thinned for this reason. The four sidebar fixtures arrived in one commit and only `CRM Territory` was cut from it.

Worth a separate look, and deliberately not done here: `CRM Industry` is referenced by Lead, Deal and Organization but is listed only under Organizations, and `CRM Territory` is referenced by Lead too. Those rows were never authored and then removed, so listing them is new authoring rather than a restore.

Resolves [frappe#42465](https://github.com/frappe/frappe/issues/42465), on the [rail and sidebar map](https://github.com/frappe/frappe/issues/42226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)