### PR TITLE
fix: remove duplicate error toast on lead and deal field update

### DIFF
--- a/frontend/src/data/document.js
+++ b/frontend/src/data/document.js
@@ -113,7 +113,7 @@ export function useDocument(doctype, docname, resourceOverrides = {}) {
                 toast.error(msg)
               })
 
-              if (err.messages?.length === 0) {
+              if (!err.messages?.length) {
                 toast.error(__('An error occurred while updating the document'))
               }
 

--- a/frontend/src/pages/Deal.vue
+++ b/frontend/src/pages/Deal.vue
@@ -778,13 +778,12 @@ function updateField(name, value) {
 
   document.save.submit(null, {
     onSuccess: () => (reload.value = true),
-    onError: (err) => {
+    onError: () => {
       if (Array.isArray(name)) {
         name.forEach((field) => (doc.value[field] = oldValues[field]))
       } else {
         doc.value[name] = oldValues
       }
-      toast.error(err.messages?.[0] || __('Error updating field'))
     },
   })
 }

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -508,13 +508,12 @@ function updateField(name, value) {
 
   document.save.submit(null, {
     onSuccess: () => (reload.value = true),
-    onError: (err) => {
+    onError: () => {
       if (Array.isArray(name)) {
         name.forEach((field) => (doc.value[field] = oldValues[field]))
       } else {
         doc.value[name] = oldValues
       }
-      toast.error(err.messages?.[0] || __('Error updating field'))
     },
   })
 }

--- a/frontend/src/pages/MobileDeal.vue
+++ b/frontend/src/pages/MobileDeal.vue
@@ -621,13 +621,12 @@ function updateField(name, value) {
 
   document.save.submit(null, {
     onSuccess: () => (reload.value = true),
-    onError: (err) => {
+    onError: () => {
       if (Array.isArray(name)) {
         name.forEach((field) => (doc.value[field] = oldValues[field]))
       } else {
         doc.value[name] = oldValues
       }
-      toast.error(err.messages?.[0] || __('Error updating field'))
     },
   })
 }

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -360,13 +360,12 @@ function updateField(name, value) {
 
   document.save.submit(null, {
     onSuccess: () => (reload.value = true),
-    onError: (err) => {
+    onError: () => {
       if (Array.isArray(name)) {
         name.forEach((field) => (doc.value[field] = oldValues[field]))
       } else {
         doc.value[name] = oldValues
       }
-      toast.error(err.messages?.[0] || __('Error updating field'))
     },
   })
 }

--- a/frontend/tests/unit/documentSaveErrorToast.test.js
+++ b/frontend/tests/unit/documentSaveErrorToast.test.js
@@ -1,0 +1,101 @@
+// useDocument pulls in stores, composables and a live createDocumentResource
+// that aren't wired up for vitest — stub them so this test exercises only the
+// save-error toast selection in setValue.onError (regression for #1703).
+vi.mock('@/data/script', () => ({
+  getScript: () => ({ setupScript: vi.fn(), scripts: {} }),
+}))
+vi.mock('@/stores/global', () => ({ globalStore: () => ({}) }))
+vi.mock('@/stores/meta', () => ({ getMeta: () => ({}) }))
+vi.mock('@/composables/useAttachments', () => ({
+  useAttachments: () => ({
+    trackOldFile: vi.fn(),
+    processPendingDeletions: vi.fn(),
+  }),
+}))
+vi.mock('@/composables/settings', () => ({
+  showSettings: { value: false },
+  activeSettingsPage: { value: '' },
+}))
+vi.mock('@/utils', () => ({
+  runSequentially: vi.fn(),
+  parseAssignees: (d) => d,
+  sanitizeText: (t) => t,
+}))
+vi.mock('@/utils/fieldTransforms', () => ({ findMissingMandatory: () => [] }))
+vi.mock('@/utils/fetchFrom', () => ({
+  getFetchSource: vi.fn(),
+  getFieldsToFetch: vi.fn(),
+  getPendingFetchFields: vi.fn(),
+  getSourceFieldnames: vi.fn(),
+}))
+
+const { toast, captured } = vi.hoisted(() => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  captured: { options: null },
+}))
+
+vi.mock('frappe-ui', () => ({
+  call: vi.fn(),
+  toast,
+  createResource: () => ({}),
+  createDocumentResource: (options) => {
+    captured.options = options
+    return { doc: {}, save: { submit: vi.fn() } }
+  },
+}))
+
+import { useDocument } from '@/data/document'
+
+describe('useDocument setValue.onError toasts', () => {
+  let onError
+
+  beforeEach(() => {
+    toast.error.mockClear()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    useDocument('CRM Lead', `CRM-LEAD-${Math.random()}`)
+    onError = captured.options.setValue.onError
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows one toast per server message', () => {
+    onError({ messages: ['Editing this lead is not allowed.'] })
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      'Editing this lead is not allowed.',
+    )
+  })
+
+  it('shows the generic toast when messages is an empty array', () => {
+    onError({ messages: [] })
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      'An error occurred while updating the document',
+    )
+  })
+
+  it('shows the generic toast when messages is missing', () => {
+    onError({})
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      'An error occurred while updating the document',
+    )
+  })
+
+  it('collapses mandatory errors into a single toast', () => {
+    onError({
+      exc_type: 'MandatoryError',
+      messages: ['Missing: first_name', 'Missing: email'],
+    })
+
+    expect(toast.error).toHaveBeenCalledTimes(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      'Mandatory field error: first_name, email',
+    )
+  })
+})

--- a/frontend/tests/unit/documentSaveErrorToast.test.js
+++ b/frontend/tests/unit/documentSaveErrorToast.test.js
@@ -49,11 +49,16 @@ import { useDocument } from '@/data/document'
 describe('useDocument setValue.onError toasts', () => {
   let onError
 
+  // useDocument caches the resource per docname, so set it up once and
+  // reuse the captured handler across tests.
+  beforeAll(() => {
+    useDocument('CRM Lead', 'CRM-LEAD-TEST')
+    onError = captured.options.setValue.onError
+  })
+
   beforeEach(() => {
     toast.error.mockClear()
     vi.spyOn(console, 'error').mockImplementation(() => {})
-    useDocument('CRM Lead', `CRM-LEAD-${Math.random()}`)
-    onError = captured.options.setValue.onError
   })
 
   afterEach(() => {


### PR DESCRIPTION
Closes #1703

When a save fails (e.g. a server script calls frappe.throw), the error toast was shown multiple times on Lead and Deal pages. useDocument already shows the error, and updateField in the page components was showing it again. Removed the duplicate toast from the page components so only one error is shown.