### PR TITLE
fix: translate Select field option labels in frontend

### DIFF
--- a/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
+++ b/crm/fcrm/doctype/crm_fields_layout/crm_fields_layout.py
@@ -183,7 +183,7 @@ def get_field_obj(field):
 		field["placeholder"] = field.get("placeholder") or "Select " + field.label + "..."
 	elif field.fieldtype == "Select" and field.options:
 		field["placeholder"] = field.get("placeholder") or "Select " + field.label + "..."
-		field["options"] = [{"label": option, "value": option} for option in field.options.split("\n")]
+		field["options"] = [{"label": _(option), "value": option} for option in field.options.split("\n")]
 
 	if field.read_only:
 		field["tooltip"] = "This field is read only and cannot be edited."

--- a/frontend/src/components/Controls/Grid.vue
+++ b/frontend/src/components/Controls/Grid.vue
@@ -785,7 +785,7 @@ const getOptions = (options) => {
     return options
   } else if (typeof options === 'string') {
     return options.split('\n').map((option) => {
-      return { label: option, value: option }
+      return { label: __(option), value: option }
     })
   } else {
     return []

--- a/frontend/src/components/FieldLayout/Field.vue
+++ b/frontend/src/components/FieldLayout/Field.vue
@@ -504,7 +504,7 @@ const field = computed(() => {
 
   if (field.fieldtype == 'Select' && typeof field.options === 'string') {
     field.options = field.options.split('\n').map((option) => {
-      return { label: option, value: option }
+      return { label: __(option), value: option }
     })
 
     if (field.options[0].value !== '' && !field.reqd) {
@@ -617,7 +617,7 @@ const getOptions = (options) => {
     return options
   } else if (typeof options === 'string') {
     return options.split('\n').map((option) => {
-      return { label: option, value: option }
+      return { label: __(option), value: option }
     })
   } else {
     return []

--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -519,7 +519,7 @@ function parsedField(field) {
 
   if (field.fieldtype == 'Select' && typeof field.options === 'string') {
     field.options = field.options.split('\n').map((option) => {
-      return { label: option, value: option }
+      return { label: __(option), value: option }
     })
 
     if (field.options[0].value !== '' && !field.reqd) {

--- a/frontend/src/components/SidePanelLayout.vue
+++ b/frontend/src/components/SidePanelLayout.vue
@@ -519,7 +519,7 @@ function parsedField(field) {
 
   if (field.fieldtype == 'Select' && typeof field.options === 'string') {
     field.options = field.options.split('\n').map((option) => {
-      return { label: __(option), value: option }
+      return { label: option, value: option }
     })
 
     if (field.options[0].value !== '' && !field.reqd) {

--- a/frontend/src/stores/meta.js
+++ b/frontend/src/stores/meta.js
@@ -103,7 +103,7 @@ export function getMeta(doctype) {
           if (f.fieldtype === 'Select' && typeof f.options === 'string') {
             f.options = f.options.split('\n').map((option) => {
               return {
-                label: option,
+                label: __(option),
                 value: option,
               }
             })

--- a/frontend/src/utils/fieldTransforms.js
+++ b/frontend/src/utils/fieldTransforms.js
@@ -54,7 +54,7 @@ export function processField(rawField, options = {}) {
   // 4. Select options: string → array
   if (field.fieldtype === 'Select' && typeof field.options === 'string') {
     field.options = field.options.split('\n').map((option) => ({
-      label: option,
+      label: __(option),
       value: option,
     }))
 

--- a/frontend/tests/unit/processField.test.js
+++ b/frontend/tests/unit/processField.test.js
@@ -51,6 +51,28 @@ describe('processField', () => {
     ])
   })
 
+  it('translates Select option labels but keeps raw values', () => {
+    const original = globalThis.__
+    const dictionary = { Billing: 'Rozliczeniowy', Shipping: 'Wysyłkowy' }
+    globalThis.__ = (msg) => dictionary[msg] || msg
+    try {
+      const raw = {
+        fieldname: 'address_type',
+        fieldtype: 'Select',
+        options: 'Billing\nShipping\nOffice',
+        reqd: 1,
+      }
+      const result = processField(raw)
+      expect(result.options).toEqual([
+        { label: 'Rozliczeniowy', value: 'Billing' },
+        { label: 'Wysyłkowy', value: 'Shipping' },
+        { label: 'Office', value: 'Office' },
+      ])
+    } finally {
+      globalThis.__ = original
+    }
+  })
+
   it('prepends blank option for non-required Select', () => {
     const raw = {
       fieldname: 'priority',


### PR DESCRIPTION
Closes #2418

Select field options in the CRM frontend were rendered with the raw English
values from the DocType meta, even when translations exist. Field labels were
translated but the option labels inside the dropdown were not.

This wraps the option label in __() wherever a Select options string is
split into { label, value } pairs, so the dropdown shows the translated text.
The value is left as the original English string, since that is what gets
stored and validated on the server.