### PR TITLE
fix: surface errors when Kanban drag-and-drop status change fails

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -1019,6 +1019,15 @@ function updateKanbanSettings(data) {
       name: data.item,
       fieldname: view.value.column_field,
       value: data.to,
+    }).catch((error) => {
+      toast.error(
+        error.messages?.[0] || __('Could not update the record.'),
+      )
+      // Revert the optimistic drag-and-drop move in the UI since the
+      // server rejected the change (e.g. a mandatory field like
+      // lost_reason is missing) — otherwise the card stays shown in the
+      // wrong column with no indication that nothing was actually saved.
+      list.value.reload()
     })
     return
   }


### PR DESCRIPTION
## Summary
- Dragging a card to a different Kanban column (Lead **or** Deal) calls `frappe.client.set_value` without awaiting or catching the result.
- When the server rejects the change — e.g. dropping into a status whose `type` is `Lost`, which requires a mandatory `lost_reason` — the error is silently swallowed: no toast, and the card stays displayed in the wrong column even though nothing was actually saved.
- Catch the rejection, surface it via `toast.error` (same pattern already used elsewhere in this file, see `EnrichFromWebsite.vue`), and reload the list so the board reflects the true, unchanged state.

## Repro
1. Give a Lead or Deal status a `type` of `Lost` with the "Lost Reason" field marked mandatory on that transition.
2. On the Kanban view, drag a card into that column without providing a lost reason.
3. The card stays in the new column with no error shown, but the record's `status` field was never actually updated server-side.

## Test plan
- [ ] Drag a Lead/Deal into a "Lost"-type column without a lost reason set → toast error appears, card reverts to its original column.
- [ ] Drag a Lead/Deal into a normal column → still works exactly as before (no behavior change on the success path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)