### PR TITLE
feat: attach an Email Template's files automatically when applied

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -855,3 +855,24 @@ def delete_bulk_docs(doctype: str, items: str | list, delete_linked: bool = Fals
 	else:
 		delete_bulk(doctype, items)
 	return "success"
+
+
+@frappe.whitelist()
+def get_email_template_attachments(template_name: str):
+	"""Files attached to an Email Template (via the standard Frappe
+	attachment mechanism), so the email composer can attach them
+	automatically when the template is applied."""
+
+	if not frappe.db.exists("Email Template", template_name):
+		return []
+
+	frappe.has_permission("Email Template", "read", doc=template_name, throw=True)
+
+	return frappe.get_all(
+		"File",
+		filters={
+			"attached_to_doctype": "Email Template",
+			"attached_to_name": template_name,
+		},
+		fields=["name", "file_name", "file_url"],
+	)

--- a/frontend/src/components/EmailEditor.vue
+++ b/frontend/src/components/EmailEditor.vue
@@ -314,6 +314,22 @@ async function applyEmailTemplate(template) {
   if (data.message) {
     content.value = data.message
   }
+
+  // Attach any files that were uploaded to the template itself (via the
+  // standard attachment sidebar on the Email Template record), so a
+  // template can carry its own PDFs/attachments without re-uploading them
+  // by hand every time it's used.
+  call('crm.api.doc.get_email_template_attachments', {
+    template_name: template.name,
+  }).then((files) => {
+    const alreadyAttached = new Set(attachments.value.map((a) => a.file_url))
+    for (const file of files || []) {
+      if (!alreadyAttached.has(file.file_url)) {
+        attachments.value.push(file)
+      }
+    }
+  })
+
   showEmailTemplateSelectorModal.value = false
   capture('email_template_applied', { doctype: props.doctype })
 }


### PR DESCRIPTION
## Summary

`Email Template` already supports the standard Frappe file attachment mechanism — any file attached to the record via the usual attachments sidebar. Nothing new to store. But applying a template in the CRM's email composer only ever copied over its subject/body text; any files attached to the template itself were silently ignored, so a recurring email that should carry a fixed PDF (a program brochure, a price sheet, terms & conditions...) had to have that file re-uploaded by hand on every single send.

- Adds a small whitelisted API, `crm.api.doc.get_email_template_attachments(template_name)`, that returns the files attached to a given `Email Template`.
- Calls it from `applyEmailTemplate()` right after the subject/body are copied over, pushing any attachments into the composer's existing `attachments` model (skipping files already attached by `file_url`, so re-applying a template or combining it with a manual upload doesn't duplicate anything).

No new doctype fields, no new settings screen: attach a file to a template exactly the way you already attach a file to any other Frappe document (its detail page in the desk), and it now comes along automatically wherever that template is applied in the CRM composer.

## Test plan

- [x] Verified live on a real deployment: attached a file to an `Email Template`, applied it on a Lead's reply composer — subject/body filled in as before, and the attachment appeared automatically with no manual upload.
- [x] Applying a template with no attachments still works exactly as before (no regression).
- [x] Re-applying the same template (or applying two templates that share a file) does not duplicate the attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)