### PR TITLE
fix: default view resolution can pick another doctype's default view

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -264,24 +264,36 @@ router.beforeEach(async (to, from, next) => {
       const doctype = doctypeMap[to.name]
       let defaultViewType = 'list'
 
-      let globalDefault = getDefaultView()
-      if (globalDefault && globalDefault.route_name === to.name) {
-        defaultViewType = globalDefault.type || 'list'
-        if (globalDefault.name && !globalDefault.is_standard) {
-          next({
-            name: to.name,
-            params: { viewType: defaultViewType },
-            query: { ...to.query, view: globalDefault.name },
-          })
-          return
-        }
-      }
-
+      // Check the doctype-scoped standard view first: standardViews is keyed
+      // by `${doctype} ${viewType}`, so it unambiguously reflects the default
+      // configured for *this* doctype. getDefaultView() returns a single
+      // value shared across every doctype in the CRM (it's overwritten by
+      // whichever view with is_default=1 is processed last across the whole
+      // app) and can point at another doctype's default view entirely, so it
+      // is only used as a fallback when this doctype has no standard default
+      // of its own.
+      let matchedStandardDefault = false
       for (const viewType of standardViewTypes) {
         const standardView = standardViews.value?.[doctype + ' ' + viewType]
         if (standardView?.is_default) {
           defaultViewType = viewType
+          matchedStandardDefault = true
           break
+        }
+      }
+
+      if (!matchedStandardDefault) {
+        let globalDefault = getDefaultView()
+        if (globalDefault && globalDefault.route_name === to.name) {
+          defaultViewType = globalDefault.type || 'list'
+          if (globalDefault.name && !globalDefault.is_standard) {
+            next({
+              name: to.name,
+              params: { viewType: defaultViewType },
+              query: { ...to.query, view: globalDefault.name },
+            })
+            return
+          }
         }
       }
 


### PR DESCRIPTION
## Bug

Navigating to a list page without an explicit view (e.g. clicking "Leads" in the sidebar) resolves which view to open via the router's `beforeEach` guard. It checks `getDefaultView()` **first**, falling back to the doctype-scoped `standardViews` lookup only if that global default's `route_name` happens to match the page being opened.

`getDefaultView()` is backed by a single `defaultView` ref in the views Pinia store (`frontend/src/stores/views.js`), populated by iterating **every** view returned by `crm.api.views.get_views` (called with `doctype: ''`, i.e. across the whole CRM, not scoped to one doctype) and overwriting `defaultView.value` on every view where `is_default` is set:

```js
for (let view of views) {
  ...
  if (view.is_default) {
    defaultView.value = view
  }
}
```

If more than one doctype has its own standard view marked default - a completely normal configuration, e.g. Leads defaulting to Kanban and Deals also defaulting to Kanban - this loop leaves `defaultView` pointing at whichever one was processed last, independent of which doctype's page is actually being opened. Back in the router guard:

```js
let globalDefault = getDefaultView()
if (globalDefault && globalDefault.route_name === to.name) {
  defaultViewType = globalDefault.type || 'list'
  ...
}
```

If it happens to match `to.name` by coincidence, it wins over the current doctype's own configured default. Since which view ends up "last" depends on the response order of `get_views`, the resolved view type for a given doctype can end up effectively unpredictable across reloads/sessions whenever more than one doctype has a default view configured.

The per-doctype `standardViews` map (keyed by `` `${doctype} ${viewType}` ``) doesn't have this ambiguity - it's populated the exact same way but keeps every doctype's default separate.

## Fix

Check `standardViews` (doctype-scoped, unambiguous) first, and only fall back to the single global `getDefaultView()` result when the current doctype has no standard default of its own.

## Testing

Reproduced on a live site with Kanban configured as the default view for `CRM Lead` (and also for `CRM Deal`): navigating to the Leads list intermittently opened in List view instead of Kanban, depending on what the unrelated global default happened to resolve to at that moment. After this change it consistently opens in the doctype's own configured default view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)