### PR TITLE
fix: hide permlevel restricted fields from activity timeline

### DIFF
--- a/crm/api/activities.py
+++ b/crm/api/activities.py
@@ -8,6 +8,7 @@ from frappe.query_builder import JoinType
 from frappe.translate import get_translated_doctypes
 
 from crm.fcrm.doctype.crm_call_log.crm_call_log import parse_call_log
+from crm.fcrm.doctype.crm_fields_layout.crm_fields_layout import get_permlevel_access
 
 
 @frappe.whitelist()
@@ -26,10 +27,7 @@ def get_deal_activities(name: str):
 
 	get_docinfo("", "CRM Deal", name)
 	docinfo = frappe.response["docinfo"]
-	deal_meta = frappe.get_meta("CRM Deal")
-	deal_fields = {
-		field.fieldname: {"label": field.label, "options": field.options} for field in deal_meta.fields
-	}
+	deal_fields = get_readable_fields("CRM Deal")
 	avoid_fields = [
 		"lead",
 		"response_by",
@@ -183,10 +181,7 @@ def get_lead_activities(name: str):
 
 	get_docinfo("", "CRM Lead", name)
 	docinfo = frappe.response["docinfo"]
-	lead_meta = frappe.get_meta("CRM Lead")
-	lead_fields = {
-		field.fieldname: {"label": field.label, "options": field.options} for field in lead_meta.fields
-	}
+	lead_fields = get_readable_fields("CRM Lead")
 	avoid_fields = [
 		"converted",
 		"response_by",
@@ -316,6 +311,21 @@ def get_lead_activities(name: str):
 	activities = handle_multiple_versions(activities)
 
 	return activities, calls, notes, tasks, attachments
+
+
+def get_readable_fields(doctype: str):
+	"""Map of fieldname to label & options, skipping fields the user cannot read.
+
+	Permlevel restrictions already hide these fields on the form layout, so the
+	activity timeline has to hide them too instead of leaking their values.
+	"""
+	allowed_permlevels = get_permlevel_access("read", doctype)
+
+	return {
+		field.fieldname: {"label": field.label, "options": field.options}
+		for field in frappe.get_meta(doctype).fields
+		if field.permlevel == 0 or field.permlevel in allowed_permlevels
+	}
 
 
 def get_attachments(doctype: str, name: str):

--- a/crm/tests/test_activity_permlevel.py
+++ b/crm/tests/test_activity_permlevel.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+from frappe.permissions import add_permission, update_permission_property
+from frappe.tests import IntegrationTestCase
+
+from crm.api.activities import get_activities
+
+RESTRICTED_FIELD = "permlevel_secret"
+RESTRICTED_VALUE = "salary is 100000"
+
+
+class TestActivityPermlevel(IntegrationTestCase):
+	"""A permlevel-restricted field is hidden on the form layout, so its values
+	must not leak through the activity timeline either (frappe/crm#805).
+
+	  rep@permlevel.test  -- Sales User, owns the lead, no permlevel 1 access
+	  mgr@permlevel.test  -- Sales Manager, reads permlevel 1
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		make_user("rep@permlevel.test", roles=["Sales User"])
+		make_user("mgr@permlevel.test", roles=["Sales Manager"])
+
+		if not frappe.db.exists("Custom Field", {"dt": "CRM Lead", "fieldname": RESTRICTED_FIELD}):
+			frappe.get_doc(
+				{
+					"doctype": "Custom Field",
+					"dt": "CRM Lead",
+					"fieldname": RESTRICTED_FIELD,
+					"label": "Permlevel Secret",
+					"fieldtype": "Data",
+					"permlevel": 1,
+				}
+			).insert(ignore_permissions=True)
+
+		# only Sales Manager gets permlevel 1 on CRM Lead
+		add_permission("CRM Lead", "Sales Manager", 1)
+		update_permission_property("CRM Lead", "Sales Manager", 1, "write", 1)
+		frappe.clear_cache(doctype="CRM Lead")
+
+	def setUp(self):
+		frappe.db.savepoint("test_activity_permlevel")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback(save_point="test_activity_permlevel")
+
+	def make_lead_with_restricted_change(self):
+		lead = frappe.get_doc(
+			{"doctype": "CRM Lead", "lead_owner": "rep@permlevel.test", "first_name": "Permlevel"}
+		)
+		lead.flags.ignore_mandatory = True
+		lead.insert(ignore_permissions=True)
+
+		lead.set(RESTRICTED_FIELD, RESTRICTED_VALUE)
+		# the timeline is built from versions, which tests skip unless asked for
+		lead.save(ignore_permissions=True, ignore_version=False)
+		return lead
+
+	def activities_as(self, user, name):
+		frappe.set_user(user)
+		try:
+			activities, *_ = get_activities(name)
+		finally:
+			frappe.set_user("Administrator")
+		return activities
+
+	def test_restricted_field_change_is_hidden_from_activity(self):
+		lead = self.make_lead_with_restricted_change()
+		activities = self.activities_as("rep@permlevel.test", lead.name)
+
+		self.assertNotIn(RESTRICTED_FIELD, changed_fields(activities))
+		self.assertNotIn(RESTRICTED_VALUE, frappe.as_json(activities))
+
+	def test_permitted_user_still_sees_the_change(self):
+		lead = self.make_lead_with_restricted_change()
+		activities = self.activities_as("mgr@permlevel.test", lead.name)
+
+		self.assertIn(RESTRICTED_FIELD, changed_fields(activities))
+
+	def test_unrestricted_fields_are_untouched(self):
+		lead = self.make_lead_with_restricted_change()
+		lead.status = "Qualified"
+		lead.save(ignore_permissions=True, ignore_version=False)
+
+		activities = self.activities_as("rep@permlevel.test", lead.name)
+		self.assertIn("status", changed_fields(activities))
+		self.assertNotIn(RESTRICTED_FIELD, changed_fields(activities))
+
+
+def changed_fields(activities):
+	"""Fieldnames reported by the timeline, including grouped versions."""
+	fields = set()
+	for activity in activities:
+		for entry in [activity, *(activity.get("other_versions") or [])]:
+			data = entry.get("data")
+			if isinstance(data, dict) and data.get("field"):
+				fields.add(data["field"])
+	return fields
+
+
+def make_user(email, roles=None):
+	if frappe.db.exists("User", email):
+		return frappe.get_doc("User", email)
+	user = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": email,
+			"first_name": email.split("@")[0],
+			"send_welcome_email": 0,
+		}
+	).insert(ignore_permissions=True)
+	for role in roles or []:
+		user.add_roles(role)
+	return user


### PR DESCRIPTION
 Steps to reproduce

1. Customize Form → CRM Lead → set Perm Level = 1 on "No. of Employees"
2. Role Permissions Manager → CRM Lead → level 1 → give read/write to Sales Manager only
3. Create a user with just the Sales User role, and a lead with that user as Lead Owner
4. As Administrator, change "No. of Employees" on that lead
5. Log in as the Sales User and open the lead

Result: the field is hidden in the side panel (correct), but the Activity tab
shows "Administrator changed No. of Employees from 1-10 to 201-500" — so the user
can read the value anyway, along with the full change history.


Changes

- Added `get_readable_fields()` in `crm/api/activities.py`, which builds the field
  map using `get_permlevel_access("read", doctype)` — the same helper the form
  layout already uses, so the timeline and the form stay consistent.
- Used it in both `get_lead_activities()` and `get_deal_activities()`.
- Restricted fields never enter the map, so those version rows are skipped.

Filtering is per user: a Sales Manager still sees the full history, and unrelated
activity (creation, status changes, comments) is unaffected.

closes #805
