### PR TITLE
fix: keep WhatsApp attachment paths out of captions

### DIFF
--- a/crm/api/whatsapp.py
+++ b/crm/api/whatsapp.py
@@ -285,7 +285,7 @@ def create_whatsapp_message(
 		{
 			"reference_doctype": reference_doctype,
 			"reference_name": reference_name,
-			"message": message or attach,
+			"message": message or "",
 			"to": to,
 			"attach": attach,
 			"content_type": content_type,

--- a/crm/tests/test_whatsapp.py
+++ b/crm/tests/test_whatsapp.py
@@ -6,7 +6,49 @@ from unittest.mock import MagicMock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from crm.api.whatsapp import notify_agent, validate
+from crm.api.whatsapp import create_whatsapp_message, notify_agent, validate
+
+
+class TestWhatsAppMessageCreation(FrappeTestCase):
+	def test_text_message_is_preserved(self):
+		doc = MagicMock()
+		with (
+			patch("crm.api.whatsapp.validate_access"),
+			patch("frappe.new_doc", return_value=doc),
+		):
+			create_whatsapp_message("CRM Lead", "LEAD-0001", "Hello", "+15551234567", "", "")
+
+		self.assertEqual(doc.update.call_args.args[0]["message"], "Hello")
+		self.assertEqual(doc.update.call_args.args[0]["content_type"], "text")
+
+	def test_media_message_keeps_caption_separate_from_attachment(self):
+		for content_type in ("image", "video", "document"):
+			for caption in ("", None, "Here is the requested file"):
+				with self.subTest(content_type=content_type, caption=caption):
+					doc = MagicMock()
+					doc.name = "MESSAGE-0001"
+					attachment = "/files/customer-upload.png"
+					with (
+						patch("crm.api.whatsapp.validate_access") as validate_access,
+						patch("frappe.new_doc", return_value=doc),
+					):
+						name = create_whatsapp_message(
+							"CRM Lead", "LEAD-0001", caption, "+15551234567", attachment, "", content_type
+						)
+
+					validate_access.assert_called_once_with("CRM Lead", "LEAD-0001")
+					doc.update.assert_called_once_with(
+						{
+							"reference_doctype": "CRM Lead",
+							"reference_name": "LEAD-0001",
+							"message": caption or "",
+							"to": "+15551234567",
+							"attach": attachment,
+							"content_type": content_type,
+						}
+					)
+					doc.insert.assert_called_once_with(ignore_permissions=True)
+					self.assertEqual(name, doc.name)
 
 
 class TestWhatsAppHooks(FrappeTestCase):


### PR DESCRIPTION
Fixes #2436.

Sending an attachment without a typed caption replaces the empty message with the attachment URL in `create_whatsapp_message`. The WhatsApp integration then uses that message as the image/video/document caption, exposing `/files/...` below the media. The frontend already passes the attachment separately; the fallback is in the API.

Keep an omitted caption as an empty string, preserve user-written captions, and continue passing the file URL through `attach`. Added regression coverage for image/video/document messages with empty, null, and explicit captions, plus ordinary text messages.

Validation:
- 165 frontend tests pass (`yarn test:run`).
- Ruff 0.8.1 lint and formatting checks pass for both changed files; Python compilation and git diff checks pass.
- Ran the new tests against the actual API function using a local bootstrap with mocked Frappe services. Six empty/null caption cases failed before the fix; all nine media cases and the text case pass after it.
- Confirmed the integration's message field is optional and its media payload uses `message` as `caption`.

Full Frappe database/server tests were not run locally on Windows, and no real WhatsApp messages were sent. The repository's Server CI is needed for that environment. Implemented and validated with OpenAI Codex assistance.
