### PR TITLE
fix: prevent conversion of lost leads

### DIFF
--- a/crm/fcrm/doctype/crm_lead/crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/crm_lead.py
@@ -534,6 +534,8 @@ def convert_to_deal(
 		frappe.throw(_("Not allowed to convert Lead to Deal"), frappe.PermissionError)
 
 	lead = frappe.get_cached_doc("CRM Lead", lead)
+	if frappe.get_cached_value("CRM Lead Status", lead.status, "type") == "Lost":
+		frappe.throw(_("Cannot convert a lead with status {0}").format(lead.status))
 	if frappe.db.exists("CRM Lead Status", "Qualified"):
 		lead.db_set("status", "Qualified")
 	lead.db_set("converted", 1)

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -444,6 +444,11 @@ class TestCRMLead(IntegrationTestCase):
 
 	def test_cannot_convert_lost_lead_to_deal(self):
 		"""Lost leads cannot be converted to deals."""
+		if not frappe.db.exists("CRM Lost Reason", "Not interested"):
+			frappe.get_doc(
+				{"doctype": "CRM Lost Reason", "reason": "Not interested"}
+			).insert()
+
 		for status in ("Junk", "Unqualified"):
 			with self.subTest(status=status):
 				lead = create_lead(first_name=status, status=status, lost_reason="Not interested")

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -442,6 +442,18 @@ class TestCRMLead(IntegrationTestCase):
 		self.assertEqual(org.organization_name, "API Test Corp")
 		self.assertEqual(org.annual_revenue, 300000)
 
+	def test_cannot_convert_lost_lead_to_deal(self):
+		"""Lost leads cannot be converted to deals."""
+		for status in ("Junk", "Unqualified"):
+			with self.subTest(status=status):
+				lead = create_lead(first_name=status, status=status, lost_reason="Not interested")
+				with self.assertRaisesRegex(
+					frappe.ValidationError, f"Cannot convert a lead with status {status}"
+				):
+					convert_to_deal(lead=lead.name)
+				lead.reload()
+				self.assertFalse(lead.converted)
+
 	def test_convert_to_deal_api_with_existing_records(self):
 		"""Test convert_to_deal API with existing contact and organization parameters"""
 		# Create existing contact

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -445,7 +445,7 @@ class TestCRMLead(IntegrationTestCase):
 	def test_cannot_convert_lost_lead_to_deal(self):
 		"""Lost leads cannot be converted to deals."""
 		if not frappe.db.exists("CRM Lost Reason", "Not interested"):
-			frappe.get_doc({"doctype": "CRM Lost Reason", "reason": "Not interested"}).insert()
+			frappe.get_doc({"doctype": "CRM Lost Reason", "lost_reason": "Not interested"}).insert()
 
 		for status in ("Junk", "Unqualified"):
 			with self.subTest(status=status):

--- a/crm/fcrm/doctype/crm_lead/test_crm_lead.py
+++ b/crm/fcrm/doctype/crm_lead/test_crm_lead.py
@@ -445,9 +445,7 @@ class TestCRMLead(IntegrationTestCase):
 	def test_cannot_convert_lost_lead_to_deal(self):
 		"""Lost leads cannot be converted to deals."""
 		if not frappe.db.exists("CRM Lost Reason", "Not interested"):
-			frappe.get_doc(
-				{"doctype": "CRM Lost Reason", "reason": "Not interested"}
-			).insert()
+			frappe.get_doc({"doctype": "CRM Lost Reason", "reason": "Not interested"}).insert()
 
 		for status in ("Junk", "Unqualified"):
 			with self.subTest(status=status):

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -40,11 +40,19 @@
           </Button>
         </template>
       </Dropdown>
-      <Button
-        :label="__('Convert to Deal')"
-        variant="solid"
-        @click="showConvertToDealModal = true"
-      />
+      <Tooltip
+        :disabled="!isLeadConversionDisabled"
+        :text="__('Cannot convert a lost lead to deal')"
+      >
+        <div class="inline-flex">
+          <Button
+            :label="__('Convert to Deal')"
+            variant="solid"
+            :disabled="isLeadConversionDisabled"
+            @click="showConvertToDealModal = true"
+          />
+        </div>
+      </Tooltip>
     </template>
   </LayoutHeader>
   <div v-if="doc.name" class="flex h-full overflow-hidden">
@@ -334,6 +342,9 @@ const {
 const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
 const doc = computed(() => document.doc || {})
+const isLeadConversionDisabled = computed(
+  () => getLeadStatus(doc.value.status)?.type === 'Lost',
+)
 
 useUnsavedChangesWarning(() => document.isDirty)
 

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -343,7 +343,7 @@ const canDelete = computed(() => permissions.data?.permissions?.delete || false)
 
 const doc = computed(() => document.doc || {})
 const isLeadConversionDisabled = computed(
-  () => getLeadStatus(doc.value.status)?.type === 'Lost',
+  () => doc.value.status && getLeadStatus(doc.value.status)?.type === 'Lost',
 )
 
 useUnsavedChangesWarning(() => document.isDirty)

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -50,11 +50,19 @@
         v-if="document.actions?.length"
         :actions="document.actions"
       />
-      <Button
-        :label="__('Convert')"
-        variant="solid"
-        @click="showConvertToDealModal = true"
-      />
+      <Tooltip
+        :disabled="!isLeadConversionDisabled"
+        :text="__('Cannot convert a lost lead to deal')"
+      >
+        <div class="inline-flex">
+          <Button
+            :label="__('Convert')"
+            variant="solid"
+            :disabled="isLeadConversionDisabled"
+            @click="showConvertToDealModal = true"
+          />
+        </div>
+      </Tooltip>
     </div>
   </div>
   <div v-if="doc.name" class="flex h-full overflow-hidden">
@@ -158,6 +166,7 @@ import { useVisitedRecords } from '@/composables/useVisitedRecords'
 import {
   createResource,
   Dropdown,
+  Tooltip,
   Tabs,
   Breadcrumbs,
   call,
@@ -194,6 +203,9 @@ const {
 } = useDocument('CRM Lead', props.leadId)
 
 const doc = computed(() => document.doc || {})
+const isLeadConversionDisabled = computed(
+  () => getLeadStatus(doc.value.status)?.type === 'Lost',
+)
 
 const { markVisited } = useVisitedRecords('CRM Lead')
 

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -204,7 +204,7 @@ const {
 
 const doc = computed(() => document.doc || {})
 const isLeadConversionDisabled = computed(
-  () => getLeadStatus(doc.value.status)?.type === 'Lost',
+  () => doc.value.status && getLeadStatus(doc.value.status)?.type === 'Lost',
 )
 
 const { markVisited } = useVisitedRecords('CRM Lead')


### PR DESCRIPTION
## Summary

- disable deal conversion for lost leads on desktop and mobile
- enforce the restriction in the conversion API

Unqualified lead hover state:

<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/292dc7de-f8f6-4dd0-a14c-a724bedad4c5" />
