### PR TITLE
fix: map Exotel call statuses to valid Call Log options

### DIFF
--- a/crm/integrations/exotel/handler.py
+++ b/crm/integrations/exotel/handler.py
@@ -210,7 +210,7 @@ def create_call_log(
 	call_log.to = to_number
 	call_log.medium = medium
 	call_log.type = call_type
-	call_log.status = status
+	call_log.status = status or "Ringing"
 	call_log.telephony_medium = "Exotel"
 	setattr(call_log, "from", from_number)
 
@@ -248,32 +248,53 @@ def get_call_log(call_payload):
 		return frappe.get_doc("CRM Call Log", call_log_id)
 
 
+# Exotel reports call status in lowercase, hyphenated form. Map it onto the
+# options of the CRM Call Log status field, which is a mandatory Select.
+EXOTEL_CALL_STATUSES = {
+	"initiated": "Initiated",
+	"ringing": "Ringing",
+	"in-progress": "In Progress",
+	"completed": "Completed",
+	"failed": "Failed",
+	"busy": "Busy",
+	"no-answer": "No Answer",
+	"queued": "Queued",
+	"canceled": "Canceled",
+	"cancelled": "Canceled",
+}
+
+# Exotel sends these when a leg never connected, eg. the caller hung up before
+# an agent picked up. There is no status to record, not an unknown one.
+EXOTEL_EMPTY_STATUSES = ("", "null", "none", "undefined")
+
+
+def normalize_call_status(status):
+	"""Map a raw Exotel status onto a CRM Call Log status, or None if there isn't one."""
+	if not status:
+		return None
+
+	status = str(status).strip().lower().replace("_", "-").replace(" ", "-")
+	if status in EXOTEL_EMPTY_STATUSES:
+		return None
+
+	return EXOTEL_CALL_STATUSES.get(status)
+
+
 def get_call_log_status(call_payload, direction="inbound"):
 	if direction == "outbound-api" or direction == "outbound-dial":
-		status = call_payload.get("Status")
-		if status == "completed":
-			return "Completed"
-		elif status == "in-progress":
-			return "In Progress"
-		elif status == "busy":
-			return "Ringing"
-		elif status == "no-answer":
-			return "No Answer"
-		elif status == "failed":
-			return "Failed"
+		status = normalize_call_status(call_payload.get("Status"))
+		if status == "Busy":
+			# the call is still ringing on another leg
+			status = "Ringing"
+		if status:
+			return status
 
 	call_type = call_payload.get("CallType")
-	status = call_payload.get("DialCallStatus") or call_payload.get("Status")
+	status = normalize_call_status(call_payload.get("DialCallStatus") or call_payload.get("Status"))
 
-	if call_type == "incomplete" and status == "no-answer":
-		status = "No Answer"
-	elif call_type == "client-hangup" and status == "canceled":
-		status = "Canceled"
-	elif call_type == "incomplete" and status == "failed":
-		status = "Failed"
-	elif call_type == "completed":
+	if call_type == "completed":
 		status = "Completed"
-	elif status == "busy":
+	elif status == "Busy":
 		status = "Ringing"
 
 	return status
@@ -285,7 +306,8 @@ def update_call_log(call_payload, status="Ringing", call_log=None):
 	status = get_call_log_status(call_payload, direction)
 	try:
 		if call_log:
-			call_log.status = status
+			if status:
+				call_log.status = status
 			# resetting this because call might be redirected to other number
 			call_log.to = call_payload.get("DialWhomNumber") or call_payload.get("To")
 			call_log.duration = (

--- a/crm/integrations/exotel/handler.py
+++ b/crm/integrations/exotel/handler.py
@@ -250,6 +250,7 @@ def get_call_log(call_payload):
 
 # Exotel reports call status in lowercase, hyphenated form. Map it onto the
 # options of the CRM Call Log status field, which is a mandatory Select.
+# https://support.exotel.com/support/solutions/articles/27323-call-status
 EXOTEL_CALL_STATUSES = {
 	"initiated": "Initiated",
 	"ringing": "Ringing",
@@ -265,6 +266,8 @@ EXOTEL_CALL_STATUSES = {
 
 # Exotel sends these when a leg never connected, eg. the caller hung up before
 # an agent picked up. There is no status to record, not an unknown one.
+# Leg2Status is documented as empty when there is no second leg:
+# https://support.exotel.com/support/solutions/articles/27323-call-status
 EXOTEL_EMPTY_STATUSES = ("", "null", "none", "undefined")
 
 

--- a/crm/tests/test_integrations.py
+++ b/crm/tests/test_integrations.py
@@ -13,6 +13,11 @@ from crm.integrations.api import (
 	is_call_integration_enabled,
 	set_default_calling_medium,
 )
+from crm.integrations.exotel.handler import (
+	EXOTEL_CALL_STATUSES,
+	get_call_log_status,
+	normalize_call_status,
+)
 
 
 class TestIntegrations(IntegrationTestCase):
@@ -494,6 +499,105 @@ class TestIntegrations(IntegrationTestCase):
 		# Should return None since lead is converted
 		self.assertIsNone(docname)
 		self.assertIsNone(doctype)
+
+
+class TestExotelCallStatus(IntegrationTestCase):
+	"""Exotel reports status in its own vocabulary, CRM Call Log status is a Select."""
+
+	def get_status_options(self):
+		return frappe.get_meta("CRM Call Log").get_field("status").options.split("\n")
+
+	def test_every_mapped_status_is_a_valid_option(self):
+		"""Whatever we map to has to exist in the Select, or the call log won't save"""
+		options = self.get_status_options()
+		for status in EXOTEL_CALL_STATUSES.values():
+			self.assertIn(status, options)
+
+	def test_normalize_call_status_handles_exotel_casing(self):
+		self.assertEqual(normalize_call_status("no-answer"), "No Answer")
+		self.assertEqual(normalize_call_status("in-progress"), "In Progress")
+		self.assertEqual(normalize_call_status("No_Answer"), "No Answer")
+		self.assertEqual(normalize_call_status(" Completed "), "Completed")
+		self.assertEqual(normalize_call_status("cancelled"), "Canceled")
+
+	def test_normalize_call_status_treats_empty_values_as_unset(self):
+		"""A leg that never connected has no status, rather than an unknown one"""
+		for status in (None, "", "null", "NULL", "undefined"):
+			self.assertIsNone(normalize_call_status(status))
+
+	def test_normalize_call_status_returns_none_for_unknown_status(self):
+		self.assertIsNone(normalize_call_status("some-new-exotel-status"))
+
+	def test_incoming_no_answer_without_matching_call_type(self):
+		"""The status reported in #824, which used to be passed through as "no-answer" """
+		status = get_call_log_status({"CallType": "client-hangup", "DialCallStatus": "no-answer"})
+		self.assertEqual(status, "No Answer")
+
+		status = get_call_log_status({"Status": "no-answer"})
+		self.assertEqual(status, "No Answer")
+
+	def test_incoming_null_status_is_unset(self):
+		"""Caller hung up before any agent leg connected"""
+		status = get_call_log_status({"CallType": "client-hangup", "DialCallStatus": "null"})
+		self.assertIsNone(status)
+
+	def test_incoming_call_type_overrides_are_preserved(self):
+		cases = [
+			({"CallType": "incomplete", "DialCallStatus": "no-answer"}, "No Answer"),
+			({"CallType": "incomplete", "DialCallStatus": "failed"}, "Failed"),
+			({"CallType": "client-hangup", "DialCallStatus": "canceled"}, "Canceled"),
+			# a completed call is completed regardless of what the leg reported
+			({"CallType": "completed", "DialCallStatus": "busy"}, "Completed"),
+			# busy means it is still ringing on another leg
+			({"CallType": "incomplete", "DialCallStatus": "busy"}, "Ringing"),
+		]
+		for payload, expected in cases:
+			with self.subTest(payload=payload):
+				self.assertEqual(get_call_log_status(payload), expected)
+
+	def test_dial_call_status_takes_precedence_over_status(self):
+		payload = {"DialCallStatus": "completed", "Status": "no-answer"}
+		self.assertEqual(get_call_log_status(payload), "Completed")
+
+	def test_outgoing_statuses_are_mapped(self):
+		cases = [
+			("completed", "Completed"),
+			("in-progress", "In Progress"),
+			("no-answer", "No Answer"),
+			("failed", "Failed"),
+			# these used to fall through and be passed on as-is
+			("canceled", "Canceled"),
+			("queued", "Queued"),
+			("ringing", "Ringing"),
+			("initiated", "Initiated"),
+			# busy means it is still ringing on another leg
+			("busy", "Ringing"),
+		]
+		for direction in ("outbound-api", "outbound-dial"):
+			for reported, expected in cases:
+				with self.subTest(direction=direction, status=reported):
+					status = get_call_log_status({"Status": reported}, direction=direction)
+					self.assertEqual(status, expected)
+
+	def test_every_status_is_valid_or_unset(self):
+		"""No payload should ever produce a status the Select would reject"""
+		options = self.get_status_options()
+		payloads = [
+			{},
+			{"Status": "null"},
+			{"Status": "some-new-exotel-status"},
+			{"CallType": "client-hangup", "DialCallStatus": "null"},
+		]
+		for reported in EXOTEL_CALL_STATUSES:
+			payloads.append({"Status": reported})
+			payloads.append({"CallType": "incomplete", "DialCallStatus": reported})
+
+		for direction in ("inbound", "outbound-api", "outbound-dial"):
+			for payload in payloads:
+				with self.subTest(direction=direction, payload=payload):
+					status = get_call_log_status(payload, direction=direction)
+					if status is not None:
+						self.assertIn(status, options)
 
 
 def create_test_call_log(**kwargs):


### PR DESCRIPTION
Fixes #824

## Problem

Exotel reports call status in its own vocabulary (no-answer, in-progress,canceled, and sometimes the literal string null when a leg never connected). get_call_log_status() only mapped a handful of CallType + status combinations
and returned the raw Exotel string on fall-through. CRM Call Log status is a mandatory Select, so the save failed with Status cannot be "no-answer". It should be one of "Ringing", "In Progress",..and the call log was never created — the call did not show up in CRM at all.

## Fix

- Add EXOTEL_CALL_STATUSES, a full map from Exotel's statuses to the Select options, and normalize_call_status() which lowercases/trims before lookup.
- Treat "", "null", "none","undefined" as *no status* rather than an  unknown one — Exotel documents Leg2Status as empty when there's no second leg.
  In that case the existing status on the call log is left untouched instead of being overwritten with an invalid value.
- Keep the existing overrides: CallType=completed → Completed, busy → Ringing (still ringing on another leg).
- create_call_log() defaults to Ringing if no status is supplied.