### PR TITLE
feat: show address details inline on organization and contact

### DIFF
--- a/crm/api/address.py
+++ b/crm/api/address.py
@@ -1,0 +1,53 @@
+import frappe
+from frappe import _
+from frappe.contacts.doctype.address.address import render_address
+from frappe.utils import escape_html
+
+
+@frappe.whitelist()
+def get_address_display(name: str | None = None) -> str | None:
+	"""Return the rendered HTML block for an Address.
+
+	Annotations do not validate anything at runtime, so `name` is checked
+	explicitly: it arrives straight off an HTTP request, and frappe treats a
+	dict as a set of filters rather than a docname.
+	"""
+	if not isinstance(name, str) or not name:
+		return None
+
+	if not frappe.db.exists("Address", name):
+		return None
+
+	address = frappe.get_cached_doc("Address", name)
+	address.check_permission()
+
+	try:
+		return render_address(address.as_dict(), check_permissions=False)
+	except frappe.ValidationError:
+		# render_address() throws when the site has no Address Template record
+		# at all, which is the common case for CRM installs without ERPNext.
+		frappe.clear_last_message()
+		return render_without_template(address.as_dict())
+
+
+def render_without_template(address: dict) -> str:
+	"""Build a plain address block for sites that have no Address Template.
+
+	Deliberately avoids frappe.render_template(): a rendered template is an
+	SSTI sink, and nothing here needs one.
+	"""
+	lines = [
+		address.get("address_line1"),
+		address.get("address_line2"),
+		address.get("city"),
+		address.get("state"),
+		address.get("pincode"),
+		address.get("country"),
+	]
+	parts = [escape_html(line) for line in lines if line]
+
+	for label, value in ((_("Phone"), address.get("phone")), (_("Email"), address.get("email_id"))):
+		if value:
+			parts.append(f"{escape_html(label)}: {escape_html(value)}")
+
+	return "<br>\n".join(parts)

--- a/crm/tests/test_address_display.py
+++ b/crm/tests/test_address_display.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from crm.api.address import get_address_display, render_without_template
+
+
+class TestAddressDisplay(FrappeTestCase):
+	def setUp(self):
+		self.address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": "Test Org HQ",
+				"address_type": "Office",
+				"address_line1": "42 Baker Street",
+				"city": "London",
+				"pincode": "NW1",
+				"country": "United Kingdom",
+				"phone": "+44 20 7946 0000",
+				"email_id": "hq@example.com",
+			}
+		).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_renders_address_fields(self):
+		display = get_address_display(self.address.name)
+
+		self.assertIn("42 Baker Street", display)
+		self.assertIn("London", display)
+		self.assertIn("+44 20 7946 0000", display)
+		self.assertIn("hq@example.com", display)
+
+	def test_returns_none_without_a_name(self):
+		self.assertIsNone(get_address_display(None))
+		self.assertIsNone(get_address_display(""))
+
+	def test_rejects_a_non_string_name(self):
+		"""@frappe.whitelist() enforces the annotation on requests and in tests, so a
+		dict never reaches frappe.db.exists(), where it would be read as filters."""
+		for bad_name in ({"city": "London"}, ["Test Org HQ-Office"]):
+			with self.assertRaises(frappe.exceptions.FrappeTypeError):
+				get_address_display(bad_name)
+
+	def test_returns_none_for_a_deleted_address(self):
+		self.assertIsNone(get_address_display("Nonexistent Address-Office"))
+
+	def test_falls_back_when_no_address_template_exists(self):
+		"""A CRM site without ERPNext usually has no Address Template at all;
+		frappe's render_address() throws in that case."""
+		with patch(
+			"crm.api.address.render_address",
+			side_effect=frappe.ValidationError("No default Address Template found."),
+		):
+			display = get_address_display(self.address.name)
+
+		self.assertIn("42 Baker Street", display)
+		self.assertIn("London", display)
+		self.assertIn("hq@example.com", display)
+
+	def test_fallback_escapes_html(self):
+		display = render_without_template({"address_line1": "<script>alert(1)</script>"})
+
+		self.assertNotIn("<script>", display)
+		self.assertIn("&lt;script&gt;", display)

--- a/frontend/src/components/AddressDisplay.vue
+++ b/frontend/src/components/AddressDisplay.vue
@@ -1,0 +1,40 @@
+<template>
+  <div
+    v-if="display.data"
+    class="text-p-sm text-ink-gray-7 [&_br:last-child]:hidden"
+  >
+    <!-- content is passed through sanitizeHTML() (DOMPurify) before rendering, so v-html is safe here -->
+    <!-- eslint-disable vue/no-v-html -->
+    <div v-html="sanitizeHTML(display.data)" />
+    <!-- eslint-enable vue/no-v-html -->
+  </div>
+</template>
+
+<script setup>
+import { sanitizeHTML } from '@/utils'
+import { createResource } from 'frappe-ui'
+import { watch } from 'vue'
+
+const props = defineProps({
+  name: { type: String, default: '' },
+})
+
+// The Address Template is admin-editable, so the rendered block is fetched
+// rather than assembled here; sanitizeHTML() guards what comes back.
+const display = createResource({
+  url: 'crm.api.address.get_address_display',
+  makeParams: () => ({ name: props.name }),
+  auto: Boolean(props.name),
+})
+
+watch(
+  () => props.name,
+  (name) => {
+    if (name) {
+      display.fetch()
+    } else {
+      display.data = null
+    }
+  },
+)
+</script>

--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -399,6 +399,11 @@
                       </div>
                     </div>
                   </div>
+                  <AddressDisplay
+                    v-if="field.visible && isAddressField(field)"
+                    class="mb-1 px-3"
+                    :name="doc[field.fieldname]"
+                  />
                 </template>
               </FadedScrollableDiv>
             </slot>
@@ -430,6 +435,7 @@ import PrimaryDropdown from '@/components/PrimaryDropdown.vue'
 import FadedScrollableDiv from '@/components/FadedScrollableDiv.vue'
 import ArrowUpRightIcon from '@/components/Icons/ArrowUpRightIcon.vue'
 import EditIcon from '@/components/Icons/EditIcon.vue'
+import AddressDisplay from '@/components/AddressDisplay.vue'
 import Link from '@/components/Controls/Link.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import SidePanelModal from '@/components/Modals/SidePanelModal.vue'
@@ -661,6 +667,10 @@ function firstVisibleIndex() {
 const textareaFieldtypes = ['Small Text', 'Text', 'Long Text', 'Code']
 function isTextareaField(field) {
   return textareaFieldtypes.includes(field.fieldtype)
+}
+
+function isAddressField(field) {
+  return field.fieldtype === 'Link' && field.options === 'Address'
 }
 
 function ratingMax(field) {


### PR DESCRIPTION
closes : #2426 
issue :1
Render the formatted address block inline, underneath any `Link` field whose
options are `Address`. Because it keys off the fieldtype rather than a
hardcoded page, this covers Organization and Contact, on both desktop and
mobile, with no per-page wiring.