### PR TITLE
fix: expand primary contact by default in deal side panel

### DIFF
--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -729,8 +729,10 @@ const dealContacts = createResource({
   params: { name: props.dealId },
   cache: ['deal_contacts', props.dealId],
   transform: (data) => {
-    data.forEach((contact) => {
-      contact.opened = false
+    // get_deal_contacts orders primary first, so expanding the first contact
+    // surfaces the most relevant email and phone without a click.
+    data.forEach((contact, index) => {
+      contact.opened = index === 0
     })
     return data
   },

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -593,7 +593,9 @@ const dealContacts = createResource({
       (section) => section.name == 'contacts_section',
     )
     if (!contactSection) return
-    contactSection.contacts = data.map((contact) => {
+    // get_deal_contacts orders primary first, so expanding the first contact
+    // surfaces the most relevant email and phone without a click.
+    contactSection.contacts = data.map((contact, index) => {
       return {
         name: contact.name,
         full_name: contact.full_name,
@@ -601,7 +603,7 @@ const dealContacts = createResource({
         mobile_no: contact.mobile_no,
         image: contact.image,
         is_primary: contact.is_primary,
-        opened: false,
+        opened: index === 0,
       }
     })
   },


### PR DESCRIPTION
The deal side panel rendered every contact collapsed, hiding the email and mobile number behind a click on both desktop and mobile. The state was reset on every fetch, so it could not be dismissed by the user either.

get_deal_contacts orders by "is_primary desc, idx asc", so the first entry is the primary contact whenever one is set, and the top contact otherwise. Keying the expanded state off that position always opens exactly one contact, where checking is_primary alone would have left every contact collapsed on deals with no primary set.

Refs #436 (item 4)