### PR TITLE
fix: link Task/Note created from Call Log modal to its Lead/Deal

### DIFF
--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -72,11 +72,33 @@ def set_default_calling_medium(medium: str):
 	return get_user_default_calling_medium()
 
 
+def _get_call_log_lead_or_deal(call_log):
+	"""Resolve the Lead/Deal a call log currently belongs to.
+
+	Telephony integrations (Twilio, Exotel) link a call log to its Lead/Deal
+	only via the "links" child table (CRMCallLog.link_with_reference_doc) -
+	they never populate reference_doctype/reference_docname directly. So the
+	links table is checked first, falling back to the direct reference
+	fields for call logs that do have them set.
+	"""
+	for link in call_log.get("links") or []:
+		if link.link_doctype in ("CRM Lead", "CRM Deal"):
+			return link.link_doctype, link.link_name
+
+	if call_log.reference_doctype in ("CRM Lead", "CRM Deal"):
+		return call_log.reference_doctype, call_log.reference_docname
+
+	return None, None
+
+
 @frappe.whitelist()
 def add_note_to_call_log(call_sid: str, note: dict):
 	"""Add/Update note to call log based on call sid."""
 	if not frappe.has_permission("CRM Call Log", "write", call_sid):
 		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+	call_log = frappe.get_cached_doc("CRM Call Log", call_sid)
+	reference_doctype, reference_docname = _get_call_log_lead_or_deal(call_log)
 
 	_note = None
 	if not note.get("name"):
@@ -85,12 +107,21 @@ def add_note_to_call_log(call_sid: str, note: dict):
 				"doctype": "FCRM Note",
 				"title": note.get("title", "Call Note"),
 				"content": note.get("content"),
+				"reference_doctype": reference_doctype,
+				"reference_docname": reference_docname,
 			}
 		).insert(ignore_permissions=True)
 	else:
-		_note = frappe.set_value("FCRM Note", note.get("name"), "content", note.get("content"))
+		# The note is already inserted by the caller (DoctypeModal.vue's own
+		# frappe.client.insert) by the time this runs, so this is the branch
+		# that actually fires for a note created from the call log UI - it
+		# must set the reference here, not just in the dead insert branch above.
+		_note = frappe.get_doc("FCRM Note", note.get("name"))
+		_note.content = note.get("content")
+		_note.reference_doctype = reference_doctype
+		_note.reference_docname = reference_docname
+		_note.save(ignore_permissions=True)
 
-	call_log = frappe.get_cached_doc("CRM Call Log", call_sid)
 	call_log.link_with_reference_doc("FCRM Note", _note.name)
 	call_log.save(ignore_permissions=True)
 
@@ -103,6 +134,9 @@ def add_task_to_call_log(call_sid: str, task: dict):
 	if not frappe.has_permission("CRM Call Log", "write", call_sid):
 		frappe.throw(_("Not permitted"), frappe.PermissionError)
 
+	call_log = frappe.get_doc("CRM Call Log", call_sid)
+	reference_doctype, reference_docname = _get_call_log_lead_or_deal(call_log)
+
 	_task = None
 	if not task.get("name"):
 		_task = frappe.get_doc(
@@ -114,9 +148,15 @@ def add_task_to_call_log(call_sid: str, task: dict):
 				"due_date": task.get("due_date"),
 				"status": task.get("status"),
 				"priority": task.get("priority"),
+				"reference_doctype": reference_doctype,
+				"reference_docname": reference_docname,
 			}
 		).insert(ignore_permissions=True)
 	else:
+		# The task is already inserted by the caller (DoctypeModal.vue's own
+		# frappe.client.insert) by the time this runs, so this is the branch
+		# that actually fires for a task created from the call log UI - it
+		# must set the reference here, not just in the dead insert branch above.
 		_task = frappe.get_doc("CRM Task", task.get("name"))
 		_task.update(
 			{
@@ -126,11 +166,12 @@ def add_task_to_call_log(call_sid: str, task: dict):
 				"due_date": task.get("due_date"),
 				"status": task.get("status"),
 				"priority": task.get("priority"),
+				"reference_doctype": reference_doctype,
+				"reference_docname": reference_docname,
 			}
 		)
 		_task.save(ignore_permissions=True)
 
