### PR TITLE
fix: timeline does not live-update for new emails or read-receipts

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -604,7 +604,10 @@ onMounted(() => {
 })
 
 function handleDocinfoUpdate({ doc, key }) {
-  if (key !== 'comments') return
+  // 'comments' covers comment activity; 'communications' covers new/updated
+  // emails (e.g. a reply arriving, or a read-receipt coming in) so the
+  // timeline reflects them live instead of only after a manual reload.
+  if (key !== 'comments' && key !== 'communications') return
   if (doc.reference_doctype !== props.doctype) return
   if (doc.reference_name !== props.docname) return
 


### PR DESCRIPTION
## Bug

`Communication.notify_change()` already publishes a `docinfo_update` socket event with `key="communications"` whenever an email is created, updated, or removed for a linked document (this is how e.g. a new incoming reply is *supposed* to appear live).

The Activities panel subscribes to `docinfo_update`, but `handleDocinfoUpdate` only ever acts on `key === "comments"`:

```js
function handleDocinfoUpdate({ doc, key }) {
  if (key !== 'comments') return
  ...
}
```

Every `communications` event is silently dropped. In practice: a Lead/Deal timeline left open in the browser never reflects a new incoming email, a reply, or an email's read-receipt status — the data is already in the database and the backend is already broadcasting it, but the UI just never listens for it. Only a manual page reload picks it up.

## Fix

Also reload the timeline on `key === "communications"`, using the same reference_doctype/reference_name guard already used for comments.

## Testing

Verified live end-to-end against a real deployment:
- Kept a Lead's Emails tab open in a browser tab (no interaction).
- Marked a linked "Sent" email as read from another session (same code path a recipient opening the email in their inbox triggers).
- The email's status badge flipped from "Sent" (green) to "Read" (blue) within ~1s in the already-open tab, with no reload.
- Without this fix, the badge only updated after a manual page refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)