### PR TITLE
fix: avoid duplicate realtime socket connections

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -46,7 +46,7 @@ let pinia = createPinia()
 let app = createApp(App)
 
 setConfig('resourceFetcher', frappeRequest)
-app.use(FrappeUI)
+app.use(FrappeUI, { socketio: false })
 app.use(spritePlugin)
 app.use(pinia)
 app.use(router)

--- a/frontend/tests/unit/appSocket.test.js
+++ b/frontend/tests/unit/appSocket.test.js
@@ -1,0 +1,93 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  io: vi.fn(() => ({ on: vi.fn() })),
+  mount: vi.fn(),
+  frappeRequest: vi.fn(),
+}))
+
+vi.mock('socket.io-client', () => ({ io: mocks.io }))
+vi.mock('vue', async (importOriginal) => {
+  const vue = await importOriginal()
+  return {
+    ...vue,
+    createApp: (...args) => {
+      const app = vue.createApp(...args)
+      app.mount = mocks.mount
+      return app
+    },
+  }
+})
+vi.mock('frappe-ui', async () => {
+  const { default: FrappeUI } = await import(
+    '../../node_modules/frappe-ui/src/utils/plugin.ts'
+  )
+  return {
+    FrappeUI,
+    setConfig: vi.fn(),
+    frappeRequest: mocks.frappeRequest,
+    getCachedResource: vi.fn(),
+    getCachedListResource: vi.fn(),
+    ...Object.fromEntries(
+      [
+        'Button',
+        'Input',
+        'TextInput',
+        'FormControl',
+        'ErrorMessage',
+        'Dialog',
+        'Alert',
+        'Badge',
+        'FeatherIcon',
+      ].map((name) => [name, {}]),
+    ),
+  }
+})
+vi.mock('@/App.vue', () => ({ default: {} }))
+vi.mock('@/router', () => ({ default: { install() {} } }))
+vi.mock('@/translation', () => ({ default: { install() {} } }))
+vi.mock('@/utils/dialogs', () => ({ createDialog: vi.fn() }))
+vi.mock('frappe-ui/frappe', () => ({ telemetryPlugin: { install() {} } }))
+vi.mock('frappe-ui/icons', () => ({ spritePlugin: { install() {} } }))
+
+describe('application realtime startup', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    window.site_name = 'crm.test'
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    delete window.site_name
+  })
+
+  it('opens only the CRM socket in production', async () => {
+    vi.stubEnv('DEV', false)
+    await import('@/main')
+    expect(mocks.io).toHaveBeenCalledTimes(1)
+    expect(mocks.io.mock.calls[0][1].reconnectionAttempts).toBe(5)
+    expect(mocks.io.mock.results[0].value.on).toHaveBeenCalledWith(
+      'refetch_resource',
+      expect.any(Function),
+    )
+    expect(mocks.mount).toHaveBeenCalledWith('#app')
+  })
+
+  it('waits for development context before opening the CRM socket', async () => {
+    vi.stubEnv('DEV', true)
+    let resolveContext
+    mocks.frappeRequest.mockReturnValue(
+      new Promise((resolve) => {
+        resolveContext = resolve
+      }),
+    )
+    await import('@/main')
+    expect(mocks.io).not.toHaveBeenCalled()
+    resolveContext({ site_name: 'development.test' })
+    await Promise.resolve()
+    expect(mocks.io).toHaveBeenCalledTimes(1)
+    expect(mocks.io.mock.calls[0][0]).toContain('/development.test')
+    expect(mocks.mount).toHaveBeenCalledWith('#app')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -5,6 +5,7 @@ import path from 'path'
 export default defineConfig({
   plugins: [vue()],
   test: {
+    server: { deps: { inline: ['frappe-ui'] } },
     globals: true,
     environment: 'happy-dom',
     root: import.meta.dirname,


### PR DESCRIPTION
Fixes #2694.

CRM installs FrappeUI with its default socket enabled, then opens its own socket and replaces `$socket`. The plugin connection remains open without a reference. Disable the plugin's automatic socket so CRM owns the single connection and retains its resource-refresh listener and retry settings.

Add startup regression tests using the installed FrappeUI plugin and actual CRM entry point/socket initializer, with Socket.IO and unrelated UI services mocked. They verify one connection in production and no connection in development until context has loaded. Both tests fail on the original startup code. Inline frappe-ui in Vitest so its source modules are transformed correctly.

Validation: all 167 frontend tests pass; ESLint, Oxlint 1.50.0, Prettier 3.2.5 and diff checks pass for changed files. No dependencies changed. No live Socket.IO server or authenticated browser session was used; these tests verify initialization, not network reliability under production conditions.

Implemented and validated with OpenAI Codex assistance.