-	call_log = frappe.get_doc("CRM Call Log", call_sid)
 	call_log.link_with_reference_doc("CRM Task", _task.name)
 	call_log.save(ignore_permissions=True)
 

--- a/crm/integrations/api.py
+++ b/crm/integrations/api.py
@@ -77,17 +77,25 @@ def _get_call_log_lead_or_deal(call_log):
 
 	Telephony integrations (Twilio, Exotel) link a call log to its Lead/Deal
 	only via the "links" child table (CRMCallLog.link_with_reference_doc) -
-	they never populate reference_doctype/reference_docname directly. So the
-	links table is checked first, falling back to the direct reference
-	fields for call logs that do have them set.
+	they never populate reference_doctype/reference_docname directly. The
+	links table is append-only, so if it ever accumulates more than one
+	Lead/Deal entry, the most recently added one wins - mirroring
+	crm_call_log.parse_call_log, which resolves the same "_lead"/"_deal"
+	the UI displays by letting later links overwrite earlier ones.
 	"""
+	lead = call_log.reference_docname if call_log.reference_doctype == "CRM Lead" else None
+	deal = call_log.reference_docname if call_log.reference_doctype == "CRM Deal" else None
+
 	for link in call_log.get("links") or []:
-		if link.link_doctype in ("CRM Lead", "CRM Deal"):
-			return link.link_doctype, link.link_name
+		if link.link_doctype == "CRM Lead":
+			lead = link.link_name
+		elif link.link_doctype == "CRM Deal":
+			deal = link.link_name
 
-	if call_log.reference_doctype in ("CRM Lead", "CRM Deal"):
-		return call_log.reference_doctype, call_log.reference_docname
-
+	if lead:
+		return "CRM Lead", lead
+	if deal:
+		return "CRM Deal", deal
 	return None, None
 
 

--- a/crm/tests/test_integrations.py
+++ b/crm/tests/test_integrations.py
@@ -279,6 +279,30 @@ class TestIntegrations(IntegrationTestCase):
 		self.assertEqual(task.reference_doctype, "CRM Lead")
 		self.assertEqual(task.reference_docname, lead.name)
 
+	def test_add_task_to_call_log_follows_most_recently_linked_lead(self):
+		"""The links table is append-only, so if a call log ever accumulates
+		more than one Lead link (e.g. re-matched to a different Lead later),
+		the most recently added one must win - matching what
+		crm_call_log.parse_call_log resolves as the call log's current Lead
+		for display."""
+		first_lead = frappe.get_doc(
+			{"doctype": "CRM Lead", "first_name": "First", "last_name": "Lead"}
+		).insert()
+		second_lead = frappe.get_doc(
+			{"doctype": "CRM Lead", "first_name": "Second", "last_name": "Lead"}
+		).insert()
+		call_log = create_test_call_log()
+		call_log.link_with_reference_doc("CRM Lead", first_lead.name)
+		call_log.link_with_reference_doc("CRM Lead", second_lead.name)
+		call_log.save()
+		task = frappe.get_doc({"doctype": "CRM Task", "title": "Follow up", "status": "Todo"}).insert()
+
+		add_task_to_call_log(call_log.name, {"name": task.name, "title": "Follow up", "status": "Todo"})
+
+		task.reload()
+		self.assertEqual(task.reference_doctype, "CRM Lead")
+		self.assertEqual(task.reference_docname, second_lead.name)
+
 	def test_get_contact_by_phone_number_finds_contact(self):
 		"""Test get_contact_by_phone_number finds existing contact"""
 		# Create a test contact - use exact match by storing what will be searched

--- a/crm/tests/test_integrations.py
+++ b/crm/tests/test_integrations.py
@@ -165,6 +165,23 @@ class TestIntegrations(IntegrationTestCase):
 		note.reload()
 		self.assertEqual(note.content, "Updated content with more details")
 
+	def test_add_note_to_call_log_sets_reference_on_already_inserted_note(self):
+		"""The CallLogDetailModal UI flow inserts the note itself (via
+		frappe.client.insert, with no reference_doctype/docname) *before*
+		calling add_note_to_call_log, so `note` always already has a `name`
+		by the time this runs - the "existing note" branch, not the "new
+		note" branch, is what actually fires in production and must set the
+		reference."""
+		lead = frappe.get_doc({"doctype": "CRM Lead", "first_name": "John", "last_name": "Doe"}).insert()
+		call_log = create_test_call_log(reference_doctype="CRM Lead", reference_docname=lead.name)
+		note = frappe.get_doc({"doctype": "FCRM Note", "title": "Call Note", "content": "..."}).insert()
+
+		add_note_to_call_log(call_log.name, {"name": note.name, "content": "..."})
+
+		note.reload()
+		self.assertEqual(note.reference_doctype, "CRM Lead")
+		self.assertEqual(note.reference_docname, lead.name)
+
 	def test_add_task_to_call_log_creates_new_task(self):
 		"""Test add_task_to_call_log creates new task and links it to call log"""
 		# Create a test call log
@@ -227,6 +244,40 @@ class TestIntegrations(IntegrationTestCase):
 		self.assertEqual(task.description, "Updated description")
 		self.assertEqual(task.status, "In Progress")
 		self.assertEqual(task.priority, "High")
+
+	def test_add_task_to_call_log_sets_reference_on_already_inserted_task(self):
+		"""The CallLogDetailModal UI flow inserts the task itself (via
+		frappe.client.insert, with no reference_doctype/docname) *before*
+		calling add_task_to_call_log, so `task` always already has a `name`
+		by the time this runs - the "existing task" branch, not the "new
+		task" branch, is what actually fires in production and must set the
+		reference."""
+		deal = frappe.get_doc({"doctype": "CRM Deal"}).insert()
+		call_log = create_test_call_log(reference_doctype="CRM Deal", reference_docname=deal.name)
+		task = frappe.get_doc({"doctype": "CRM Task", "title": "Follow up", "status": "Todo"}).insert()
+
+		add_task_to_call_log(call_log.name, {"name": task.name, "title": "Follow up", "status": "Todo"})
+
+		task.reload()
+		self.assertEqual(task.reference_doctype, "CRM Deal")
+		self.assertEqual(task.reference_docname, deal.name)
+
+	def test_add_task_to_call_log_resolves_lead_linked_via_links_table(self):
+		"""Telephony integrations (Twilio/Exotel) link a call log to its Lead/Deal
+		only through the links table, never via reference_doctype/reference_docname
+		directly - a task created from such a call log must still follow that
+		Lead."""
+		lead = frappe.get_doc({"doctype": "CRM Lead", "first_name": "John", "last_name": "Doe"}).insert()
+		call_log = create_test_call_log()
+		call_log.link_with_reference_doc("CRM Lead", lead.name)
+		call_log.save()
+		task = frappe.get_doc({"doctype": "CRM Task", "title": "Follow up", "status": "Todo"}).insert()
+
+		add_task_to_call_log(call_log.name, {"name": task.name, "title": "Follow up", "status": "Todo"})
+
+		task.reload()
+		self.assertEqual(task.reference_doctype, "CRM Lead")
+		self.assertEqual(task.reference_docname, lead.name)
 
 	def test_get_contact_by_phone_number_finds_contact(self):
 		"""Test get_contact_by_phone_number finds existing contact"""


### PR DESCRIPTION
closes : #2773

Tasks/Notes created from the Call Log detail modal never got a reference_doctype/reference_docname pointing at the call log's Lead/Deal, so they were invisible on that Lead/Deal's own Tasks/Notes tab and only showed up in the global list .

The frontend inserts the Task/Note itself before calling add_note_to_call_log/add_task_to_call_log, so the fix has to set the reference in the "existing document" branch, not the "create new" branch. Resolving the call log's Lead/Deal also has to check the links child table first, since Twilio/Exotel-created call logs only carry that association there, never in reference_doctype/reference_docname directly.